### PR TITLE
Increase idle connection timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8873,6 +8873,7 @@ dependencies = [
  "sp-transaction-storage-proof 26.0.0",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
+ "tracing",
  "try-runtime-cli",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.126" }
 serde_json = { version = "1.0.132", default-features = false }
 static_assertions = { version = "1.1" }
 try-runtime-cli = { version = "0.42" }
+tracing = { version = "0.1.41", default-features = false }
 
 [workspace]
 resolver = "2"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,6 +18,7 @@ name = "polkadot-bulletin-chain"
 [dependencies]
 clap = { features = ["derive"], workspace = true }
 futures = { features = ["thread-pool"], workspace = true }
+tracing = { workspace = true }
 
 frame-system = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "db5e645422ccf952018a3c466a33fef477858602" }
 sc-cli = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "db5e645422ccf952018a3c466a33fef477858602" }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -147,17 +147,8 @@ pub fn new_partial(
 pub fn new_full<
 	N: sc_network::NetworkBackend<Block, <Block as sp_runtime::traits::Block>::Hash>,
 >(
-	mut config: Configuration,
+	config: Configuration,
 ) -> Result<TaskManager, ServiceError> {
-	// Override default idle connection timeout of 10 seconds to give IPFS clients more time to
-	// query data over Bitswap. This is needed when manually adding our node to a swarm of an IPFS
-	// node, because the IPFS node doesn't keep any active substreams with us and our node closes
-	// a connection after `idle_connection_timeout`.
-	let config = {
-		config.network.idle_connection_timeout = Duration::from_secs(3600);
-		config
-	};
-
 	let sc_service::PartialComponents {
 		client,
 		backend,


### PR DESCRIPTION
Increase idle connection timeout from default 10 seconds to 1 hour to give IPFS clients more time to query data over Bitswap. This is needed when manually adding our node to a swarm of an IPFS node, because the IPFS node doesn't keep any active substreams with us and our node closes a connection after `idle_connection_timeout`.