### PR TITLE
Reproducing chopsticks issue

### DIFF
--- a/examples/check_chopsticks.js
+++ b/examples/check_chopsticks.js
@@ -1,0 +1,10 @@
+import { ChopsticksProvider, setup } from "@acala-network/chopsticks-core";
+
+const chain = await setup({ endpoint: "wss://rpc.interweb-it.com/bulletin" });
+await chain.api.isReady;
+
+const innerProvider = new ChopsticksProvider(chain);
+await innerProvider.isReady;
+
+const result = await innerProvider.send("dev_newBlock", [], false);
+console.log({ result });

--- a/examples/package.json
+++ b/examples/package.json
@@ -19,6 +19,7 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
+    "@acala-network/chopsticks": "^1.2.5",
     "@polkadot-api/cli": "^0.13.3"
   }
 }


### PR DESCRIPTION
repro example from here - https://github.com/AcalaNetwork/chopsticks/issues/969

when I run this script it still fails with:
```
➜  examples git:(check_chop) ✗ node check_chopsticks.js
{
  result: '0xd0f63aa8b3f8183a9938c59803f30be74b4b9de3649e24cf12c44aac743d3afd'
}
[15:05:20.807] ERROR (txpool): build block failed
    app: "chopsticks"
    error: {}
[15:05:20.807] ERROR (txpool): build block failed
    app: "chopsticks"
    err: {
      "type": "Error",
      "message": "Unresolved function `env`:`ext_transaction_index_renew_version_1`",
      "stack":
          Error: Unresolved function `env`:`ext_transaction_index_renew_version_1`
              at Block.call (file:///Users/ndk/parity/polkadot-bulletin-chain/examples/node_modules/@acala-network/chopsticks-core/dist/esm/blockchain/block.js:258:35)
              at async Promise.all (index 0)
              at async buildBlock (file:///Users/ndk/parity/polkadot-bulletin-chain/examples/node_modules/@acala-network/chopsticks-core/dist/esm/blockchain/block-builder.js:187:22)
              at async #buildBlock (file:///Users/ndk/parity/polkadot-bulletin-chain/examples/node_modules/@acala-network/chopsticks-core/dist/esm/blockchain/txpool.js:227:47)
              at async #buildBlockIfNeeded (file:///Users/ndk/parity/polkadot-bulletin-chain/examples/node_modules/@acala-network/chopsticks-core/dist/esm/blockchain/txpool.js:203:13)
              ```
