### PR TITLE
feat: adopt tracing for structured logging (#123)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,6 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "hex",
- "log",
  "pallet-authorship",
  "pallet-babe",
  "pallet-bridge-grandpa",
@@ -1424,6 +1423,7 @@ dependencies = [
  "staging-xcm-executor",
  "static_assertions",
  "substrate-wasm-builder",
+ "tracing",
 ]
 
 [[package]]
@@ -7118,10 +7118,10 @@ dependencies = [
 name = "pallet-relayer-set"
 version = "1.0.0"
 dependencies = [
- "log",
  "parity-scale-codec",
  "polkadot-sdk-frame",
  "scale-info",
+ "tracing",
 ]
 
 [[package]]
@@ -7289,7 +7289,6 @@ dependencies = [
 name = "pallet-validator-set"
 version = "1.0.0"
 dependencies = [
- "log",
  "pallet-session",
  "pallets-common",
  "parity-scale-codec",
@@ -7297,6 +7296,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-staking",
+ "tracing",
 ]
 
 [[package]]
@@ -7827,7 +7827,6 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "hex",
- "log",
  "pallet-authorship",
  "pallet-babe",
  "pallet-bridge-grandpa",
@@ -7876,6 +7875,7 @@ dependencies = [
  "staging-xcm-executor",
  "static_assertions",
  "substrate-wasm-builder",
+ "tracing",
 ]
 
 [[package]]

--- a/pallets/relayer-set/Cargo.toml
+++ b/pallets/relayer-set/Cargo.toml
@@ -12,7 +12,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { workspace = true }
-log = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 scale-info = { features = ["derive"], workspace = true }
 
 polkadot-sdk-frame = { workspace = true, default-features = false, features = [
@@ -26,7 +26,7 @@ runtime-benchmarks = [
 ]
 std = [
 	"codec/std",
-	"log/std",
+	"tracing/std",
 	"polkadot-sdk-frame/std",
 	"scale-info/std",
 ]

--- a/pallets/relayer-set/src/lib.rs
+++ b/pallets/relayer-set/src/lib.rs
@@ -156,7 +156,7 @@ impl<T: Config> Pallet<T> {
 
 		// Decrement who's provider reference count
 		if let Err(err) = frame_system::Pallet::<T>::dec_providers(who) {
-			log::warn!(
+			tracing::warn!(
 				target: LOG_TARGET,
 				"Failed to decrement provider reference count for relayer {who:?}, \
 				leaking reference: {err:?}"
@@ -185,7 +185,7 @@ impl<T: Config> Pallet<T> {
 			Some(relayer) =>
 				relayer.min_bridge_tx_block = frame_system::Pallet::<T>::block_number()
 					.saturating_add(T::BridgeTxFailCooldownBlocks::get()),
-			None => log::warn!(
+			None => tracing::warn!(
 				target: LOG_TARGET,
 				"Could not find signer {who:?} of failed bridge transaction in relayer set"
 			),

--- a/pallets/validator-set/Cargo.toml
+++ b/pallets/validator-set/Cargo.toml
@@ -8,7 +8,7 @@ license = 'Apache-2.0'
 
 [dependencies]
 codec = { workspace = true, features = ["derive"] }
-log = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 scale-info = { features = ["derive"], workspace = true }
 
 polkadot-sdk-frame = { workspace = true, default-features = false, features = [
@@ -32,7 +32,7 @@ runtime-benchmarks = [
 	"sp-staking/runtime-benchmarks",
 ]
 std = [
-	"log/std",
+	"tracing/std",
 	"pallets-common/std",
 	"sp-staking/std",
 	'codec/std',

--- a/pallets/validator-set/src/lib.rs
+++ b/pallets/validator-set/src/lib.rs
@@ -238,13 +238,13 @@ impl<T: Config> Pallet<T> {
 		if let Err(err) =
 			pallet_session::Pallet::<T>::purge_keys(RawOrigin::Signed(who.clone()).into())
 		{
-			log::trace!(
+			tracing::trace!(
 				target: LOG_TARGET,
 				"Failed to purge session keys for validator {who:?}: {err:?}"
 			);
 		}
 		if let Err(err) = frame_system::Pallet::<T>::dec_providers(who) {
-			log::warn!(
+			tracing::warn!(
 				target: LOG_TARGET,
 				"Failed to decrement provider reference count for validator {who:?}, \
 				leaking reference: {err:?}"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { workspace = true, features = ["derive"] }
-log = { workspace = true }
+tracing = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 serde_json = { features = ["alloc"], workspace = true }
 frame-executive = { workspace = true }
@@ -104,7 +104,7 @@ static_assertions = { workspace = true }
 default = ["std"]
 std = [
 	"codec/std",
-	"log/std",
+	"tracing/std",
 	"scale-info/std",
 	"serde_json/std",
 

--- a/runtime/src/bridge_config.rs
+++ b/runtime/src/bridge_config.rs
@@ -153,7 +153,7 @@ impl<BlobDispatcher: DispatchBlob, Weights: pallet_bridge_messages::WeightInfoEx
 		let payload = match message.data.payload {
 			Ok(payload) => payload,
 			Err(e) => {
-				log::error!(
+				tracing::error!(
 					target: LOG_TARGET_BRIDGE_DISPATCH,
 					"dispatch - payload error: {e:?} for lane_id: {:?} and message_nonce: {:?}",
 					message.key.lane_id,
@@ -167,7 +167,7 @@ impl<BlobDispatcher: DispatchBlob, Weights: pallet_bridge_messages::WeightInfoEx
 		};
 		let dispatch_level_result = match BlobDispatcher::dispatch_blob(payload) {
 			Ok(_) => {
-				log::debug!(
+				tracing::debug!(
 					target: LOG_TARGET_BRIDGE_DISPATCH,
 					"dispatch - `DispatchBlob::dispatch_blob` was ok for lane_id: {:?} and message_nonce: {:?}",
 					message.key.lane_id,
@@ -176,7 +176,7 @@ impl<BlobDispatcher: DispatchBlob, Weights: pallet_bridge_messages::WeightInfoEx
 				XcmBlobMessageDispatchResult::Dispatched
 			},
 			Err(e) => {
-				log::error!(
+				tracing::error!(
 					target: LOG_TARGET_BRIDGE_DISPATCH,
 					"dispatch - `DispatchBlob::dispatch_blob` failed with error: {e:?} for lane_id: {:?} and message_nonce: {:?}",
 					message.key.lane_id,
@@ -279,7 +279,7 @@ where
 				XCM_LANE, &blob,
 			)
 			.map_err(|e| {
-				log::error!(
+				tracing::error!(
 					target: LOG_TARGET_BRIDGE_DISPATCH,
 					"haul_blob result - error: {e:?} on lane: {XCM_LANE:?}",
 				);
@@ -288,7 +288,7 @@ where
 		let artifacts = pallet_bridge_messages::Pallet::<Runtime, MessagesInstance>::send_message(
 			send_message_args,
 		);
-		log::info!(
+		tracing::info!(
 			target: LOG_TARGET_BRIDGE_DISPATCH,
 			"haul_blob result - ok: {:?} on lane: {:?}. Enqueued messages: {}",
 			artifacts.nonce,

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -99,7 +99,7 @@ impl ConvertOrigin<RuntimeOrigin> for KawabungaParachainAsRoot {
 		kind: OriginKind,
 	) -> Result<RuntimeOrigin, Location> {
 		let origin = origin.into();
-		log::trace!(
+		tracing::trace!(
 			target: "xcm::origin_conversion",
 			"KawabungaParachainAsRoot origin: {origin:?}, kind: {kind:?}",
 		);
@@ -148,7 +148,7 @@ impl<RuntimeCall: Decode, AllowedOrigin: Contains<Location>> ShouldExecute
 		max_weight: Weight,
 		_properties: &mut xcm_executor::traits::Properties,
 	) -> Result<(), ProcessMessageError> {
-		log::trace!(
+		tracing::trace!(
 			target: "xcm::barriers",
 			"AllowUnpaidTransactsFrom origin: {origin:?}, instructions: {instructions:?}, max_weight: {max_weight:?}, properties:
 		{_properties:?}",
@@ -247,7 +247,7 @@ impl DispatchBlob for ImmediateXcmDispatcher {
 		let message: Xcm<RuntimeCall> =
 			message.try_into().map_err(|_| DispatchBlobError::UnsupportedXcmVersion)?;
 
-		log::trace!(
+		tracing::trace!(
 			target: "runtime::xcm",
 			"Going to dispatch XCM message from {:?}: {:?}",
 			KawabungaLocation::get(),
@@ -270,7 +270,7 @@ impl DispatchBlob for ImmediateXcmDispatcher {
 		)
 		.ensure_complete()
 		.map_err(|e| {
-			log::trace!(
+			tracing::trace!(
 				target: "runtime::xcm",
 				"XCM message from {:?} was dispatched with an error: {:?}",
 				KawabungaLocation::get(),

--- a/runtimes/bulletin-polkadot/Cargo.toml
+++ b/runtimes/bulletin-polkadot/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { workspace = true, features = ["derive"] }
-log = { workspace = true }
+tracing = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 serde_json = { features = ["alloc"], workspace = true }
 frame-executive = { workspace = true }
@@ -105,7 +105,7 @@ sp-tracing = { workspace = true }
 default = ["std"]
 std = [
 	"codec/std",
-	"log/std",
+	"tracing/std",
 	"scale-info/std",
 	"serde_json/std",
 

--- a/runtimes/bulletin-polkadot/src/polkadot_bridge_config.rs
+++ b/runtimes/bulletin-polkadot/src/polkadot_bridge_config.rs
@@ -262,7 +262,7 @@ impl<BlobDispatcher: DispatchBlob, Weights: pallet_bridge_messages::WeightInfoEx
 		let payload = match message.data.payload {
 			Ok(payload) => payload,
 			Err(e) => {
-				log::error!(
+				tracing::error!(
 					target: LOG_TARGET_BRIDGE_DISPATCH,
 					"dispatch - payload error: {e:?} for lane_id: {:?} and message_nonce: {:?}",
 					message.key.lane_id,
@@ -276,7 +276,7 @@ impl<BlobDispatcher: DispatchBlob, Weights: pallet_bridge_messages::WeightInfoEx
 		};
 		let dispatch_level_result = match BlobDispatcher::dispatch_blob(payload) {
 			Ok(_) => {
-				log::debug!(
+				tracing::debug!(
 					target: LOG_TARGET_BRIDGE_DISPATCH,
 					"dispatch - `DispatchBlob::dispatch_blob` was ok for lane_id: {:?} and message_nonce: {:?}",
 					message.key.lane_id,
@@ -285,7 +285,7 @@ impl<BlobDispatcher: DispatchBlob, Weights: pallet_bridge_messages::WeightInfoEx
 				XcmBlobMessageDispatchResult::Dispatched
 			},
 			Err(e) => {
-				log::error!(
+				tracing::error!(
 					target: LOG_TARGET_BRIDGE_DISPATCH,
 					"dispatch - `DispatchBlob::dispatch_blob` failed with error: {e:?} for lane_id: {:?} and message_nonce: {:?}",
 					message.key.lane_id,
@@ -401,7 +401,7 @@ where
 				XCM_LANE, &blob,
 			)
 			.map_err(|e| {
-				log::error!(
+				tracing::error!(
 					target: LOG_TARGET_BRIDGE_DISPATCH,
 					"haul_blob result - error: {e:?} on lane: {XCM_LANE:?}",
 				);
@@ -410,7 +410,7 @@ where
 		let artifacts = pallet_bridge_messages::Pallet::<Runtime, MessagesInstance>::send_message(
 			send_message_args,
 		);
-		log::info!(
+		tracing::info!(
 			target: LOG_TARGET_BRIDGE_DISPATCH,
 			"haul_blob result - ok: {:?} on lane: {:?}. Enqueued messages: {}",
 			artifacts.nonce,

--- a/runtimes/bulletin-polkadot/src/xcm_config.rs
+++ b/runtimes/bulletin-polkadot/src/xcm_config.rs
@@ -159,7 +159,7 @@ impl<Execute: ExecuteXcm<Call>, Call, AsOrigin: Get<Location>> SendXcm
 				Ok((Xcm::<Call>::from(msg), Assets::new()))
 			},
 			_ => {
-				log::trace!(
+				tracing::trace!(
 					target: "xcm::execute::validate",
 					"ImmediateExecutingXcmRouter unsupported destination: {dest:?}",
 				);
@@ -186,7 +186,7 @@ impl<Execute: ExecuteXcm<Call>, Call, AsOrigin: Get<Location>> SendXcm
 		.ensure_complete()
 		.map(|_| message_hash)
 		.map_err(|e| {
-			log::trace!(
+			tracing::trace!(
 				target: "xcm::execute::deliver",
 				"XCM message from {:?} was dispatched with an error: {:?}",
 				AsOrigin::get(),

--- a/runtimes/bulletin-polkadot/tests/tests.rs
+++ b/runtimes/bulletin-polkadot/tests/tests.rs
@@ -298,7 +298,7 @@ fn construct_and_apply_extrinsic(
 	let dispatch_info = call.get_dispatch_info();
 	let xt = construct_extrinsic(account, call)?;
 	let xt_len = xt.encode().len();
-	log::info!(
+	tracing::info!(
 		"Applying extrinsic: class={:?} pays_fee={:?} weight={:?} encoded_len={} bytes",
 		dispatch_info.class,
 		dispatch_info.pays_fee,
@@ -344,7 +344,7 @@ fn transaction_storage_runtime_sizes() {
 
 		// store data
 		for (index, size) in sizes.into_iter().enumerate() {
-			log::info!("Storing data with size: {size} and index: {index}");
+			tracing::info!("Storing data with size: {size} and index: {index}");
 			advance_block();
 			let res = construct_and_apply_extrinsic(
 				account.pair(),


### PR DESCRIPTION
Replace all uses of the log crate with the tracing ecosystem across:
- pallets/validator-set
- pallets/relayer-set
- runtime/
- runtimes/bulletin-polkadot

This aligns with upstream Polkadot SDK initiatives for improved observability and debuggability.