### PR TITLE
Add polkadot-bulletin-chain binary to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,11 @@ jobs:
           targets: wasm32-unknown-unknown
           components: rust-src
 
-      - name: Install Protobuf
-        run: sudo apt-get install -y protobuf-compiler
+      - name: Install system dependencies
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler libclang-dev
 
       - name: Build polkadot-bulletin-chain binary
         run: cargo build --profile production -p polkadot-bulletin-chain


### PR DESCRIPTION
Build the node binary with production profile and include it in the GitHub release assets alongside the runtime WASMs.