### PR TITLE
fix: resolve SDK workspace dependency conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4620,7 +4620,7 @@ dependencies = [
  "sp-version",
  "sp-wasm-interface",
  "subxt 0.43.1",
- "subxt-signer 0.43.0",
+ "subxt-signer",
  "thiserror 1.0.69",
  "thousands",
 ]
@@ -9106,7 +9106,7 @@ dependencies = [
  "sp-runtime",
  "sp-version",
  "substrate-bn",
- "subxt-signer 0.43.0",
+ "subxt-signer",
 ]
 
 [[package]]
@@ -11870,23 +11870,6 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
-
-[[package]]
-name = "rust-authorize-and-store"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "bulletin-sdk-rust",
- "clap",
- "hex",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime",
- "subxt 0.37.0",
- "subxt-signer 0.37.0",
- "tokio",
-]
 
 [[package]]
 name = "rustc-demangle"
@@ -15951,28 +15934,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "subxt-signer"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49888ae6ae90fe01b471193528eea5bd4ed52d8eecd2d13f4a2333b87388850"
-dependencies = [
- "bip39",
- "cfg-if",
- "hex",
- "hmac 0.12.1",
- "parity-scale-codec",
- "pbkdf2",
- "regex",
- "schnorrkel",
- "secp256k1 0.28.2",
- "secrecy 0.8.0",
- "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subxt-core 0.37.1",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,6 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk.git
 [workspace]
 resolver = "2"
 members = [
-	"examples/rust-authorize-and-store",
 	"node",
 	"pallets/common",
 	"pallets/relayer-set",

--- a/examples/rust-authorize-and-store/Cargo.toml
+++ b/examples/rust-authorize-and-store/Cargo.toml
@@ -13,7 +13,6 @@ bulletin-sdk-rust = { path = "../../sdk/rust" }
 clap = { version = "4.2", features = ["derive"] }
 subxt = { version = "0.37", features = ["substrate-compat"] }
 subxt-signer = { version = "0.37", features = ["sr25519", "subxt"] }
-sp-runtime = { workspace = true }
 tokio = { version = "1.40", features = ["full"] }
 async-trait = "0.1"
 anyhow = "1.0"

--- a/sdk/rust/src/submitters/mock_submitter.rs
+++ b/sdk/rust/src/submitters/mock_submitter.rs
@@ -36,7 +36,7 @@ use std::sync::Mutex;
 /// let client = AsyncBulletinClient::new(submitter);
 ///
 /// let data = b"Hello, Bulletin!".to_vec();
-/// let result = client.store(data, StoreOptions::default()).await?;
+/// let result = client.store(data, None).await?;
 ///
 /// println!("Mock CID: {:?}", result.cid);
 /// # Ok(())
@@ -202,10 +202,7 @@ impl TransactionSubmitter for MockSubmitter {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{
-		async_client::AsyncBulletinClient,
-		types::{AuthorizationScope, StoreOptions},
-	};
+	use crate::{async_client::AsyncBulletinClient, types::AuthorizationScope};
 
 	#[tokio::test]
 	async fn test_mock_submitter_success() {
@@ -231,7 +228,7 @@ mod tests {
 		let client = AsyncBulletinClient::new(submitter);
 
 		let data = b"Hello, Bulletin!".to_vec();
-		let result = client.store(data, StoreOptions::default(), None).await;
+		let result = client.store(data, None).await;
 
 		assert!(result.is_ok());
 		let store_result = result.unwrap();
@@ -280,7 +277,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_authorization_check_with_client() {
-		use crate::{async_client::AsyncClientConfig, types::StoreOptions};
+		use crate::async_client::AsyncClientConfig;
 
 		let submitter = MockSubmitter::new();
 		let account = AccountId32::from([1u8; 32]);
@@ -303,13 +300,13 @@ mod tests {
 
 		// Should succeed - 16 bytes is within limits
 		let data = b"Hello, Bulletin!".to_vec();
-		let result = client.store(data, StoreOptions::default(), None).await;
+		let result = client.store(data, None).await;
 		assert!(result.is_ok());
 	}
 
 	#[tokio::test]
 	async fn test_insufficient_authorization_fails() {
-		use crate::{async_client::AsyncClientConfig, types::StoreOptions};
+		use crate::async_client::AsyncClientConfig;
 
 		let submitter = MockSubmitter::new();
 		let account = AccountId32::from([1u8; 32]);
@@ -332,7 +329,7 @@ mod tests {
 
 		// Should fail - 16 bytes exceeds limits
 		let data = b"Hello, Bulletin!".to_vec();
-		let result = client.store(data, StoreOptions::default(), None).await;
+		let result = client.store(data, None).await;
 		assert!(result.is_err());
 		assert!(matches!(
 			result.unwrap_err(),
@@ -342,7 +339,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_unified_api_small_data() {
-		use crate::{async_client::AsyncClientConfig, types::StoreOptions};
+		use crate::async_client::AsyncClientConfig;
 
 		let submitter = MockSubmitter::new();
 		let config =
@@ -351,7 +348,7 @@ mod tests {
 
 		// Small data (16 bytes < 2 MiB threshold) - should use single transaction
 		let data = b"Hello, Bulletin!".to_vec();
-		let result = client.store(data, StoreOptions::default(), None).await;
+		let result = client.store(data, None).await;
 
 		assert!(result.is_ok());
 		let store_result = result.unwrap();
@@ -361,7 +358,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_unified_api_large_data() {
-		use crate::{async_client::AsyncClientConfig, types::StoreOptions};
+		use crate::async_client::AsyncClientConfig;
 
 		let submitter = MockSubmitter::new();
 		let config = AsyncClientConfig {
@@ -373,7 +370,7 @@ mod tests {
 
 		// Large data (150 bytes > 100 byte threshold) - should auto-chunk
 		let data = vec![0u8; 150];
-		let result = client.store(data, StoreOptions::default(), None).await;
+		let result = client.store(data, None).await;
 
 		assert!(result.is_ok());
 		let store_result = result.unwrap();
@@ -386,7 +383,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_authorization_expiration() {
-		use crate::{async_client::AsyncClientConfig, types::StoreOptions};
+		use crate::async_client::AsyncClientConfig;
 
 		let submitter = MockSubmitter::new();
 		let account = AccountId32::from([1u8; 32]);
@@ -414,7 +411,7 @@ mod tests {
 
 		// Should fail with expiration error - authorization expired at block 5, current is 11
 		let data = b"Hello".to_vec();
-		let result = client.store(data, StoreOptions::default(), None).await;
+		let result = client.store(data, None).await;
 
 		assert!(result.is_err());
 		assert!(matches!(result.unwrap_err(), crate::types::Error::AuthorizationExpired { .. }));

--- a/sdk/rust/src/utils.rs
+++ b/sdk/rust/src/utils.rs
@@ -24,7 +24,7 @@ use sp_runtime::AccountId32;
 pub fn hex_to_bytes(hex: &str) -> Result<Vec<u8>> {
 	let hex = hex.trim_start_matches("0x");
 
-	if hex.len() % 2 != 0 {
+	if !hex.len().is_multiple_of(2) {
 		return Err(Error::InvalidConfig("Hex string must have even length".into()));
 	}
 


### PR DESCRIPTION
Fix the workspace dependency conflict that prevented SDK tests from running.

## Problem

The `rust-authorize-and-store` example uses `subxt 0.37` which pulls in `parity-bip39 v2.0.1` requiring `unicode-normalization = "=0.1.22"` (exact version). However, the workspace's polkadot-sdk dependencies use `unicode-normalization 0.1.25`, causing a resolution conflict.

## Solution

- Remove `rust-authorize-and-store` from workspace members (make it standalone)
- Remove unused `sp-runtime` dependency (uses `subxt::utils::AccountId32` instead)
- Fix SDK tests to use new `store()` API signature
- Fix clippy `is_multiple_of` warning

## Verification

```bash
cd sdk/rust
cargo test --all-features  # ✓ 58 tests pass
cargo clippy --all-targets --all-features -- -D warnings  # ✓ clean
cargo +nightly fmt --all -- --check  # ✓ formatted
```