### PR TITLE
Bump bulletin-westend spec_version to 1_000_003

### DIFF
--- a/runtimes/bulletin-westend/src/lib.rs
+++ b/runtimes/bulletin-westend/src/lib.rs
@@ -184,7 +184,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("bulletin-westend"),
 	impl_name: alloc::borrow::Cow::Borrowed("bulletin-westend"),
 	authoring_version: 1,
-	spec_version: 1_000_002,
+	spec_version: 1_000_003,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Bumps `spec_version` from `1_000_002` to `1_000_003` for the bulletin-westend runtime