### PR TITLE
Add native_ipfs_dag_pb_chunked_data to integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -185,6 +185,10 @@ jobs:
         working-directory: examples
         run: just run-test-store-chunked-data "$TEST_DIR"
 
+      - name: Test native-ipfs-dag-pb-chunked-data
+        working-directory: examples
+        run: just run-test-native-ipfs-dag-pb-chunked-data "$TEST_DIR"
+
       - name: Test store-big-data
         working-directory: examples
         run: just run-test-store-big-data "$TEST_DIR" "big32"

--- a/examples/justfile
+++ b/examples/justfile
@@ -485,6 +485,17 @@ run-test-store-chunked-data test_dir ws_url="ws://localhost:10000" seed="//Alice
     set -e
     node store_chunked_data.js "{{ ws_url }}" "{{ seed }}" "{{ http_ipfs_api }}"
 
+# Run native-ipfs-dag-pb-chunked-data test only (services must already be running via start-services)
+# Parameters:
+#   test_dir - Test directory where services are running
+#   ws_url - WebSocket URL of the Bulletin chain node (default: ws://localhost:10000)
+#   seed - Account seed phrase or dev seed (default: //Alice)
+#   http_ipfs_api - IPFS API URL (default: http://127.0.0.1:8283)
+run-test-native-ipfs-dag-pb-chunked-data test_dir ws_url="ws://localhost:10000" seed="//Alice" http_ipfs_api="http://127.0.0.1:8283":
+    #!/usr/bin/env bash
+    set -e
+    node native_ipfs_dag_pb_chunked_data.js "{{ ws_url }}" "{{ seed }}" "{{ http_ipfs_api }}"
+
 # Run store-big-data test only (services must already be running via start-services)
 # Parameters:
 #   test_dir - Test directory where services are running

--- a/examples/native_ipfs_dag_pb_chunked_data.js
+++ b/examples/native_ipfs_dag_pb_chunked_data.js
@@ -2,7 +2,7 @@ import { createClient } from 'polkadot-api';
 import { getWsProvider } from 'polkadot-api/ws-provider';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { cidFromBytes, buildUnixFSDagPB, convertCid } from './cid_dag_metadata.js';
-import { generateTextImage, fileToDisk, filesAreEqual, newSigner, DEFAULT_IPFS_GATEWAY_URL as HTTP_IPFS_API } from './common.js';
+import { generateTextImage, fileToDisk, filesAreEqual, newSigner, DEFAULT_IPFS_GATEWAY_URL } from './common.js';
 import { authorizeAccount, store, storeChunkedFile, fetchCid } from './api.js';
 import { bulletin } from './.papi/descriptors/dist/index.mjs';
 import { withPolkadotSdkCompat } from "polkadot-api/polkadot-sdk-compat"
@@ -12,6 +12,12 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import * as dagPB from "@ipld/dag-pb";
+
+// Command line arguments: [ws_url] [seed] [ipfs_api_url]
+const args = process.argv.slice(2);
+const NODE_WS = args[0] || 'ws://localhost:10000';
+const SEED = args[1] || '//Alice';
+const HTTP_IPFS_API = args[2] || DEFAULT_IPFS_GATEWAY_URL;
 
 // ---- CONFIG ----
 const CHUNK_SIZE = 6 * 1024 // 6 KB
@@ -28,12 +34,12 @@ async function main() {
         generateTextImage(filePath, "Hello, Bulletin dag - " + new Date().toString());
 
         // Create PAPI client with WebSocket provider
-        client = createClient(withPolkadotSdkCompat(getWsProvider('ws://localhost:10000')));
+        client = createClient(withPolkadotSdkCompat(getWsProvider(NODE_WS)));
         // Get typed API with generated descriptors
         const typedApi = client.getTypedApi(bulletin);
 
         // Create signers
-        const { signer: sudoSigner } = newSigner('//Alice');
+        const { signer: sudoSigner } = newSigner(SEED);
         const { signer: whoSigner, address: whoAddress } = newSigner('//Nativeipfsdagsigner');
 
         console.log('✅ Connected to Bulletin node')


### PR DESCRIPTION
Add the missing native IPFS DAG-PB chunked data test to the CI integration test workflow. Also parameterize the script to accept ws_url, seed, and ipfs_api_url from the command line, matching the pattern of the other test scripts.