### PR TITLE
Extract CID utilities into transaction-storage-primitives crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2128,6 +2128,7 @@ dependencies = [
  "staging-xcm-executor",
  "static_assertions",
  "substrate-wasm-builder",
+ "transaction-storage-primitives",
 ]
 
 [[package]]
@@ -2218,6 +2219,7 @@ dependencies = [
  "substrate-wasm-builder",
  "testnet-parachains-constants",
  "tracing",
+ "transaction-storage-primitives",
  "westend-runtime-constants",
  "xcm-runtime-apis",
 ]
@@ -9081,13 +9083,13 @@ name = "pallet-transaction-storage"
 version = "4.0.0-dev"
 dependencies = [
  "array-bytes 6.2.3",
- "cid",
  "pallets-common",
  "parity-scale-codec",
  "polkadot-sdk-frame",
  "scale-info",
  "sp-transaction-storage-proof",
  "tracing",
+ "transaction-storage-primitives",
 ]
 
 [[package]]
@@ -15666,6 +15668,17 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "transaction-storage-primitives"
+version = "0.1.0"
+dependencies = [
+ "cid",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ pallet-relayer-set = { path = "pallets/relayer-set", default-features = false }
 pallet-transaction-storage = { path = "pallets/transaction-storage", default-features = false }
 pallet-validator-set = { path = "pallets/validator-set", default-features = false }
 pallets-common = { path = "pallets/common", default-features = false }
+transaction-storage-primitives = { path = "pallets/transaction-storage/primitives", default-features = false }
 
 # Polkadot SDK crates (shared git revision)
 frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk.git", rev = "c7b9c08825acc61f1adde54535a41855c04962a2", default-features = false }
@@ -174,6 +175,7 @@ members = [
 	"pallets/common",
 	"pallets/relayer-set",
 	"pallets/transaction-storage",
+	"pallets/transaction-storage/primitives",
 	"pallets/validator-set",
 	"runtimes/bulletin-polkadot",
 	"runtimes/bulletin-westend",

--- a/pallets/transaction-storage/Cargo.toml
+++ b/pallets/transaction-storage/Cargo.toml
@@ -14,10 +14,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 array-bytes = { optional = true, workspace = true }
-cid = { features = ["alloc"], workspace = true }
 codec = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 tracing = { workspace = true }
+transaction-storage-primitives = { workspace = true }
 
 polkadot-sdk-frame = { workspace = true, default-features = false, features = [
 	"runtime",
@@ -35,13 +35,13 @@ runtime-benchmarks = [
 	"polkadot-sdk-frame/runtime-benchmarks",
 ]
 std = [
-	"cid/std",
 	"codec/std",
 	"pallets-common/std",
 	"polkadot-sdk-frame/std",
 	"scale-info/std",
 	"sp-transaction-storage-proof/std",
 	"tracing/std",
+	"transaction-storage-primitives/std",
 ]
 try-runtime = [
 	"pallets-common/try-runtime",

--- a/pallets/transaction-storage/primitives/Cargo.toml
+++ b/pallets/transaction-storage/primitives/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "transaction-storage-primitives"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+repository.workspace = true
+description = "Primitives for transaction storage pallet"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+cid = { features = ["alloc"], workspace = true }
+codec = { workspace = true }
+scale-info = { features = ["derive"], workspace = true }
+tracing = { workspace = true }
+sp-io = { workspace = true, default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"cid/std",
+	"codec/std",
+	"scale-info/std",
+	"sp-io/std",
+	"tracing/std",
+]

--- a/pallets/transaction-storage/primitives/src/cids.rs
+++ b/pallets/transaction-storage/primitives/src/cids.rs
@@ -20,14 +20,12 @@
 //!
 //! See [`CidData`].
 
-use crate::LOG_TARGET;
+use crate::ContentHash;
 use alloc::vec::Vec;
 use cid::{multihash::Multihash, CidGeneric};
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
-use polkadot_sdk_frame::deps::sp_io;
 
-/// 32-byte hash of a stored blob of data.
-pub type ContentHash = [u8; 32];
+const LOG_TARGET: &str = "runtime::transaction-storage::cids";
 
 /// CIDv1 serialized bytes (codec + multihash(ContentHash)).
 pub type Cid = Vec<u8>;
@@ -177,7 +175,6 @@ mod tests {
 		CidGeneric,
 	};
 	use core::str::FromStr;
-	use polkadot_sdk_frame::deps::sp_io;
 
 	#[test]
 	fn test_cid_raw_blake2b_256_roundtrip_works() {

--- a/pallets/transaction-storage/primitives/src/lib.rs
+++ b/pallets/transaction-storage/primitives/src/lib.rs
@@ -1,0 +1,25 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Primitives for the transaction storage pallet.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+pub mod cids;
+
+/// 32-byte hash of a stored blob of data.
+pub type ContentHash = [u8; 32];

--- a/pallets/transaction-storage/src/lib.rs
+++ b/pallets/transaction-storage/src/lib.rs
@@ -29,7 +29,6 @@ extern crate alloc;
 mod benchmarking;
 pub mod weights;
 
-pub mod cids;
 pub mod migrations;
 #[cfg(test)]
 mod mock;
@@ -37,7 +36,6 @@ mod mock;
 mod tests;
 
 use alloc::vec::Vec;
-use cids::{calculate_cid, Cid, CidCodec, CidConfig, ContentHash, HashingAlgorithm, RAW_CODEC};
 use codec::{Decode, Encode, MaxEncodedLen};
 use core::fmt::Debug;
 use polkadot_sdk_frame::{
@@ -51,6 +49,10 @@ use polkadot_sdk_frame::{
 use sp_transaction_storage_proof::{
 	encode_index, num_chunks, random_chunk, ChunkIndex, InherentError, TransactionStorageProof,
 	CHUNK_SIZE, INHERENT_IDENTIFIER,
+};
+use transaction_storage_primitives::{
+	cids::{calculate_cid, Cid, CidCodec, CidConfig, HashingAlgorithm, RAW_CODEC},
+	ContentHash,
 };
 
 /// A type alias for the balance type from this pallet's point of view.

--- a/pallets/transaction-storage/src/migrations.rs
+++ b/pallets/transaction-storage/src/migrations.rs
@@ -73,7 +73,6 @@ impl<T: Config, NewValue: Get<BlockNumberFor<T>>> OnRuntimeUpgrade
 pub mod v1 {
 	use super::*;
 	use crate::{
-		cids::{CidCodec, ContentHash, HashingAlgorithm, RAW_CODEC},
 		pallet::{Pallet, Transactions},
 		TransactionInfo,
 	};
@@ -88,6 +87,10 @@ pub mod v1 {
 		sp_runtime::traits::{BlakeTwo256, Hash},
 	};
 	use sp_transaction_storage_proof::ChunkIndex;
+	use transaction_storage_primitives::{
+		cids::{CidCodec, HashingAlgorithm, RAW_CODEC},
+		ContentHash,
+	};
 
 	/// `TransactionInfo` layout before v1 (no CID fields).
 	#[derive(Encode, Decode, Clone, Debug, MaxEncodedLen)]

--- a/pallets/transaction-storage/src/tests.rs
+++ b/pallets/transaction-storage/src/tests.rs
@@ -18,7 +18,6 @@
 //! Tests for transaction-storage pallet.
 
 use super::{
-	cids::{CidConfig, HashingAlgorithm},
 	mock::{
 		new_test_ext, run_to_block, RuntimeCall, RuntimeEvent, RuntimeOrigin, System, Test,
 		TransactionStorage,
@@ -39,6 +38,7 @@ use polkadot_sdk_frame::{
 	traits::StorageVersion,
 };
 use sp_transaction_storage_proof::{random_chunk, registration::build_proof, CHUNK_SIZE};
+use transaction_storage_primitives::cids::{CidConfig, HashingAlgorithm};
 
 type Call = super::Call<Test>;
 type Error = super::Error<Test>;

--- a/runtimes/bulletin-polkadot/Cargo.toml
+++ b/runtimes/bulletin-polkadot/Cargo.toml
@@ -100,6 +100,7 @@ sp-io = { workspace = true }
 sp-trie = { workspace = true }
 static_assertions = { workspace = true }
 sp-tracing = { workspace = true }
+transaction-storage-primitives = { workspace = true }
 
 [features]
 default = ["std"]
@@ -176,6 +177,7 @@ std = [
 	"sp-storage?/std",
 	"sp-trie/std",
 	"substrate-wasm-builder",
+	"transaction-storage-primitives/std",
 ]
 runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",

--- a/runtimes/bulletin-polkadot/tests/tests.rs
+++ b/runtimes/bulletin-polkadot/tests/tests.rs
@@ -22,7 +22,6 @@ use pallet_bridge_messages::{
 };
 use pallet_bridge_parachains::ParachainHeaders;
 use pallet_transaction_storage::{
-	cids::{calculate_cid, CidConfig, HashingAlgorithm},
 	AuthorizationExtent, Call as TxStorageCall, Config as TxStorageConfig, BAD_DATA_SIZE,
 };
 use runtime::{
@@ -40,6 +39,7 @@ use sp_runtime::{
 };
 use sp_trie::{trie_types::TrieDBMutBuilderV1, LayoutV1, MemoryDB, TrieMut};
 use std::collections::HashMap;
+use transaction_storage_primitives::cids::{calculate_cid, CidConfig, HashingAlgorithm};
 
 fn advance_block() {
 	let current_number = System::block_number();

--- a/runtimes/bulletin-westend/Cargo.toml
+++ b/runtimes/bulletin-westend/Cargo.toml
@@ -85,6 +85,7 @@ testnet-parachains-constants = { features = ["westend"], workspace = true }
 [dev-dependencies]
 parachains-runtimes-test-utils = { workspace = true, default-features = true }
 sp-io = { workspace = true }
+transaction-storage-primitives = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true, default-features = true }
@@ -151,6 +152,7 @@ std = [
 	"substrate-wasm-builder",
 	"testnet-parachains-constants/std",
 	"tracing/std",
+	"transaction-storage-primitives/std",
 	"westend-runtime-constants/std",
 	"xcm-builder/std",
 	"xcm-executor/std",

--- a/runtimes/bulletin-westend/tests/tests.rs
+++ b/runtimes/bulletin-westend/tests/tests.rs
@@ -25,7 +25,6 @@ use bulletin_westend_runtime::{
 };
 use frame_support::{assert_err, assert_ok, dispatch::GetDispatchInfo, pallet_prelude::Hooks};
 use pallet_transaction_storage::{
-	cids::{calculate_cid, CidConfig, HashingAlgorithm},
 	AuthorizationExtent, Call as TxStorageCall, Config as TxStorageConfig,
 };
 use parachains_common::{AccountId, AuraId, Hash as PcHash, Signature as PcSignature};
@@ -38,6 +37,7 @@ use sp_runtime::{
 };
 use std::collections::HashMap;
 use testnet_parachains_constants::westend::{fee::WeightToFee, locations::PeopleLocation};
+use transaction_storage_primitives::cids::{calculate_cid, CidConfig, HashingAlgorithm};
 use xcm::latest::prelude::*;
 use xcm_runtime_apis::conversions::LocationToAccountHelper;
 


### PR DESCRIPTION
Fixes: https://github.com/paritytech/polkadot-bulletin-chain/issues/282
```
- [ ] Fix bulletin-sdk-rust vs pallet-transaction-storage dependency: https://github.com/paritytech/polkadot-bulletin-chain/pull/202/changes#r2861796864
```

## Summary
- Extract CID types and functions from `pallet-transaction-storage` into a standalone `transaction-storage-primitives` crate at `pallets/transaction-storage/primitives/`
- `ContentHash` lives in `lib.rs`, CID-specific types (`CidConfig`, `HashingAlgorithm`, `CidData`, `calculate_cid`, etc.) live in a `cids` submodule
- All consumers (pallet internals, runtime tests) import directly from the primitives crate
- Removed unused `cid` dependency from `pallet-transaction-storage` (now only in the primitives crate)
