### PR TITLE
refactor(sdk): replace pallet-transaction-storage dep with transaction-storage-primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,7 +2136,6 @@ name = "bulletin-sdk-rust"
 version = "0.1.0"
 dependencies = [
  "cid",
- "pallet-transaction-storage",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -2146,6 +2145,7 @@ dependencies = [
  "subxt-signer 0.44.2",
  "thiserror 2.0.18",
  "tokio",
+ "transaction-storage-primitives",
 ]
 
 [[package]]

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -17,8 +17,8 @@ scale-info = { workspace = true, features = [
 # IPFS CID support
 cid = { version = "0.11", default-features = false, features = ["alloc"] }
 
-# Re-export pallet types
-pallet-transaction-storage = { workspace = true }
+# CID primitives
+transaction-storage-primitives = { workspace = true }
 
 # Substrate primitives
 sp-core = { workspace = true }
@@ -43,7 +43,6 @@ default = ["std"]
 std = [
 	"cid/std",
 	"codec/std",
-	"pallet-transaction-storage/std",
 	"scale-info/std",
 	"sp-core/std",
 	"sp-io/std",
@@ -52,17 +51,16 @@ std = [
 	"subxt-signer",
 	"thiserror",
 	"tokio",
+	"transaction-storage-primitives/std",
 ]
 
 # Runtime benchmarking (no-op for SDK, but required for workspace consistency)
 runtime-benchmarks = [
-	"pallet-transaction-storage/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 ]
 
 # Try-runtime support (no-op for SDK, but required for workspace consistency)
 try-runtime = [
-	"pallet-transaction-storage/try-runtime",
 	"sp-runtime/try-runtime",
 ]
 

--- a/sdk/rust/src/cid.rs
+++ b/sdk/rust/src/cid.rs
@@ -10,9 +10,10 @@ extern crate alloc;
 
 use crate::types::{CidCodec, Error, HashAlgorithm, Result};
 
-// Re-export CID types from the pallet
-pub use pallet_transaction_storage::cids::{
-	calculate_cid, Cid, CidConfig, CidData, CidError, ContentHash, HashingAlgorithm,
+// Re-export CID types from transaction-storage-primitives
+pub use transaction_storage_primitives::{
+	cids::{calculate_cid, Cid, CidConfig, CidData, CidError, HashingAlgorithm},
+	ContentHash,
 };
 
 /// Convert SDK CidCodec enum to pallet CidCodec (u64).


### PR DESCRIPTION
Part of: https://github.com/paritytech/polkadot-bulletin-chain/issues/282

## Summary
- Replace `pallet-transaction-storage` dependency with lightweight `transaction-storage-primitives` in `bulletin-sdk-rust`
- The SDK only needs CID types/utilities, not the full pallet