### PR TITLE
fix(ci): fix submit_and_finalize and run-test-rust recipe

### DIFF
--- a/examples/justfile
+++ b/examples/justfile
@@ -540,18 +540,9 @@ run-test-rust example test_dir runtime ws_url="ws://localhost:10000" seed="//Ali
     echo "   WS URL: {{ ws_url }}"
     echo "   Seed: {{ seed }}"
 
-    # Build the Rust binary with appropriate runtime feature
-    # Map runtime name to feature flag
-    # bulletin-polkadot-runtime -> polkadot-runtime
-    # bulletin-westend-runtime -> westend-runtime
-    if echo "{{ runtime }}" | grep -q "westend"; then
-        RUNTIME_FEATURE="westend-runtime"
-    else
-        RUNTIME_FEATURE="polkadot-runtime"
-    fi
-
-    echo "🔧 Building with runtime: {{ runtime }} (feature: $RUNTIME_FEATURE)"
-    cargo build --release --manifest-path "rust/{{ example }}/Cargo.toml" --no-default-features --features "$RUNTIME_FEATURE"
+    # Build the Rust binary
+    echo "🔧 Building Rust example: {{ example }}"
+    cargo build --release --manifest-path "rust/{{ example }}/Cargo.toml"
 
     # Run the example
     RUST_LOG=info "./rust/{{ example }}/target/release/{{ example }}" --ws "{{ ws_url }}" --seed "{{ seed }}"


### PR DESCRIPTION
## Summary

- **Fix `submit_and_finalize` compilation error**: `wait_for_finalized_success()` returns `ExtrinsicEvents` which has no `block_hash()` method. Split into `wait_for_finalized()` + `wait_for_success()` to get `TxInBlock` which does.
- **Fix `run-test-rust` recipe**: Remove `--no-default-features --features "$RUNTIME_FEATURE"` — the Rust example uses the SDK directly and has no runtime feature flags in its Cargo.toml.

Fixes:
- https://github.com/paritytech/polkadot-bulletin-chain/actions/runs/22545020451/job/65306252184
- https://github.com/paritytech/polkadot-bulletin-chain/actions/runs/22545020440/job/65306086367