### PR TITLE
Add Grafana dashboard for Bulletin chain health

### DIFF
--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,0 +1,135 @@
+# Bulletin Chain Dashboard
+
+One Grafana dashboard, sixteen panels, four rows. Each row answers a different question about the chain's health: Is it alive? Is data flowing? Is IPFS serving? Is the machine holding up?
+
+## How to import
+
+1. Open Grafana → Dashboards → Import
+2. Upload `monitoring/grafana/bulletin-health.json`
+3. Select your Prometheus datasource when prompted
+4. The dashboard auto-refreshes every 10 seconds and defaults to a 1-hour window
+
+## Row 1 — Is the chain alive?
+
+The top row is a glanceable status bar. Six panels, each answering one yes/no question. If you're paged at 3am, start here.
+
+### Block Height (best vs finalized)
+
+**Metrics:** `substrate_block_height{status="best"}`, `substrate_block_height{status="finalized"}`
+
+Two lines that should climb together, one block every 6 seconds. The "best" line is the latest block the node knows about; the "finalized" line is the latest block confirmed by GRANDPA. A growing gap between them means finality is stalling — the chain is still producing blocks but can't agree they're final.
+
+### Finality Lag
+
+**Metric:** `substrate_block_height{status="best"} - substrate_block_height{status="finalized"}`
+
+The gap between best and finalized as a single number. Green under 20, yellow 20–50, red above 50. On a healthy chain this hovers around 2–3. If it climbs past 20, GRANDPA consensus is struggling — usually a sign that validators can't communicate or too many are offline.
+
+### Peers
+
+**Metric:** `substrate_sub_libp2p_peers_count`
+
+How many other nodes this one is connected to. Red at 0 (isolated — can't receive or propagate blocks), yellow at 1–2 (fragile), green at 3+. A node with zero peers is effectively offline even if the process is running.
+
+### Proof Generation
+
+**Metric:** `bulletin_proof_generation_failed`
+
+The metric unique to Bulletin. Before authoring a block, the validator must prove it still holds data from ~7 days ago. This panel shows OK (green) or FAILED (red). A failure means this specific node cannot author blocks — its storage is corrupted or data has been lost. Other validators can still produce blocks, but this one is dead for authoring until storage is fixed.
+
+### Validators
+
+**Metric:** `bulletin_registered_validators`
+
+How many validators are in the active set. Bulletin uses a PoA validator model managed through the `ValidatorSet` pallet. Red at 0 (chain halted — no one can produce blocks), yellow at 1–2 (fragile), green at 3+. A sudden drop means validators were explicitly removed via governance.
+
+### Disk Free %
+
+**Metric:** `100 * node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"}`
+
+Bulletin stores up to 1.5–2 TB of data with 7-day retention. This gauge shows remaining disk as a percentage. Red below 5%, yellow 5–15%, green above 15%. Running out of disk is a slow-motion catastrophe — the node can't store new data, can't generate proofs, and eventually crashes.
+
+**Why it uses `node_exporter`:** This metric comes from Prometheus's `node_exporter`, not from the Bulletin node itself. The node doesn't know about disk space — it just writes. You need `node_exporter` running alongside the Bulletin node for this panel to work.
+
+## Row 2 — Is data flowing?
+
+The second row shows what Bulletin exists for: storing data. Three time-series panels covering volume, size, and production rate.
+
+### Store + Renew Transactions (per block)
+
+**Metrics:** `bulletin_block_store_transactions`, `bulletin_block_renew_transactions`
+
+Two overlaid lines. The "total" line counts all data operations (stores + renewals) in each block. The "renewals" line counts just the renewals — data whose retention is being extended for another cycle. The gap between them is pure new data.
+
+On a healthy chain with active users you'll see both lines moving. If renewals drop to zero and stores continue, nobody is extending data retention — everything will expire after 7 days. If both are zero for extended periods, the chain is idle (which may be fine, or may mean clients can't submit transactions).
+
+### Store + Renew Bytes (per block)
+
+**Metrics:** `bulletin_block_store_bytes`, `bulletin_block_renew_bytes`
+
+The byte-level companion to the transaction count panel. Shows how much data (in bytes) was stored and renewed per block. Useful for capacity planning — a sustained spike in bytes means more disk consumption per block. Each block can hold up to ~10 MB total.
+
+### Block Production Rate
+
+**Metric:** `rate(substrate_block_height{status="best"}[1m]) * 60`
+
+Blocks produced per minute. Expected value is ~10 (one block every 6 seconds). Drops below 10 mean blocks are being skipped — either the validator scheduled to produce missed its slot, or the network is partitioned. Consistently below 8 warrants investigation.
+
+## Row 3 — Is IPFS serving?
+
+Bulletin serves stored data over IPFS via the Bitswap protocol. These three panels tell you whether external peers can actually retrieve data. The metrics come from polkadot-sdk's `BitswapServer` (not from litep2p directly — see [metrics-monitoring.md](metrics-monitoring.md) for why).
+
+All three panels use `rate(...[1m])` because the underlying metrics are Counters (monotonically increasing), unlike the Gauges in rows 1–2.
+
+### Bitswap Requests/sec
+
+**Metrics:** `rate(substrate_bitswap_requests_received_total[1m])`, `rate(substrate_bitswap_cids_requested_total[1m])`
+
+Two lines: incoming Bitswap request rate and the CID request rate. A single Bitswap request can ask for multiple CIDs, so the CIDs/s line is always ≥ requests/s. Activity here means external IPFS peers are fetching data from this node. Zero activity isn't necessarily bad — it just means nobody is requesting data right now.
+
+### Bitswap Hit/Miss
+
+**Metrics:** `rate(substrate_bitswap_blocks_sent_total[1m])`, `rate(substrate_bitswap_blocks_not_found_total[1m])`
+
+The most telling Bitswap panel. "Blocks found" means the node had the requested data and served it. "Not found" means the data was requested but wasn't in storage — either it expired (past the 7-day retention), was never stored on this node, or storage is corrupted.
+
+A healthy node shows mostly hits. A rising miss rate with constant request rate means data is expiring faster than expected, or the node's indexed storage is damaged. Combined with `bulletin_proof_generation_failed = 1`, this confirms a storage problem.
+
+### Bitswap Throughput
+
+**Metric:** `rate(substrate_bitswap_blocks_sent_bytes_total[1m])`
+
+Bytes per second of data served over Bitswap. This is the "bandwidth" panel — how much data this node is actually delivering to the IPFS network. Useful for sizing network capacity and understanding load patterns.
+
+## Row 4 — Is the machine holding up?
+
+The bottom row tracks system-level health over time. These are the "did something change?" panels — useful for spotting slow degradation.
+
+### Memory RSS
+
+**Metric:** `process_resident_memory_bytes`
+
+Resident memory of the node process. A steady line is normal. A gradual upward trend over days suggests a memory leak. A sudden spike might indicate a burst of large transactions being processed.
+
+### Proof Generation Status Over Time
+
+**Metric:** `bulletin_proof_generation_failed`
+
+The same metric as the Row 1 stat panel, but as a time-series. Shows the history of proof generation success/failure. Useful for correlating proof failures with other events — did proofs start failing when disk hit 95%? When a validator was removed? The stat panel tells you "right now"; this panel tells you "when did it start?"
+
+### Network Peers Over Time
+
+**Metric:** `substrate_sub_libp2p_peers_count`
+
+Peer count as a time-series. A stable line around 10–25 is healthy. Sudden drops correlate with network issues. A slow decline might mean the node's address is falling out of peer tables. Useful for understanding connectivity trends that the Row 1 stat panel can't show.
+
+## What the dashboard doesn't cover
+
+The dashboard focuses on a single node's view. It doesn't show:
+
+- **Cross-node comparison** — you'd need multi-instance Prometheus labels and `instance` selectors
+- **Bridge health** — relay between Bulletin and People Chain has its own metrics (see bridge monitoring)
+- **Total data stored by accounts** — no metric for this yet (see [metrics-monitoring.md](metrics-monitoring.md#whats-not-here-yet))
+- **Admin operations** — validator/relayer set changes aren't tracked per-block yet
+
+For the full list of available metrics and what's planned, see [metrics-monitoring.md](metrics-monitoring.md).

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,135 +1,106 @@
 # Bulletin Chain Dashboard
 
-One Grafana dashboard, sixteen panels, four rows. Each row answers a different question about the chain's health: Is it alive? Is data flowing? Is IPFS serving? Is the machine holding up?
+One Grafana dashboard, sixteen panels, four rows. Import `monitoring/grafana/bulletin-health.json`, pick your Prometheus datasource, done. Auto-refreshes every 10s, defaults to 1h window.
 
-## How to import
+## Layout
 
-1. Open Grafana → Dashboards → Import
-2. Upload `monitoring/grafana/bulletin-health.json`
-3. Select your Prometheus datasource when prompted
-4. The dashboard auto-refreshes every 10 seconds and defaults to a 1-hour window
+```
+bulletin-health
+├── Row 1 — Is the chain alive?
+│   ├── Block Height (best vs finalized)    substrate_block_height{status=best|finalized}
+│   ├── Finality Lag                        best - finalized, green < 20 / yellow < 50 / red
+│   ├── Peers                               substrate_sub_libp2p_peers_count, red at 0
+│   ├── Proof Generation                    bulletin_proof_generation_failed, OK or FAILED
+│   ├── Validators                          bulletin_registered_validators, red at 0
+│   └── Disk Free %                         node_filesystem_{avail,size}_bytes, red < 5%
+│
+├── Row 2 — Is data flowing?
+│   ├── Store + Renew Transactions          bulletin_block_store_transactions + renew overlay
+│   ├── Store + Renew Bytes                 bulletin_block_store_bytes + renew overlay
+│   └── Block Production Rate               rate(substrate_block_height{best}[1m]) * 60
+│
+├── Row 3 — Is IPFS serving?
+│   ├── Bitswap Requests/sec                rate(substrate_bitswap_requests_received_total[1m])
+│   ├── Bitswap Hit/Miss                    rate(blocks_sent_total) vs rate(blocks_not_found_total)
+│   └── Bitswap Throughput                  rate(substrate_bitswap_blocks_sent_bytes_total[1m])
+│
+└── Row 4 — Is the machine holding up?
+    ├── Memory RSS                          process_resident_memory_bytes
+    ├── Proof Generation Over Time          bulletin_proof_generation_failed as timeseries
+    └── Network Peers Over Time             substrate_sub_libp2p_peers_count as timeseries
+```
 
 ## Row 1 — Is the chain alive?
 
-The top row is a glanceable status bar. Six panels, each answering one yes/no question. If you're paged at 3am, start here.
+The top row is a glanceable status bar. If paged at 3am, start here.
 
-### Block Height (best vs finalized)
-
-**Metrics:** `substrate_block_height{status="best"}`, `substrate_block_height{status="finalized"}`
-
-Two lines that should climb together, one block every 6 seconds. The "best" line is the latest block the node knows about; the "finalized" line is the latest block confirmed by GRANDPA. A growing gap between them means finality is stalling — the chain is still producing blocks but can't agree they're final.
-
-### Finality Lag
-
-**Metric:** `substrate_block_height{status="best"} - substrate_block_height{status="finalized"}`
-
-The gap between best and finalized as a single number. Green under 20, yellow 20–50, red above 50. On a healthy chain this hovers around 2–3. If it climbs past 20, GRANDPA consensus is struggling — usually a sign that validators can't communicate or too many are offline.
-
-### Peers
-
-**Metric:** `substrate_sub_libp2p_peers_count`
-
-How many other nodes this one is connected to. Red at 0 (isolated — can't receive or propagate blocks), yellow at 1–2 (fragile), green at 3+. A node with zero peers is effectively offline even if the process is running.
-
-### Proof Generation
-
-**Metric:** `bulletin_proof_generation_failed`
-
-The metric unique to Bulletin. Before authoring a block, the validator must prove it still holds data from ~7 days ago. This panel shows OK (green) or FAILED (red). A failure means this specific node cannot author blocks — its storage is corrupted or data has been lost. Other validators can still produce blocks, but this one is dead for authoring until storage is fixed.
-
-### Validators
-
-**Metric:** `bulletin_registered_validators`
-
-How many validators are in the active set. Bulletin uses a PoA validator model managed through the `ValidatorSet` pallet. Red at 0 (chain halted — no one can produce blocks), yellow at 1–2 (fragile), green at 3+. A sudden drop means validators were explicitly removed via governance.
-
-### Disk Free %
-
-**Metric:** `100 * node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"}`
-
-Bulletin stores up to 1.5–2 TB of data with 7-day retention. This gauge shows remaining disk as a percentage. Red below 5%, yellow 5–15%, green above 15%. Running out of disk is a slow-motion catastrophe — the node can't store new data, can't generate proofs, and eventually crashes.
-
-**Why it uses `node_exporter`:** This metric comes from Prometheus's `node_exporter`, not from the Bulletin node itself. The node doesn't know about disk space — it just writes. You need `node_exporter` running alongside the Bulletin node for this panel to work.
+- **Block Height** — Two lines climbing together (best and finalized). Growing gap = GRANDPA stalling.
+- **Finality Lag** — The gap as a single number. Healthy = 2–3. Above 20 = consensus struggling.
+- **Peers** — 0 = isolated, < 3 = fragile. Zero peers means effectively offline.
+- **Proof Generation** — Bulletin-unique: validator must prove it holds 7-day-old data to author blocks. FAILED = storage broken, can't author.
+- **Validators** — Active PoA validator count. Drop = removal via governance. Zero = chain halted.
+- **Disk Free %** — Bulletin needs 1.5–2 TB. Uses `node_exporter`, not the Bulletin process itself.
 
 ## Row 2 — Is data flowing?
 
-The second row shows what Bulletin exists for: storing data. Three time-series panels covering volume, size, and production rate.
-
-### Store + Renew Transactions (per block)
-
-**Metrics:** `bulletin_block_store_transactions`, `bulletin_block_renew_transactions`
-
-Two overlaid lines. The "total" line counts all data operations (stores + renewals) in each block. The "renewals" line counts just the renewals — data whose retention is being extended for another cycle. The gap between them is pure new data.
-
-On a healthy chain with active users you'll see both lines moving. If renewals drop to zero and stores continue, nobody is extending data retention — everything will expire after 7 days. If both are zero for extended periods, the chain is idle (which may be fine, or may mean clients can't submit transactions).
-
-### Store + Renew Bytes (per block)
-
-**Metrics:** `bulletin_block_store_bytes`, `bulletin_block_renew_bytes`
-
-The byte-level companion to the transaction count panel. Shows how much data (in bytes) was stored and renewed per block. Useful for capacity planning — a sustained spike in bytes means more disk consumption per block. Each block can hold up to ~10 MB total.
-
-### Block Production Rate
-
-**Metric:** `rate(substrate_block_height{status="best"}[1m]) * 60`
-
-Blocks produced per minute. Expected value is ~10 (one block every 6 seconds). Drops below 10 mean blocks are being skipped — either the validator scheduled to produce missed its slot, or the network is partitioned. Consistently below 8 warrants investigation.
+- **Store + Renew Transactions** — Total data ops and renewal overlay per block. Gap between lines = pure new stores.
+- **Store + Renew Bytes** — Same split but in bytes. Useful for capacity planning (~10 MB max per block).
+- **Block Production Rate** — Blocks/min, expected ~10 (6s slots). Below 8 = slots being missed.
 
 ## Row 3 — Is IPFS serving?
 
-Bulletin serves stored data over IPFS via the Bitswap protocol. These three panels tell you whether external peers can actually retrieve data. The metrics come from polkadot-sdk's `BitswapServer` (not from litep2p directly — see [metrics-monitoring.md](metrics-monitoring.md) for why).
+All panels use `rate(...[1m])` — underlying metrics are Counters from polkadot-sdk's `BitswapServer`, not litep2p (see [metrics-monitoring.md](metrics-monitoring.md) for why).
 
-All three panels use `rate(...[1m])` because the underlying metrics are Counters (monotonically increasing), unlike the Gauges in rows 1–2.
-
-### Bitswap Requests/sec
-
-**Metrics:** `rate(substrate_bitswap_requests_received_total[1m])`, `rate(substrate_bitswap_cids_requested_total[1m])`
-
-Two lines: incoming Bitswap request rate and the CID request rate. A single Bitswap request can ask for multiple CIDs, so the CIDs/s line is always ≥ requests/s. Activity here means external IPFS peers are fetching data from this node. Zero activity isn't necessarily bad — it just means nobody is requesting data right now.
-
-### Bitswap Hit/Miss
-
-**Metrics:** `rate(substrate_bitswap_blocks_sent_total[1m])`, `rate(substrate_bitswap_blocks_not_found_total[1m])`
-
-The most telling Bitswap panel. "Blocks found" means the node had the requested data and served it. "Not found" means the data was requested but wasn't in storage — either it expired (past the 7-day retention), was never stored on this node, or storage is corrupted.
-
-A healthy node shows mostly hits. A rising miss rate with constant request rate means data is expiring faster than expected, or the node's indexed storage is damaged. Combined with `bulletin_proof_generation_failed = 1`, this confirms a storage problem.
-
-### Bitswap Throughput
-
-**Metric:** `rate(substrate_bitswap_blocks_sent_bytes_total[1m])`
-
-Bytes per second of data served over Bitswap. This is the "bandwidth" panel — how much data this node is actually delivering to the IPFS network. Useful for sizing network capacity and understanding load patterns.
+- **Bitswap Requests/sec** — Incoming requests and CIDs/sec. Zero = nobody fetching right now.
+- **Bitswap Hit/Miss** — Found vs not-found. Rising miss rate = data expiring or storage damaged.
+- **Bitswap Throughput** — Bytes/sec served over IPFS. Network bandwidth panel.
 
 ## Row 4 — Is the machine holding up?
 
-The bottom row tracks system-level health over time. These are the "did something change?" panels — useful for spotting slow degradation.
+Time-series for spotting slow degradation.
 
-### Memory RSS
+- **Memory RSS** — Gradual climb over days = possible leak.
+- **Proof Generation Over Time** — History of proof success/failure. "When did it start failing?"
+- **Network Peers Over Time** — Connectivity trends the stat panel can't show.
 
-**Metric:** `process_resident_memory_bytes`
+## Planned panels
 
-Resident memory of the node process. A steady line is normal. A gradual upward trend over days suggests a memory leak. A sudden spike might indicate a burst of large transactions being processed.
+Four features are planned, each as a separate PR:
 
-### Proof Generation Status Over Time
+### Total data stored
 
-**Metric:** `bulletin_proof_generation_failed`
+**Metric:** `bulletin_total_stored_bytes` (Gauge)
 
-The same metric as the Row 1 stat panel, but as a time-series. Shows the history of proof generation success/failure. Useful for correlating proof failures with other events — did proofs start failing when disk hit 95%? When a validator was removed? The stat panel tells you "right now"; this panel tells you "when did it start?"
+A global running total of all data currently held in on-chain storage. Incremented in `do_store()`, decremented when blocks expire past `RetentionPeriod` in `on_initialize()`. Added as a stat panel in Row 1 or a time-series in Row 2.
 
-### Network Peers Over Time
+Shows the chain's actual storage footprint. Combined with Disk Free %, tells you when you'll run out of space.
 
-**Metric:** `substrate_sub_libp2p_peers_count`
+### Admin operations per block
 
-Peer count as a time-series. A stable line around 10–25 is healthy. Sudden drops correlate with network issues. A slow decline might mean the node's address is falling out of peer tables. Useful for understanding connectivity trends that the Row 1 stat panel can't show.
+**Metric:** `bulletin_block_admin_ops` (Gauge)
+
+Per-block count of admin operations: validator add/remove, relayer add/remove, account authorization, preimage authorization, and auth removals/refreshes. Uses the same `BlockRenewCount` pattern — per-block StorageValues cleared in `on_initialize()`, incremented in each extrinsic.
+
+Shows governance activity. Normally zero. Spikes during validator rotations or authorization batches.
+
+### Bridge health
+
+**Metrics:** `bulletin_bridge_outbound_pending`, `bulletin_bridge_outbound_latest_generated_nonce`, `bulletin_bridge_outbound_latest_received_nonce` (Gauges, Polkadot runtime only)
+
+Read from `pallet_bridge_messages::OutboundLanes` storage for lane `[0,0,0,0]`. Pending = `latest_generated_nonce - latest_received_nonce`. Shows whether messages from Bulletin to People Chain are being relayed.
+
+A growing pending count means the bridge is congested or relayers are down. Combined with the Validators panel, tells you whether it's a chain problem or a relay problem.
+
+Not available in Westend runtime (parachain mode has no bridge pallets).
+
+### Cross-node comparison
+
+No new metrics — dashboard-only change. Adds a `$instance` template variable so you can filter or compare metrics across multiple Bulletin nodes.
+
+Requires Prometheus scraping multiple nodes with distinct `instance` labels.
 
 ## What the dashboard doesn't cover
 
-The dashboard focuses on a single node's view. It doesn't show:
+- **Per-account storage breakdown** — would need expensive storage iteration or pallet-level per-account tracking. See [metrics-monitoring.md](metrics-monitoring.md#whats-not-here-yet).
 
-- **Cross-node comparison** — you'd need multi-instance Prometheus labels and `instance` selectors
-- **Bridge health** — relay between Bulletin and People Chain has its own metrics (see bridge monitoring)
-- **Total data stored by accounts** — no metric for this yet (see [metrics-monitoring.md](metrics-monitoring.md#whats-not-here-yet))
-- **Admin operations** — validator/relayer set changes aren't tracked per-block yet
-
-For the full list of available metrics and what's planned, see [metrics-monitoring.md](metrics-monitoring.md).
+For the full metric reference, see [metrics-monitoring.md](metrics-monitoring.md).

--- a/docs/metrics-monitoring.md
+++ b/docs/metrics-monitoring.md
@@ -70,7 +70,47 @@ These are Counters (monotonically increasing, unlike the Gauges above). Use `rat
 
 These are available to any chain running `--ipfs-server` with the litep2p backend, not just Bulletin. See [polkadot-sdk#11370](https://github.com/paritytech/polkadot-sdk/pull/11370).
 
+## Planned metrics
+
+Four metrics are planned, each as a separate PR. They follow the same patterns established above — Gauges read from on-chain storage after block import.
+
+### `bulletin_total_stored_bytes`
+
+**Gauge: total bytes of data currently held on-chain**
+
+A global running total. Implementation: add a `TotalStoredBytes` StorageValue to `pallet-transaction-storage`. Increment by `data.len()` in `do_store()`. Decrement when blocks expire past `RetentionPeriod` in `on_initialize()` — before removing `Transactions` for the obsolete block, sum their sizes and subtract. The node reads it like any other StorageValue.
+
+This replaces the rough `sum_over_time(bulletin_block_store_bytes[7d])` approximation with an exact value. Combined with disk metrics, it tells operators exactly how much of their 1.5–2 TB is occupied.
+
+Per-account breakdown is not planned — `TransactionInfo` doesn't include an owner field, and attributing data to accounts would require tracking the signer through `do_store()` plus a `TransactionOwner` double-map for pruning. That's a significant pallet refactor for minimal monitoring value.
+
+### `bulletin_block_admin_ops`
+
+**Gauge: number of admin operations in the latest block**
+
+Per-block counter using the `BlockRenewCount` pattern. Implementation: add `BlockAdminOps` StorageValue to `pallet-transaction-storage` (or a shared common pallet). Increment in:
+- `pallet-validator-set`: `add_validator`, `remove_validator`
+- `pallet-relayer-set`: `add_relayer`, `remove_relayer`
+- `pallet-transaction-storage`: `authorize_account`, `authorize_preimage`, `remove_expired_account_authorization`, `remove_expired_preimage_authorization`, `refresh_account_authorization`, `refresh_preimage_authorization`
+
+Clear in `on_initialize()`. The node reads it the same way it reads `BlockRenewCount`.
+
+This avoids the event-decoding problem — the node doesn't need to parse runtime events, it just reads a u32 from storage.
+
+### `bulletin_bridge_outbound_pending`
+
+**Gauge: messages waiting to be relayed to People Chain**
+
+Read `OutboundLanes` storage from `pallet_bridge_messages` for lane `[0,0,0,0]`. The `OutboundLaneData` struct contains `latest_generated_nonce` (sent) and `latest_received_nonce` (confirmed delivered). Pending = generated − received. The node reads the raw storage key using the same `storage_value_key` / Blake2_128Concat pattern.
+
+Additional gauges: `bulletin_bridge_outbound_latest_generated_nonce` and `bulletin_bridge_outbound_latest_received_nonce` for the raw nonce values.
+
+Only available in the Polkadot runtime (solochain mode). The Westend runtime is a parachain and doesn't include bridge pallets.
+
+### Cross-node comparison (dashboard only)
+
+No new metric. The dashboard gets a `$instance` template variable added to all queries as `{instance=~"$instance"}`. Requires Prometheus scraping multiple nodes with distinct `instance` labels. This is a dashboard-level change — no pallet or node code needed.
+
 ## What's not here yet
 
-- **Total data stored by accounts** — would require iterating the `Authorizations` storage map or maintaining a running aggregate in the pallet. Can be approximated in Grafana with `sum_over_time(bulletin_block_store_bytes[7d])`.
-- **Admin operations per block period** — authorization, validator, and relayer changes emit runtime events but can't be decoded from the node side (uses fake runtime API). Would need per-block counters added to each pallet.
+- **Per-account storage breakdown** — would need `TransactionOwner(BlockNumber, Index → AccountId)` double-map plus refactoring `do_store()` to accept an account parameter. Significant pallet change for marginal monitoring value. Can be explored if there's a product need.

--- a/monitoring/grafana/bulletin-health.json
+++ b/monitoring/grafana/bulletin-health.json
@@ -1,0 +1,258 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "type": "datasource",
+      "pluginId": "prometheus"
+    }
+  ],
+  "title": "Bulletin Chain Health",
+  "description": "Bulletin Chain node health: block production, storage operations, proof generation, and system resources.",
+  "uid": "bulletin-health",
+  "tags": ["bulletin", "substrate"],
+  "timezone": "utc",
+  "refresh": "10s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "title": "Block Height (best vs finalized)",
+      "description": "Best and finalized block numbers. Gap > 20 = GRANDPA problem.",
+      "type": "timeseries",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "substrate_block_height{status=\"best\"}",
+          "legendFormat": "best"
+        },
+        {
+          "expr": "substrate_block_height{status=\"finalized\"}",
+          "legendFormat": "finalized"
+        }
+      ]
+    },
+    {
+      "title": "Finality Lag",
+      "description": "Blocks between best and finalized. > 20 = warning, > 50 = critical.",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 3, "x": 6, "y": 0 },
+      "id": 2,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "substrate_block_height{status=\"best\"} - substrate_block_height{status=\"finalized\"}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 20 },
+              { "color": "red", "value": 50 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Peers",
+      "description": "Connected peers. 0 = isolated, < 3 = degraded.",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 3, "x": 9, "y": 0 },
+      "id": 3,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "substrate_sub_libp2p_peers_count"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "green", "value": 3 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Proof Generation",
+      "description": "Proof generation status. 0 = ok, 1 = failed.",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 3, "x": 12, "y": 0 },
+      "id": 4,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "bulletin_proof_generation_failed"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "OK" }, "1": { "text": "FAILED" } } }
+          ],
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Tx Pool Pending",
+      "description": "Pending transaction pool validations. > 500 = overwhelmed.",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 3, "x": 15, "y": 0 },
+      "id": 5,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "substrate_sub_txpool_validations_scheduled - substrate_sub_txpool_validations_finished"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 500 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Disk Free %",
+      "description": "Available disk space. Bulletin needs 1.5-2 TB. < 5% = critical.",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 3, "x": 18, "y": 0 },
+      "id": 6,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "100 * node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "green", "value": 15 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Store Transactions (per block)",
+      "description": "Number of data store transactions in the latest imported block. Max 512 per block.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 4 },
+      "id": 10,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "bulletin_block_store_transactions",
+          "legendFormat": "txs/block"
+        }
+      ]
+    },
+    {
+      "title": "Store Bytes (per block)",
+      "description": "Bytes of data stored in the latest imported block. Max 10 MB per block.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 4 },
+      "id": 11,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "bulletin_block_store_bytes",
+          "legendFormat": "bytes/block"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      }
+    },
+    {
+      "title": "Block Production Rate",
+      "description": "Blocks produced per minute. Expected ~10 (one every 6s).",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 5, "x": 16, "y": 4 },
+      "id": 12,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "rate(substrate_block_height{status=\"best\"}[1m]) * 60",
+          "legendFormat": "blocks/min"
+        }
+      ]
+    },
+    {
+      "title": "Memory RSS",
+      "description": "Resident memory. Gradual increase over days = possible leak.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 7, "x": 0, "y": 10 },
+      "id": 20,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes",
+          "legendFormat": "RSS"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      }
+    },
+    {
+      "title": "Proof Generation Status Over Time",
+      "description": "Proof generation status over time. 1 = failed, 0 = ok.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 7, "x": 7, "y": 10 },
+      "id": 21,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "bulletin_proof_generation_failed",
+          "legendFormat": "status"
+        }
+      ]
+    },
+    {
+      "title": "Network Peers Over Time",
+      "description": "Connected peer count over time.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 7, "x": 14, "y": 10 },
+      "id": 22,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "substrate_sub_libp2p_peers_count",
+          "legendFormat": "peers"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "version": 2
+}

--- a/monitoring/grafana/bulletin-health.json
+++ b/monitoring/grafana/bulletin-health.json
@@ -8,7 +8,7 @@
     }
   ],
   "title": "Bulletin Chain Health",
-  "description": "Bulletin Chain node health: block production, storage operations, proof generation, and system resources.",
+  "description": "Bulletin Chain node health: block production, storage operations, proof generation, IPFS serving, and system resources.",
   "uid": "bulletin-health",
   "tags": ["bulletin", "substrate"],
   "timezone": "utc",
@@ -108,24 +108,24 @@
       }
     },
     {
-      "title": "Tx Pool Pending",
-      "description": "Pending transaction pool validations. > 500 = overwhelmed.",
+      "title": "Validators",
+      "description": "Registered validators. Drop = validators removed. 0 = chain halted.",
       "type": "stat",
       "gridPos": { "h": 4, "w": 3, "x": 15, "y": 0 },
       "id": 5,
       "datasource": "${DS_PROMETHEUS}",
       "targets": [
         {
-          "expr": "substrate_sub_txpool_validations_scheduled - substrate_sub_txpool_validations_finished"
+          "expr": "bulletin_registered_validators"
         }
       ],
       "fieldConfig": {
         "defaults": {
           "thresholds": {
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 100 },
-              { "color": "red", "value": 500 }
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "green", "value": 3 }
             ]
           }
         }
@@ -159,30 +159,38 @@
       }
     },
     {
-      "title": "Store Transactions (per block)",
-      "description": "Number of data store transactions in the latest imported block. Max 512 per block.",
+      "title": "Store + Renew Transactions (per block)",
+      "description": "Data operations per block: stores (new data) and renewals (extending retention).",
       "type": "timeseries",
-      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 4 },
+      "gridPos": { "h": 6, "w": 7, "x": 0, "y": 4 },
       "id": 10,
       "datasource": "${DS_PROMETHEUS}",
       "targets": [
         {
           "expr": "bulletin_block_store_transactions",
-          "legendFormat": "txs/block"
+          "legendFormat": "total (store+renew)"
+        },
+        {
+          "expr": "bulletin_block_renew_transactions",
+          "legendFormat": "renewals"
         }
       ]
     },
     {
-      "title": "Store Bytes (per block)",
-      "description": "Bytes of data stored in the latest imported block. Max 10 MB per block.",
+      "title": "Store + Renew Bytes (per block)",
+      "description": "Bytes of data stored and renewed per block.",
       "type": "timeseries",
-      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 4 },
+      "gridPos": { "h": 6, "w": 7, "x": 7, "y": 4 },
       "id": 11,
       "datasource": "${DS_PROMETHEUS}",
       "targets": [
         {
           "expr": "bulletin_block_store_bytes",
-          "legendFormat": "bytes/block"
+          "legendFormat": "total bytes"
+        },
+        {
+          "expr": "bulletin_block_renew_bytes",
+          "legendFormat": "renewed bytes"
         }
       ],
       "fieldConfig": {
@@ -195,7 +203,7 @@
       "title": "Block Production Rate",
       "description": "Blocks produced per minute. Expected ~10 (one every 6s).",
       "type": "timeseries",
-      "gridPos": { "h": 6, "w": 5, "x": 16, "y": 4 },
+      "gridPos": { "h": 6, "w": 7, "x": 14, "y": 4 },
       "id": 12,
       "datasource": "${DS_PROMETHEUS}",
       "targets": [
@@ -206,10 +214,65 @@
       ]
     },
     {
+      "title": "Bitswap Requests/sec",
+      "description": "IPFS Bitswap incoming request rate. Shows how actively peers are fetching stored data.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 7, "x": 0, "y": 10 },
+      "id": 30,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "rate(substrate_bitswap_requests_received_total[1m])",
+          "legendFormat": "requests/s"
+        },
+        {
+          "expr": "rate(substrate_bitswap_cids_requested_total[1m])",
+          "legendFormat": "CIDs/s"
+        }
+      ]
+    },
+    {
+      "title": "Bitswap Hit/Miss",
+      "description": "Blocks found vs not found in Bitswap responses. High miss rate = data may have expired or storage issue.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 7, "x": 7, "y": 10 },
+      "id": 31,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "rate(substrate_bitswap_blocks_sent_total[1m])",
+          "legendFormat": "blocks found/s"
+        },
+        {
+          "expr": "rate(substrate_bitswap_blocks_not_found_total[1m])",
+          "legendFormat": "not found/s"
+        }
+      ]
+    },
+    {
+      "title": "Bitswap Throughput",
+      "description": "Bytes of block data served over Bitswap per second.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 7, "x": 14, "y": 10 },
+      "id": 32,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "rate(substrate_bitswap_blocks_sent_bytes_total[1m])",
+          "legendFormat": "bytes/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        }
+      }
+    },
+    {
       "title": "Memory RSS",
       "description": "Resident memory. Gradual increase over days = possible leak.",
       "type": "timeseries",
-      "gridPos": { "h": 6, "w": 7, "x": 0, "y": 10 },
+      "gridPos": { "h": 6, "w": 7, "x": 0, "y": 16 },
       "id": 20,
       "datasource": "${DS_PROMETHEUS}",
       "targets": [
@@ -228,7 +291,7 @@
       "title": "Proof Generation Status Over Time",
       "description": "Proof generation status over time. 1 = failed, 0 = ok.",
       "type": "timeseries",
-      "gridPos": { "h": 6, "w": 7, "x": 7, "y": 10 },
+      "gridPos": { "h": 6, "w": 7, "x": 7, "y": 16 },
       "id": 21,
       "datasource": "${DS_PROMETHEUS}",
       "targets": [
@@ -242,7 +305,7 @@
       "title": "Network Peers Over Time",
       "description": "Connected peer count over time.",
       "type": "timeseries",
-      "gridPos": { "h": 6, "w": 7, "x": 14, "y": 10 },
+      "gridPos": { "h": 6, "w": 7, "x": 14, "y": 16 },
       "id": 22,
       "datasource": "${DS_PROMETHEUS}",
       "targets": [
@@ -254,5 +317,5 @@
     }
   ],
   "schemaVersion": 39,
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
## Summary

- Importable Grafana dashboard JSON (`monitoring/grafana/bulletin-health.json`)
- 12 panels across 3 rows covering block production, storage operations, proof failures, and system resources
- Uses `bulletin_*` gauge metrics from #320 and standard `substrate_*` metrics

Depends on #320.

## Test plan

- [ ] Import JSON into Grafana, verify all panels render
- [ ] Confirm `bulletin_block_store_transactions` and `bulletin_block_store_bytes` panels show data after store txs