### PR TITLE
Add total stored bytes metric with automatic expiry tracking

### DIFF
--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -24,6 +24,8 @@ pub struct BulletinMetrics {
 	pub block_renew_bytes: Gauge<U64>,
 	/// Number of registered validators.
 	pub registered_validators: Gauge<U64>,
+	/// Total bytes of data currently stored on-chain.
+	pub total_stored_bytes: Gauge<U64>,
 	/// Whether proof generation failed on the last attempt (0 = ok, 1 = failed).
 	pub proof_generation_failed: Gauge<U64>,
 }
@@ -63,6 +65,13 @@ impl BulletinMetrics {
 				Gauge::new(
 					"bulletin_registered_validators",
 					"Number of registered validators in the validator set",
+				)?,
+				registry,
+			)?,
+			total_stored_bytes: register(
+				Gauge::new(
+					"bulletin_total_stored_bytes",
+					"Total bytes of data currently stored on-chain",
 				)?,
 				registry,
 			)?,
@@ -141,6 +150,7 @@ pub fn spawn_metrics_task(
 	let num_validators_key = storage_value_key(b"ValidatorSet", b"NumValidators");
 	let renew_count_key = storage_value_key(b"TransactionStorage", b"BlockRenewCount");
 	let renew_bytes_key = storage_value_key(b"TransactionStorage", b"BlockRenewBytes");
+	let total_stored_bytes_key = storage_value_key(b"TransactionStorage", b"TotalStoredBytes");
 
 	let task = async move {
 		let mut stream = client.import_notification_stream();
@@ -170,6 +180,11 @@ pub fn spawn_metrics_task(
 			metrics
 				.block_renew_bytes
 				.set(read_u64_storage(&client, block_hash, &renew_bytes_key).unwrap_or(0));
+
+			// Total stored bytes.
+			metrics
+				.total_stored_bytes
+				.set(read_u64_storage(&client, block_hash, &total_stored_bytes_key).unwrap_or(0));
 
 			// Registered validators.
 			metrics

--- a/pallets/transaction-storage/src/lib.rs
+++ b/pallets/transaction-storage/src/lib.rs
@@ -296,6 +296,15 @@ pub mod pallet {
 			let period = Self::retention_period();
 			let obsolete = n.saturating_sub(period.saturating_add(One::one()));
 			if obsolete > Zero::zero() {
+				// Subtract expired data from total before removing
+				weight.saturating_accrue(db_weight.reads(1));
+				if let Some(expired_txs) = <Transactions<T>>::get(obsolete) {
+					let expired_bytes: u64 = expired_txs.iter().map(|t| t.size as u64).sum();
+					TotalStoredBytes::<T>::mutate(|total| {
+						*total = total.saturating_sub(expired_bytes)
+					});
+					weight.saturating_accrue(db_weight.reads_writes(1, 1));
+				}
 				weight.saturating_accrue(db_weight.writes(2));
 				<Transactions<T>>::remove(obsolete);
 			}
@@ -709,6 +718,11 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type BlockRenewBytes<T: Config> = StorageValue<_, u64, ValueQuery>;
 
+	/// Total bytes of data currently stored on-chain across all blocks.
+	/// Incremented when data is stored, decremented when blocks expire past RetentionPeriod.
+	#[pallet::storage]
+	pub type TotalStoredBytes<T: Config> = StorageValue<_, u64, ValueQuery>;
+
 	/// Was the proof checked in this block?
 	#[pallet::storage]
 	pub(super) type ProofChecked<T: Config> = StorageValue<_, bool, ValueQuery>;
@@ -823,6 +837,7 @@ pub mod pallet {
 					})
 					.map_err(|_| Error::<T>::TooManyTransactions)
 			})?;
+			TotalStoredBytes::<T>::mutate(|total| *total = total.saturating_add(data.len() as u64));
 			Self::deposit_event(Event::Stored {
 				index,
 				content_hash: cid.content_hash,


### PR DESCRIPTION
## Summary

- Adds `bulletin_total_stored_bytes` Gauge — a global running total of all data currently held on-chain
- Incremented in `do_store()` when new data is stored
- Decremented in `on_initialize()` when blocks expire past `RetentionPeriod` (reads expired transactions, sums their sizes, subtracts before removing)
- Node metrics task reads the new `TotalStoredBytes` StorageValue like existing metrics

Combined with Disk Free %, this tells operators exactly how much of their 1.5–2 TB storage is occupied.

## Changes

- `pallets/transaction-storage/src/lib.rs`: new `TotalStoredBytes` StorageValue, increment in `do_store()`, decrement in `on_initialize()` with proper weight accounting
- `node/src/metrics.rs`: new `total_stored_bytes` Gauge, registered as `bulletin_total_stored_bytes`

## Depends on

- #320 (Bulletin-specific Prometheus metrics)