### PR TITLE
Add per-block admin operations metric across all pallets

### DIFF
--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -26,6 +26,9 @@ pub struct BulletinMetrics {
 	pub registered_validators: Gauge<U64>,
 	/// Whether proof generation failed on the last attempt (0 = ok, 1 = failed).
 	pub proof_generation_failed: Gauge<U64>,
+	/// Total admin operations in the latest block (validator changes + relayer changes + auth
+	/// ops).
+	pub block_admin_ops: Gauge<U64>,
 }
 
 impl BulletinMetrics {
@@ -70,6 +73,13 @@ impl BulletinMetrics {
 				Gauge::new(
 					"bulletin_proof_generation_failed",
 					"Whether proof generation failed on the last attempt (0 = ok, 1 = failed)",
+				)?,
+				registry,
+			)?,
+			block_admin_ops: register(
+				Gauge::new(
+					"bulletin_block_admin_ops",
+					"Total admin operations in the latest block (validator changes + relayer changes + authorization ops)",
 				)?,
 				registry,
 			)?,
@@ -141,6 +151,9 @@ pub fn spawn_metrics_task(
 	let num_validators_key = storage_value_key(b"ValidatorSet", b"NumValidators");
 	let renew_count_key = storage_value_key(b"TransactionStorage", b"BlockRenewCount");
 	let renew_bytes_key = storage_value_key(b"TransactionStorage", b"BlockRenewBytes");
+	let validator_changes_key = storage_value_key(b"ValidatorSet", b"BlockValidatorChanges");
+	let relayer_changes_key = storage_value_key(b"RelayerSet", b"BlockRelayerChanges");
+	let auth_ops_key = storage_value_key(b"TransactionStorage", b"BlockAuthorizationOps");
 
 	let task = async move {
 		let mut stream = client.import_notification_stream();
@@ -175,6 +188,13 @@ pub fn spawn_metrics_task(
 			metrics
 				.registered_validators
 				.set(read_u32_storage(&client, block_hash, &num_validators_key).unwrap_or(0) as u64);
+
+			// Admin operations (sum of validator changes + relayer changes + authorization ops).
+			let admin_ops = read_u32_storage(&client, block_hash, &validator_changes_key)
+				.unwrap_or(0) as u64 +
+				read_u32_storage(&client, block_hash, &relayer_changes_key).unwrap_or(0) as u64 +
+				read_u32_storage(&client, block_hash, &auth_ops_key).unwrap_or(0) as u64;
+			metrics.block_admin_ops.set(admin_ops);
 		}
 	};
 

--- a/pallets/relayer-set/src/lib.rs
+++ b/pallets/relayer-set/src/lib.rs
@@ -69,6 +69,19 @@ pub mod pallet {
 	pub(super) type Relayers<T: Config> =
 		StorageMap<_, Blake2_128Concat, T::AccountId, Relayer<BlockNumberFor<T>>, OptionQuery>;
 
+	/// Number of relayer set changes in the current block.
+	/// Cleared in on_initialize of the next block.
+	#[pallet::storage]
+	pub type BlockRelayerChanges<T: Config> = StorageValue<_, u32, ValueQuery>;
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
+			BlockRelayerChanges::<T>::kill();
+			T::DbWeight::get().writes(1)
+		}
+	}
+
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
@@ -113,6 +126,7 @@ pub mod pallet {
 		pub fn add_relayer(origin: OriginFor<T>, who: T::AccountId) -> DispatchResult {
 			T::AddRemoveOrigin::ensure_origin(origin)?;
 			Self::do_add_relayer(&who)?;
+			BlockRelayerChanges::<T>::mutate(|c| *c = c.saturating_add(1));
 			Self::deposit_event(Event::RelayerAdded(who));
 			Ok(())
 		}
@@ -126,6 +140,7 @@ pub mod pallet {
 		pub fn remove_relayer(origin: OriginFor<T>, who: T::AccountId) -> DispatchResult {
 			T::AddRemoveOrigin::ensure_origin(origin)?;
 			ensure!(Self::do_remove_relayer(&who), Error::<T>::NotARelayer);
+			BlockRelayerChanges::<T>::mutate(|c| *c = c.saturating_add(1));
 			Self::deposit_event(Event::RelayerRemoved(who));
 			Ok(())
 		}

--- a/pallets/transaction-storage/src/lib.rs
+++ b/pallets/transaction-storage/src/lib.rs
@@ -285,10 +285,11 @@ pub mod pallet {
 			// this is just a redundant storage read per block.
 			weight.saturating_accrue(migrations::v1::maybe_migrate_v0_to_v1::<T>());
 
-			// Clear per-block renew counters from the previous block.
+			// Clear per-block counters from the previous block.
 			BlockRenewCount::<T>::kill();
 			BlockRenewBytes::<T>::kill();
-			weight.saturating_accrue(db_weight.writes(2));
+			BlockAuthorizationOps::<T>::kill();
+			weight.saturating_accrue(db_weight.writes(3));
 
 			// Drop obsolete roots. The proof for `obsolete` will be checked later
 			// in this block, so we drop `obsolete` - 1.
@@ -520,6 +521,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::Authorizer::ensure_origin(origin)?;
 			Self::authorize(AuthorizationScope::Account(who.clone()), transactions, bytes);
+			BlockAuthorizationOps::<T>::mutate(|c| *c = c.saturating_add(1));
 			Self::deposit_event(Event::AccountAuthorized { who, transactions, bytes });
 			Ok(())
 		}
@@ -549,6 +551,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::Authorizer::ensure_origin(origin)?;
 			Self::authorize(AuthorizationScope::Preimage(content_hash), 1, max_size);
+			BlockAuthorizationOps::<T>::mutate(|c| *c = c.saturating_add(1));
 			Self::deposit_event(Event::PreimageAuthorized { content_hash, max_size });
 			Ok(())
 		}
@@ -568,6 +571,7 @@ pub mod pallet {
 			who: T::AccountId,
 		) -> DispatchResult {
 			Self::remove_expired_authorization(AuthorizationScope::Account(who.clone()))?;
+			BlockAuthorizationOps::<T>::mutate(|c| *c = c.saturating_add(1));
 			Self::deposit_event(Event::ExpiredAccountAuthorizationRemoved { who });
 			Ok(())
 		}
@@ -588,6 +592,7 @@ pub mod pallet {
 			content_hash: ContentHash,
 		) -> DispatchResult {
 			Self::remove_expired_authorization(AuthorizationScope::Preimage(content_hash))?;
+			BlockAuthorizationOps::<T>::mutate(|c| *c = c.saturating_add(1));
 			Self::deposit_event(Event::ExpiredPreimageAuthorizationRemoved { content_hash });
 			Ok(())
 		}
@@ -610,6 +615,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::Authorizer::ensure_origin(origin)?;
 			Self::refresh_authorization(AuthorizationScope::Account(who.clone()))?;
+			BlockAuthorizationOps::<T>::mutate(|c| *c = c.saturating_add(1));
 			Self::deposit_event(Event::AccountAuthorizationRefreshed { who });
 			Ok(())
 		}
@@ -633,6 +639,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::Authorizer::ensure_origin(origin)?;
 			Self::refresh_authorization(AuthorizationScope::Preimage(content_hash))?;
+			BlockAuthorizationOps::<T>::mutate(|c| *c = c.saturating_add(1));
 			Self::deposit_event(Event::PreimageAuthorizationRefreshed { content_hash });
 			Ok(())
 		}
@@ -708,6 +715,11 @@ pub mod pallet {
 	/// Set during block execution, cleared in `on_initialize` of the next block.
 	#[pallet::storage]
 	pub type BlockRenewBytes<T: Config> = StorageValue<_, u64, ValueQuery>;
+
+	/// Number of authorization-related admin operations in the current block.
+	/// Set during block execution, cleared in `on_initialize` of the next block.
+	#[pallet::storage]
+	pub type BlockAuthorizationOps<T: Config> = StorageValue<_, u32, ValueQuery>;
 
 	/// Was the proof checked in this block?
 	#[pallet::storage]

--- a/pallets/validator-set/src/lib.rs
+++ b/pallets/validator-set/src/lib.rs
@@ -112,6 +112,11 @@ pub mod pallet {
 	#[pallet::storage]
 	pub(super) type NumValidators<T: Config> = StorageValue<_, u32, ValueQuery>;
 
+	/// Number of validator set changes in the current block.
+	/// Cleared in on_initialize of the next block.
+	#[pallet::storage]
+	pub type BlockValidatorChanges<T: Config> = StorageValue<_, u32, ValueQuery>;
+
 	/// Validators that should be disabled in the next session.
 	///
 	/// Validator removal takes effect in the session after next. Validator disabling takes effect
@@ -159,6 +164,14 @@ pub mod pallet {
 		}
 	}
 
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
+			BlockValidatorChanges::<T>::kill();
+			T::DbWeight::get().writes(1)
+		}
+	}
+
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Add a new validator.
@@ -176,6 +189,7 @@ pub mod pallet {
 		pub fn add_validator(origin: OriginFor<T>, who: T::AccountId) -> DispatchResult {
 			T::AddRemoveOrigin::ensure_origin(origin)?;
 			Self::do_add_validator(&who)?;
+			BlockValidatorChanges::<T>::mutate(|c| *c = c.saturating_add(1));
 			Self::deposit_event(Event::ValidatorAdded(who));
 			Ok(())
 		}
@@ -194,6 +208,7 @@ pub mod pallet {
 		pub fn remove_validator(origin: OriginFor<T>, who: T::AccountId) -> DispatchResult {
 			T::AddRemoveOrigin::ensure_origin(origin)?;
 			ensure!(Self::do_remove_validator(&who), Error::<T>::NotAValidator);
+			BlockValidatorChanges::<T>::mutate(|c| *c = c.saturating_add(1));
 			Self::deposit_event(Event::ValidatorRemoved(who));
 			Ok(())
 		}


### PR DESCRIPTION
## Summary

- Adds `bulletin_block_admin_ops` Gauge — counts total admin operations per block
- Uses the proven `BlockRenewCount` pattern: per-block StorageValues cleared in `on_initialize()`, incremented in each extrinsic
- Three independent per-pallet counters summed by the node metrics task (avoids cross-pallet coupling)

### Tracked operations

| Pallet | Operations | Storage |
|--------|-----------|---------|
| validator-set | `add_validator`, `remove_validator` | `BlockValidatorChanges` |
| relayer-set | `add_relayer`, `remove_relayer` | `BlockRelayerChanges` |
| transaction-storage | `authorize_account`, `authorize_preimage`, `remove_expired_account_authorization`, `remove_expired_preimage_authorization`, `refresh_account_authorization`, `refresh_preimage_authorization` | `BlockAuthorizationOps` |

## Changes

- `pallets/validator-set/src/lib.rs`: new `BlockValidatorChanges` + `on_initialize` hook
- `pallets/relayer-set/src/lib.rs`: new `BlockRelayerChanges` + `on_initialize` hook
- `pallets/transaction-storage/src/lib.rs`: new `BlockAuthorizationOps`, cleared alongside existing renew counters
- `node/src/metrics.rs`: new `block_admin_ops` Gauge, sums all three storage values

## Depends on

- #320 (Bulletin-specific Prometheus metrics)