### PR TITLE
Add PeopleNext (para ID 5140) as authorizer in bulletin-westend runtime

### DIFF
--- a/runtimes/bulletin-westend/src/storage.rs
+++ b/runtimes/bulletin-westend/src/storage.rs
@@ -17,6 +17,7 @@
 //! Storage-specific configurations.
 
 use super::{AccountId, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason};
+use crate::xcm_config::PeopleNextLocation;
 use alloc::vec::Vec;
 use frame_support::{
 	parameter_types,
@@ -65,8 +66,11 @@ impl pallet_transaction_storage::Config for Runtime {
 		EitherOfDiverse<
 			// Root can do whatever.
 			crate::EnsureRoot<Self::AccountId>,
-			// People chain can also handle authorizations.
-			EnsureXcm<Equals<PeopleLocation>>,
+			// People chains can also handle authorizations.
+			EitherOfDiverse<
+				EnsureXcm<Equals<PeopleLocation>>,
+				EnsureXcm<Equals<PeopleNextLocation>>,
+			>,
 		>,
 		// Test accounts can also authorize for testing purposes.
 		EnsureSignedBy<TestAccounts, Self::AccountId>,

--- a/runtimes/bulletin-westend/src/xcm_config.rs
+++ b/runtimes/bulletin-westend/src/xcm_config.rs
@@ -58,6 +58,10 @@ use xcm_executor::XcmExecutor;
 pub use testnet_parachains_constants::westend::locations::{GovernanceLocation, PeopleLocation};
 
 parameter_types! {
+	pub PeopleNextLocation: Location = Location::new(1, [Parachain(5140)]);
+}
+
+parameter_types! {
 	pub const RootLocation: Location = Location::here();
 	pub const TokenRelayLocation: Location = Location::parent();
 	pub AssetHubLocation: Location = Location::new(1, [Parachain(ASSET_HUB_ID)]);
@@ -158,8 +162,9 @@ pub type Barrier = TrailingSetTopicAsId<(
 				ParentOrParentsPlurality,
 				FellowsPlurality,
 				Equals<GovernanceLocation>,
-				// Let's allow a People chain for PoP authorizations.
+				// Let's allow People chains for PoP authorizations.
 				Equals<PeopleLocation>,
+				Equals<PeopleNextLocation>,
 			)>,
 			// Subscriptions for version tracking are OK.
 			AllowSubscriptionsFrom<ParentRelayOrSiblingParachains>,

--- a/runtimes/bulletin-westend/tests/tests.rs
+++ b/runtimes/bulletin-westend/tests/tests.rs
@@ -647,6 +647,49 @@ fn people_chain_can_authorize_storage_with_transact() {
 		})
 }
 
+#[test]
+fn people_next_chain_can_authorize_storage_with_transact() {
+	// PeopleNext chain (parachain 5140) should be able to authorize storage via XCM Transact,
+	// similar to the People chain.
+	let people_next_location = Location::new(1, [Parachain(5140)]);
+
+	let account = Sr25519Keyring::Ferdie;
+	let authorize_call = RuntimeCall::TransactionStorage(pallet_transaction_storage::Call::<
+		Runtime,
+	>::authorize_account {
+		who: account.to_account_id(),
+		transactions: 16,
+		bytes: 1024,
+	});
+
+	ExtBuilder::<Runtime>::default()
+		.with_collators(vec![AccountId::from(ALICE)])
+		.with_session_keys(vec![(
+			AccountId::from(ALICE),
+			AccountId::from(ALICE),
+			SessionKeys { aura: AuraId::from(sp_core::sr25519::Public::from_raw(ALICE)) },
+		)])
+		.with_tracing()
+		.build()
+		.execute_with(|| {
+			assert_ok!(RuntimeHelper::<Runtime, AllPalletsWithoutSystem>::execute_as_origin(
+				(people_next_location, OriginKind::Xcm),
+				authorize_call,
+				None
+			)
+			.ensure_complete());
+
+			// Check event.
+			System::assert_has_event(RuntimeEvent::TransactionStorage(
+				pallet_transaction_storage::Event::AccountAuthorized {
+					who: account.to_account_id(),
+					transactions: 16,
+					bytes: 1024,
+				},
+			));
+		})
+}
+
 /// See [`pallet_transaction_storage::ensure_weight_sanity`].
 #[test]
 fn transaction_storage_weight_sanity() {


### PR DESCRIPTION
### Changes

  - **`runtimes/bulletin-westend/src/xcm_config.rs`** — Define `PeopleNextLocation` (`Parachain(5140)`) and add to XCM barrier for unpaid execution.
  - **`runtimes/bulletin-westend/src/storage.rs`** — Add `EnsureXcm<Equals<PeopleNextLocation>>` to `Authorizer` via nested `EitherOfDiverse`.
  - **`runtimes/bulletin-westend/tests/tests.rs`** — Add `people_next_chain_can_authorize_storage_with_transact` test.

  ### Test results

  - New test confirmed to fail **before** runtime changes (Barrier error).
  - All 12 tests pass **after** changes, including existing People chain test.
