### PR TITLE
Bump bulletin-westend spec_version to 1_000_007

### DIFF
--- a/runtimes/bulletin-westend/src/lib.rs
+++ b/runtimes/bulletin-westend/src/lib.rs
@@ -179,7 +179,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("bulletin-westend"),
 	impl_name: alloc::borrow::Cow::Borrowed("bulletin-westend"),
 	authoring_version: 1,
-	spec_version: 1_000_006,
+	spec_version: 1_000_007,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Bump spec_version for paseo release v0.0.7