### PR TITLE
Bump bulletin-westend spec_version to 1_000_008

### DIFF
--- a/runtimes/bulletin-westend/src/lib.rs
+++ b/runtimes/bulletin-westend/src/lib.rs
@@ -182,7 +182,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("bulletin-westend"),
 	impl_name: alloc::borrow::Cow::Borrowed("bulletin-westend"),
 	authoring_version: 1,
-	spec_version: 1_000_007,
+	spec_version: 1_000_008,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Bump spec_version from 1_000_007 to 1_000_008 for westend and paseo release.