### PR TITLE
Replace sp_io::trie host functions with sp_trie equivalents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9109,6 +9109,7 @@ dependencies = [
  "polkadot-sdk-frame",
  "scale-info",
  "sp-transaction-storage-proof",
+ "sp-trie",
  "tracing",
  "transaction-storage-primitives",
 ]

--- a/pallets/transaction-storage/Cargo.toml
+++ b/pallets/transaction-storage/Cargo.toml
@@ -22,6 +22,7 @@ transaction-storage-primitives = { workspace = true }
 polkadot-sdk-frame = { workspace = true, default-features = false, features = [
 	"runtime",
 ] }
+sp-trie = { workspace = true, default-features = false }
 sp-transaction-storage-proof = { workspace = true, default-features = false }
 
 [dev-dependencies]
@@ -40,6 +41,7 @@ std = [
 	"polkadot-sdk-frame/std",
 	"scale-info/std",
 	"sp-transaction-storage-proof/std",
+	"sp-trie/std",
 	"tracing/std",
 	"transaction-storage-primitives/std",
 ]

--- a/pallets/transaction-storage/src/lib.rs
+++ b/pallets/transaction-storage/src/lib.rs
@@ -900,7 +900,10 @@ pub mod pallet {
 			let chunks: Vec<_> = data.chunks(CHUNK_SIZE).map(|c| c.to_vec()).collect();
 			let chunk_count = chunks.len() as u32;
 			debug_assert_eq!(chunk_count, num_chunks(data.len() as u32));
-			let root = sp_io::trie::blake2_256_ordered_root(chunks, sp_runtime::StateVersion::V1);
+			let root =
+				<sp_trie::LayoutV1<BlakeTwo256> as sp_trie::TrieConfiguration>::ordered_trie_root(
+					chunks,
+				);
 
 			let extrinsic_index =
 				<frame_system::Pallet<T>>::extrinsic_index().ok_or(Error::<T>::BadContext)?;
@@ -1419,16 +1422,15 @@ pub mod pallet {
 			};
 
 			// Verify the tx chunk proof.
-			ensure!(
-				sp_io::trie::blake2_256_verify_proof(
-					tx_info.chunk_root,
-					&proof.proof,
-					&encode_index(tx_chunk_index),
-					&proof.chunk,
-					sp_runtime::StateVersion::V1,
-				),
+			sp_trie::verify_trie_proof::<sp_trie::LayoutV1<BlakeTwo256>, _, _, _>(
+				&tx_info.chunk_root,
+				&proof.proof,
+				&[(encode_index(tx_chunk_index), Some::<&[u8]>(proof.chunk.as_ref()))],
+			)
+			.map_err(|e| {
+				tracing::error!(target: LOG_TARGET, "Proof verification failed: {e:?}");
 				Error::<T>::InvalidProof
-			);
+			})?;
 
 			Ok(())
 		}


### PR DESCRIPTION
## Summary

- Replace `sp_io::trie::blake2_256_ordered_root` and `sp_io::trie::blake2_256_verify_proof` host function calls in `pallet-transaction-storage` with direct `sp_trie` pure-Rust equivalents
- This makes the runtime compatible with Chopsticks, which doesn't implement `ext_trie_blake2_256_verify_proof_version_2`

Closes #341