### PR TITLE
Stress test: add mixed payload sizes support

### DIFF
--- a/stress-test/README.md
+++ b/stress-test/README.md
@@ -111,7 +111,7 @@ bulletin-stress-test [OPTIONS] <COMMAND>
 
 #### `throughput [block-capacity]`
 
-Measures write throughput by filling blocks with storage transactions across payload sizes from 1KB to 10MB.
+Measures write throughput by filling blocks with storage transactions across payload sizes from 1KB up to **2MB** (maximum per `TransactionStorage::store` for this tooling).
 
 ```bash
 # Run all payload sizes against a local dev node
@@ -121,7 +121,7 @@ Measures write throughput by filling blocks with storage transactions across pay
 ./target/release/bulletin-stress-test throughput --variants "1KB,128KB,1MB"
 ```
 
-Payload sizes tested: 1KB, 4KB, 32KB, 128KB, 512KB, 1MB, 2MB, 4MB, 5MB, 7MB, 7.5MB, 2050KB, 8MB, 10MB.
+Payload sizes tested: 1KB, 4KB, 32KB, 128KB, 512KB, 1MB, 2MB. Use `--variants MIXED` for a weighted random mix over those sizes (see `scenarios/throughput.rs`).
 
 For each size, the tool:
 1. Calculates how many transactions are needed to fill `--target-blocks` steady-state blocks
@@ -130,7 +130,7 @@ For each size, the tool:
 4. Measures avg/peak transactions per block and throughput in bytes/s over steady-state blocks
 5. Drains the transaction pool before proceeding to the next variant
 
-The `--variants` flag accepts a comma-separated list of size labels to run a subset (e.g. `"1KB,128KB,1MB"`).
+The `--variants` flag accepts a comma-separated list of size labels to run a subset (e.g. `"1KB,128KB,1MB"`) or **`MIXED`** for the real-world weighted mix. Global `--mix-seed <u64>` fixes RNG draws for mixed mode.
 
 #### `bitswap [b2]`
 
@@ -268,13 +268,6 @@ All throughput variant tests share a single zombienet network (spawned on first 
 | `test_parachain_throughput_512kb` | 512KB | success |
 | `test_parachain_throughput_1mb` | 1MB | success |
 | `test_parachain_throughput_2mb` | 2MB | success |
-| `test_parachain_throughput_2050kb` | 2050KB | success |
-| `test_parachain_throughput_4mb` | 4MB | rejection (WASM OOM) |
-| `test_parachain_throughput_5mb` | 5MB | rejection |
-| `test_parachain_throughput_7mb` | 7MB | rejection |
-| `test_parachain_throughput_7_5mb` | 7.5MB | rejection |
-| `test_parachain_throughput_8mb` | 8MB | rejection |
-| `test_parachain_throughput_10mb` | 10MB | rejection |
 
 #### Bitswap
 
@@ -286,7 +279,7 @@ All throughput variant tests share a single zombienet network (spawned on first 
 
 The zombienet tests validate results against per-variant expectations tables:
 
-Payload sizes up to 2050KB expected to succeed. 4MB+ may OOM during WASM block import on non-authoring nodes (the WASM freeing-bump allocator has a 16MB heap limit; chunking in `do_store` requires ~2x the payload size in concurrent allocations).
+All listed throughput variants are ≤ 2MB and expected to succeed on the zombienet parachain configuration. If CI flakes on the 2MB case, check WASM heap / PoV limits on full nodes.
 
 ### Network Topology
 

--- a/stress-test/src/chain_info.rs
+++ b/stress-test/src/chain_info.rs
@@ -36,9 +36,9 @@ pub struct EnvironmentInfo {
 impl EnvironmentInfo {
 	/// Query environment info from a live node.
 	pub async fn query(client: &OnlineClient<BulletinConfig>, ws_url: &str) -> Result<Self> {
-		use jsonrpsee::{core::client::ClientT, ws_client::WsClientBuilder};
+		use jsonrpsee::core::client::ClientT;
 
-		let rpc = WsClientBuilder::default().build(ws_url).await?;
+		let rpc = crate::client::ws_client_builder().build(ws_url).await?;
 		let node_name: String = rpc.request("system_name", jsonrpsee::rpc_params![]).await?;
 		let node_version: String = rpc.request("system_version", jsonrpsee::rpc_params![]).await?;
 		let chain_name: String = rpc.request("system_chain", jsonrpsee::rpc_params![]).await?;

--- a/stress-test/src/client.rs
+++ b/stress-test/src/client.rs
@@ -65,19 +65,22 @@ impl Default for BulletinExtrinsicParamsBuilder {
 
 // --- Connection ---
 
-/// 50 MB — enough for 8 MB payloads after hex encoding + JSON-RPC wrapping.
-const MAX_RPC_MESSAGE_SIZE: u32 = 50 * 1024 * 1024;
+/// jsonrpsee defaults to **10 MiB**; large `author_pendingExtrinsics` / submit payloads need more.
+/// Align with the node’s RPC max frame settings if you still hit size errors.
+const MAX_RPC_WS_FRAME: u32 = 50 * 1024 * 1024;
+
+/// WebSocket JSON-RPC client with request/response size limits above the jsonrpsee default (10
+/// MiB).
+pub fn ws_client_builder() -> jsonrpsee::ws_client::WsClientBuilder {
+	jsonrpsee::ws_client::WsClientBuilder::default()
+		.max_request_size(MAX_RPC_WS_FRAME)
+		.max_response_size(MAX_RPC_WS_FRAME)
+}
 
 pub async fn connect(ws_url: &str) -> Result<OnlineClient<BulletinConfig>> {
 	log::info!("Connecting to {ws_url}");
 
-	// Build a WS client with larger message size limits (default is 10 MB,
-	// which is too small for 8 MB payloads after hex encoding).
-	let rpc_client = jsonrpsee::ws_client::WsClientBuilder::default()
-		.max_request_size(MAX_RPC_MESSAGE_SIZE)
-		.max_response_size(MAX_RPC_MESSAGE_SIZE)
-		.build(ws_url)
-		.await?;
+	let rpc_client = ws_client_builder().build(ws_url).await?;
 
 	let client = OnlineClient::<BulletinConfig>::from_rpc_client(rpc_client).await?;
 	log::info!("Connected successfully");
@@ -87,9 +90,9 @@ pub async fn connect(ws_url: &str) -> Result<OnlineClient<BulletinConfig>> {
 /// Discover the node's P2P listen addresses and peer ID via a separate RPC call.
 /// Returns (peer_id, listen_addresses).
 pub async fn discover_p2p_info(ws_url: &str) -> Result<(String, Vec<String>)> {
-	use jsonrpsee::{core::client::ClientT, ws_client::WsClientBuilder};
+	use jsonrpsee::core::client::ClientT;
 
-	let client = WsClientBuilder::default().build(ws_url).await?;
+	let client = ws_client_builder().build(ws_url).await?;
 
 	let peer_id: String = client.request("system_localPeerId", jsonrpsee::rpc_params![]).await?;
 
@@ -101,9 +104,9 @@ pub async fn discover_p2p_info(ws_url: &str) -> Result<(String, Vec<String>)> {
 
 /// Ready + future transaction count from the node (lightweight `txpool_status` when available).
 pub async fn fetch_txpool_pending_total(ws_url: &str) -> Result<usize> {
-	use jsonrpsee::{core::client::ClientT, rpc_params, ws_client::WsClientBuilder};
+	use jsonrpsee::{core::client::ClientT, rpc_params};
 
-	let client = WsClientBuilder::default().build(ws_url).await?;
+	let client = ws_client_builder().build(ws_url).await?;
 
 	if let Ok(v) = client.request::<serde_json::Value, _>("txpool_status", rpc_params![]).await {
 		let n = match &v {

--- a/stress-test/src/main.rs
+++ b/stress-test/src/main.rs
@@ -47,6 +47,11 @@ struct Cli {
 	#[arg(long, default_value = "20", global = true)]
 	iteration_blocks: u32,
 
+	/// Block-capacity `--variants mixed` only: seed for random payload-size draws (reproducible
+	/// runs)
+	#[arg(long, global = true)]
+	mix_seed: Option<u64>,
+
 	/// Output format
 	#[arg(long, default_value = "text", global = true)]
 	output: OutputFormat,
@@ -70,8 +75,8 @@ enum Commands {
 		#[arg(default_value = "block-capacity")]
 		test: String,
 
-		/// Comma-separated payload size labels (e.g. "1KB,128KB,1MB").
-		/// Omit to run all.
+		/// Comma-separated payload size labels (e.g. "1KB,128KB,1MB") or **MIXED** for a weighted
+		/// real-world size mix. Omit to run all fixed sizes (no mixed).
 		#[arg(long)]
 		variants: Option<String>,
 	},
@@ -290,6 +295,7 @@ async fn run_throughput(
 				cli.target_blocks,
 				cli.iteration_blocks,
 				variants,
+				cli.mix_seed,
 				results,
 				on_result,
 			)

--- a/stress-test/src/pipeline.rs
+++ b/stress-test/src/pipeline.rs
@@ -12,6 +12,7 @@
 
 use anyhow::Result;
 use futures::future::{join_all, try_join_all};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{
 	collections::HashMap,
 	sync::{
@@ -48,6 +49,119 @@ pub const WORK_CHANNEL_CAPACITY: usize = 1000;
 
 /// Concurrent `sign_store_extrinsic` calls per wave in [`generate_block_capacity_work`].
 pub const STORE_SIGN_PARALLELISM: usize = 16;
+
+/// Weighted mix of store payload sizes (integer weights; any positive scale).
+///
+/// Used by [`StorePayloadMode::Mixed`] so each signed store draws a size from a distribution.
+#[derive(Clone, Debug)]
+pub struct PayloadSizeMix {
+	sizes: Vec<usize>,
+	weights: Vec<u32>,
+	total: u32,
+}
+
+impl PayloadSizeMix {
+	/// Build from `(payload_bytes, weight)` pairs. Entries with weight `0` are skipped.
+	pub fn from_weighted_sizes(pairs: &[(usize, u32)]) -> anyhow::Result<Self> {
+		if pairs.is_empty() {
+			anyhow::bail!("PayloadSizeMix: need at least one (size, weight)");
+		}
+		let mut sizes = Vec::with_capacity(pairs.len());
+		let mut weights = Vec::with_capacity(pairs.len());
+		let mut total = 0u32;
+		for &(sz, w) in pairs {
+			if w == 0 {
+				continue;
+			}
+			sizes.push(sz);
+			weights.push(w);
+			total = total.saturating_add(w);
+		}
+		if total == 0 {
+			anyhow::bail!("PayloadSizeMix: all weights zero");
+		}
+		Ok(Self { sizes, weights, total })
+	}
+
+	#[must_use]
+	pub fn max_payload_bytes(&self) -> usize {
+		*self.sizes.iter().max().unwrap_or(&0)
+	}
+
+	/// Expected payload size (for capacity estimates and monitor byte stats).
+	#[must_use]
+	pub fn mean_payload_bytes(&self) -> f64 {
+		let sum: f64 = self
+			.sizes
+			.iter()
+			.zip(self.weights.iter())
+			.map(|(&s, &w)| s as f64 * f64::from(w))
+			.sum();
+		sum / f64::from(self.total)
+	}
+
+	/// Weighted mean of per-size estimated txs/block (used to size mixed-mode account counts).
+	#[must_use]
+	pub fn weighted_mean_est_block_cap(
+		&self,
+		block_usable_bytes: usize,
+		extrinsic_overhead: usize,
+		max_block_txs: usize,
+	) -> usize {
+		let total_w = u64::from(self.total);
+		let sum_caps: f64 = self
+			.sizes
+			.iter()
+			.zip(self.weights.iter())
+			.map(|(&sz, &w)| {
+				let cap =
+					(block_usable_bytes / (sz + extrinsic_overhead).max(1)).min(max_block_txs);
+				cap as f64 * f64::from(w)
+			})
+			.sum();
+		(sum_caps / total_w as f64).floor().max(1.0) as usize
+	}
+
+	pub fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
+		let mut r = rng.gen_range(0..self.total);
+		for i in 0..self.sizes.len() {
+			let w = self.weights[i];
+			if r < w {
+				return self.sizes[i];
+			}
+			r -= w;
+		}
+		*self.sizes.last().expect("non-empty")
+	}
+}
+
+/// How [`generate_store_work_for_keypairs`] chooses per-account payload sizes.
+#[derive(Clone, Debug)]
+pub enum StorePayloadMode {
+	Fixed(usize),
+	Mixed(PayloadSizeMix),
+}
+
+impl StorePayloadMode {
+	#[must_use]
+	pub fn authorize_bytes_per_account(&self) -> u64 {
+		let max_payload = match self {
+			Self::Fixed(n) => *n,
+			Self::Mixed(m) => m.max_payload_bytes(),
+		};
+		(max_payload.saturating_add(1024)) as u64
+	}
+
+	/// Bytes assumed per store tx in block monitor [`BlockStats::payload_bytes`] (approximate for
+	/// mixed).
+	#[must_use]
+	pub fn monitor_payload_bytes_per_tx(&self) -> u64 {
+		match self {
+			Self::Fixed(n) => *n as u64,
+			Self::Mixed(m) => m.mean_payload_bytes().round().max(1.0) as u64,
+		}
+	}
+}
 
 /// Max ready+future tx pool depth before [`wait_until_txpool_can_pull_work`] returns; also how many
 /// **store work items dispatched** to per-worker channels before the reader calls that check
@@ -167,7 +281,7 @@ async fn wait_until_txpool_can_pull_work(ws_url: &str) {
 #[allow(clippy::too_many_arguments)]
 fn spawn_pipeline_dual_monitor(
 	dual: DualBlockSubscription,
-	payload_size: usize,
+	monitor_payload_bytes_per_tx: u64,
 	fork_detections: Arc<AtomicU64>,
 	new_block_notify: Arc<Notify>,
 	block_stats: Arc<Mutex<Vec<BlockStats>>>,
@@ -235,7 +349,7 @@ fn spawn_pipeline_dual_monitor(
 						number: block_number,
 						hash: block_hash,
 						tx_count: total_store_extrinsics,
-						payload_bytes: total_store_extrinsics * payload_size as u64,
+						payload_bytes: total_store_extrinsics.saturating_mul(monitor_payload_bytes_per_tx),
 						timestamp_ms,
 						prefill: false,
 					});
@@ -547,11 +661,13 @@ pub async fn run_block_capacity_pipeline(
 	dual: DualBlockSubscription,
 	ws_urls: &[&str],
 	submitters: usize,
-	payload_size: usize,
+	store_payload: StorePayloadMode,
 	client: &OnlineClient<BulletinConfig>,
 	authorizer: &Keypair,
 	authorizer_nonce_tracker: &NonceTracker,
 ) -> Result<BulkStoreResult> {
+	let monitor_payload_bytes_per_tx = store_payload.monitor_payload_bytes_per_tx();
+	let authorize_payload_bytes = store_payload.authorize_bytes_per_account();
 	const TX_TIMEOUT_SECS: u64 = 60;
 
 	let fork_detections = Arc::new(AtomicU64::new(0));
@@ -562,7 +678,7 @@ pub async fn run_block_capacity_pipeline(
 
 	let monitor_handle = spawn_pipeline_dual_monitor(
 		dual,
-		payload_size,
+		monitor_payload_bytes_per_tx,
 		fork_detections.clone(),
 		new_block_notify.clone(),
 		block_stats.clone(),
@@ -637,7 +753,7 @@ pub async fn run_block_capacity_pipeline(
 						authorizer_nonce_tracker,
 						&account_ids,
 						1,
-						(payload_size + 1024) as u64,
+						authorize_payload_bytes,
 					)
 					.await?;
 				}
@@ -757,13 +873,27 @@ async fn generate_store_work_for_keypairs(
 	work_tx: &mpsc::Sender<StressWorkItem>,
 	client: Arc<OnlineClient<BulletinConfig>>,
 	keypairs: Vec<Keypair>,
-	payload_size: usize,
+	mode: &StorePayloadMode,
+	mix_rng: Option<Arc<Mutex<StdRng>>>,
 ) -> Result<()> {
 	for chunk in keypairs.chunks(STORE_SIGN_PARALLELISM) {
 		let signed = try_join_all(chunk.iter().map(|kp| {
 			let kp = kp.clone();
 			let client = client.clone();
+			let mix_rng = mix_rng.clone();
+			let mode = mode.clone();
 			async move {
+				let payload_size = match &mode {
+					StorePayloadMode::Fixed(n) => *n,
+					StorePayloadMode::Mixed(mix) => {
+						let mut g = mix_rng
+							.as_ref()
+							.ok_or_else(|| anyhow::anyhow!("pipeline: mixed mode requires RNG"))?
+							.lock()
+							.unwrap();
+						mix.sample(&mut *g)
+					},
+				};
 				let payload = tokio::task::spawn_blocking(move || {
 					crate::store::generate_payload(payload_size)
 				})
@@ -794,15 +924,27 @@ async fn generate_store_work_for_keypairs(
 /// then one signed [`StressWorkItem::Store`] per account (nonce 0). Signing runs in waves of
 /// [`STORE_SIGN_PARALLELISM`] (parallel per wave), with [`tokio::task::spawn_blocking`] for
 /// payloads.
+///
+/// For [`StorePayloadMode::Mixed`], `mix_seed` fixes the RNG (`StdRng::seed_from_u64`); if `None`,
+/// uses a fresh `StdRng::from_entropy()` for this run.
 pub async fn generate_block_capacity_work(
 	work_tx: mpsc::Sender<StressWorkItem>,
 	plans: &[IterationPlan],
-	payload_size: usize,
+	store_payload: StorePayloadMode,
+	mix_seed: Option<u64>,
 	client: Arc<OnlineClient<BulletinConfig>>,
 ) -> Result<()> {
 	if plans.is_empty() || plans.iter().all(|p| p.account_count == 0) {
 		return Ok(());
 	}
+
+	let mix_rng = match &store_payload {
+		StorePayloadMode::Mixed(_) => Some(Arc::new(Mutex::new(match mix_seed {
+			Some(s) => StdRng::seed_from_u64(s),
+			None => StdRng::from_entropy(),
+		}))),
+		StorePayloadMode::Fixed(_) => None,
+	};
 
 	for i in 0..plans.len() {
 		if plans[i].account_count == 0 {
@@ -832,8 +974,14 @@ pub async fn generate_block_capacity_work(
 				.await
 				.map_err(|_| anyhow::anyhow!("pipeline work channel closed (authorize+init)"))?;
 
-			generate_store_work_for_keypairs(&work_tx, client.clone(), keypairs, payload_size)
-				.await?;
+			generate_store_work_for_keypairs(
+				&work_tx,
+				client.clone(),
+				keypairs,
+				&store_payload,
+				mix_rng.clone(),
+			)
+			.await?;
 
 			batch_start = batch_end;
 		}

--- a/stress-test/src/scenarios/throughput.rs
+++ b/stress-test/src/scenarios/throughput.rs
@@ -6,10 +6,107 @@ use crate::{
 	accounts::NonceTracker,
 	chain_info::ChainLimits,
 	client::BulletinConfig,
-	pipeline::{self, IterationPlan, StressWorkItem},
+	pipeline::{self, IterationPlan, PayloadSizeMix, StorePayloadMode, StressWorkItem},
 	report::{ScenarioResult, SubmissionStats},
 	store,
 };
+
+/// Maximum raw store payload size for stress-test variants (matches chain / runtime limit, ~2 MiB).
+pub const MAX_STORE_PAYLOAD_BYTES: usize = 2 * 1024 * 1024;
+
+/// Canonical payload table for fixed variants and for **`MIXED`** weights (subset of labels).
+/// Every `usize` is ≤ [`MAX_STORE_PAYLOAD_BYTES`].
+const ALL_PAYLOAD_SIZES: &[(usize, &str)] = &[
+	(1024, "1KB"),
+	(4096, "4KB"),
+	(32 * 1024, "32KB"),
+	(128 * 1024, "128KB"),
+	(512 * 1024, "512KB"),
+	(1024 * 1024, "1MB"),
+	(MAX_STORE_PAYLOAD_BYTES, "2MB"),
+];
+
+/// Weighted mix for **`MIXED`**: labels must exist in [`ALL_PAYLOAD_SIZES`] (same strings as
+/// `--variants`). Weights sum to 1000 (~basis points).
+const REAL_WORLD_MIX_LABEL_WEIGHTS: &[(&str, u32)] = &[
+	("1KB", 230),
+	("4KB", 150),
+	("32KB", 120),
+	("128KB", 175),
+	("512KB", 155),
+	("1MB", 90),
+	("2MB", 80),
+];
+
+fn real_world_payload_mix() -> anyhow::Result<PayloadSizeMix> {
+	let pairs: Vec<(usize, u32)> = REAL_WORLD_MIX_LABEL_WEIGHTS
+		.iter()
+		.map(|&(label, w)| {
+			let size =
+				ALL_PAYLOAD_SIZES
+					.iter()
+					.find(|(_, l)| *l == label)
+					.map(|(s, _)| *s)
+					.ok_or_else(|| {
+						anyhow::anyhow!("REAL_WORLD_MIX_LABEL_WEIGHTS: label {label:?} not in ALL_PAYLOAD_SIZES")
+					})?;
+			Ok((size, w))
+		})
+		.collect::<anyhow::Result<_>>()?;
+	PayloadSizeMix::from_weighted_sizes(&pairs)
+}
+
+enum BlockCapacitySweepStep {
+	Fixed { size: usize, label: &'static str },
+	Mixed { mix: PayloadSizeMix },
+}
+
+fn build_sweep_steps(variant_filter: Option<&str>) -> anyhow::Result<Vec<BlockCapacitySweepStep>> {
+	match variant_filter {
+		None => Ok(ALL_PAYLOAD_SIZES
+			.iter()
+			.map(|&(size, label)| BlockCapacitySweepStep::Fixed { size, label })
+			.collect()),
+		Some(f) => {
+			let tokens: Vec<String> = f
+				.split(',')
+				.map(|s| s.trim().to_uppercase())
+				.filter(|s| !s.is_empty())
+				.collect();
+			if tokens.is_empty() {
+				anyhow::bail!("Empty --variants string");
+			}
+			let mix = if tokens.iter().any(|t| t == "MIXED") {
+				Some(real_world_payload_mix()?)
+			} else {
+				None
+			};
+			let mut steps = Vec::with_capacity(tokens.len());
+			for t in tokens {
+				if t == "MIXED" {
+					// `mix` is `Some` because we built it when `tokens` contained `MIXED`.
+					steps.push(BlockCapacitySweepStep::Mixed { mix: mix.clone().unwrap() });
+					continue;
+				}
+				let found =
+					ALL_PAYLOAD_SIZES.iter().find(|(_, label)| label.to_uppercase() == t).copied();
+				match found {
+					Some((size, label)) =>
+						steps.push(BlockCapacitySweepStep::Fixed { size, label }),
+					None => {
+						let available: Vec<&str> =
+							ALL_PAYLOAD_SIZES.iter().map(|(_, l)| *l).collect();
+						anyhow::bail!(
+							"Unknown variant {t:?}. Use a label from the table or MIXED. Available: {}, MIXED",
+							available.join(", ")
+						);
+					},
+				}
+			}
+			Ok(steps)
+		},
+	}
+}
 
 fn scenario_result_from_bulk(
 	result: &store::BulkStoreResult,
@@ -114,8 +211,8 @@ fn scenario_result_from_bulk(
 
 /// Block capacity measurement across multiple payload sizes.
 ///
-/// For each payload size, splits one-shot accounts into iterations (~`iteration_blocks` measured
-/// blocks worth of txs per iteration), then runs the producer/consumer pipeline:
+/// For each step (fixed size or **`MIXED`**), splits one-shot accounts into iterations
+/// (~`iteration_blocks` measured blocks worth of txs per iteration), then runs the pipeline:
 /// [`StressWorkItem`]s on a bounded channel; the consumer waits on `txpool_status` before further
 /// `recv`s when the pool is deep, so the generator blocks on `send`. Drains the pool between
 /// variants.
@@ -130,6 +227,7 @@ pub async fn run_block_capacity_sweep(
 	target_blocks: u32,
 	iteration_blocks: u32,
 	variant_filter: Option<&str>,
+	mix_seed: Option<u64>,
 	results: &mut Vec<ScenarioResult>,
 	on_result: &dyn Fn(&mut Vec<ScenarioResult>),
 ) -> Result<()> {
@@ -138,58 +236,65 @@ pub async fn run_block_capacity_sweep(
 	let extrinsic_overhead = chain_limits.extrinsic_length_overhead as usize;
 	let max_block_txs = chain_limits.max_block_transactions as usize;
 
-	let all_payload_sizes: &[(usize, &str)] = &[
-		(1024, "1KB"),
-		(4096, "4KB"),
-		(32 * 1024, "32KB"),
-		(128 * 1024, "128KB"),
-		(512 * 1024, "512KB"),
-		(1024 * 1024, "1MB"),
-		(2 * 1024 * 1024, "2MB"),
-		(4 * 1024 * 1024, "4MB"),
-		(5 * 1024 * 1024, "5MB"),
-		(7 * 1024 * 1024, "7MB"),
-		(7 * 1024 * 1024 + 512 * 1024, "7.5MB"),
-		(2050 * 1024, "2050KB"),
-		(8 * 1024 * 1024, "8MB"),
-		(10 * 1024 * 1024, "10MB"),
-	];
+	let sweep_steps = build_sweep_steps(variant_filter)?;
 
-	// Filter variants if --variants was specified.
-	let filter_set: Option<Vec<String>> = variant_filter.map(|f| {
-		f.split(',')
-			.map(|s| s.trim().to_uppercase())
-			.filter(|s| !s.is_empty())
-			.collect()
-	});
-	let payload_sizes: Vec<(usize, &str)> = all_payload_sizes
+	let step_labels: Vec<String> = sweep_steps
 		.iter()
-		.filter(|(_, label)| {
-			filter_set
-				.as_ref()
-				.is_none_or(|set| set.iter().any(|f| f == &label.to_uppercase()))
+		.map(|s| match s {
+			BlockCapacitySweepStep::Fixed { label, .. } => (*label).to_string(),
+			BlockCapacitySweepStep::Mixed { .. } => "mixed".to_string(),
 		})
-		.copied()
 		.collect();
+	log::info!("Running {} block-capacity step(s): {}", sweep_steps.len(), step_labels.join(", "));
 
-	if payload_sizes.is_empty() {
-		let available: Vec<&str> = all_payload_sizes.iter().map(|(_, l)| *l).collect();
-		anyhow::bail!(
-			"No matching variants for filter {:?}. Available: {}",
-			variant_filter.unwrap_or(""),
-			available.join(", ")
-		);
-	}
+	for step in &sweep_steps {
+		let (
+			label,
+			payload_size_report,
+			est_block_cap,
+			store_payload,
+			est_pool_bytes_per_account,
+			largest_payload_in_step,
+		) = match step {
+			BlockCapacitySweepStep::Fixed { size, label } => {
+				let cap =
+					(block_usable_bytes / (*size + extrinsic_overhead).max(1)).min(max_block_txs);
+				(
+					*label,
+					*size,
+					cap,
+					StorePayloadMode::Fixed(*size),
+					*size + extrinsic_overhead,
+					*size,
+				)
+			},
+			BlockCapacitySweepStep::Mixed { mix } => {
+				let cap = mix.weighted_mean_est_block_cap(
+					block_usable_bytes,
+					extrinsic_overhead,
+					max_block_txs,
+				);
+				let mean = mix.mean_payload_bytes().round().max(1.0) as usize;
+				let max_b = mix.max_payload_bytes();
+				let seed_note = match mix_seed {
+					Some(s) => format!("--mix-seed {s}"),
+					None => "OS entropy (use --mix-seed to reproduce)".to_string(),
+				};
+				log::info!(
+					"mixed: weighted payload mix — mean ≈ {mean} B, max ≈ {max_b} B, est ~{cap} txs/block; \
+					 draws: {seed_note}",
+				);
+				(
+					"mixed",
+					mean,
+					cap,
+					StorePayloadMode::Mixed(mix.clone()),
+					mean + extrinsic_overhead,
+					max_b,
+				)
+			},
+		};
 
-	log::info!(
-		"Running {} variant(s): {}",
-		payload_sizes.len(),
-		payload_sizes.iter().map(|(_, l)| *l).collect::<Vec<_>>().join(", ")
-	);
-
-	for &(payload_size, label) in &payload_sizes {
-		let est_block_cap =
-			(block_usable_bytes / (payload_size + extrinsic_overhead)).min(max_block_txs);
 		// One-shot accounts: one account per transaction needed.
 		// Need enough to fill all target blocks (plus ramp-up/down) plus a
 		// backpressure buffer so the pool stays saturated while blocks drain.
@@ -199,8 +304,7 @@ pub async fn run_block_capacity_sweep(
 		let total_block_slots = (target_blocks + 2) as usize * est_block_cap;
 		let backpressure_buffer = est_block_cap * 3;
 		let accounts_needed = ((total_block_slots + backpressure_buffer) * 3 / 2).max(1) as u32;
-		let est_pool_mb =
-			(accounts_needed as usize * (payload_size + extrinsic_overhead)) / (1024 * 1024);
+		let est_pool_mb = (accounts_needed as usize * est_pool_bytes_per_account) / (1024 * 1024);
 		let accounts_per_iter =
 			pipeline::block_capacity_accounts_per_iteration(est_block_cap, iteration_blocks);
 		let n_iterations = accounts_needed.div_ceil(accounts_per_iter);
@@ -227,11 +331,18 @@ pub async fn run_block_capacity_sweep(
 				tokio::sync::mpsc::channel::<StressWorkItem>(pipeline::WORK_CHANNEL_CAPACITY);
 
 			let gen_plans = plans.clone();
-			let gen_payload = payload_size;
+			let gen_store = store_payload.clone();
+			let gen_mix_seed = mix_seed;
 			let gen_client = std::sync::Arc::new(client.clone());
 			let generator = tokio::spawn(async move {
-				pipeline::generate_block_capacity_work(work_tx, &gen_plans, gen_payload, gen_client)
-					.await
+				pipeline::generate_block_capacity_work(
+					work_tx,
+					&gen_plans,
+					gen_store,
+					gen_mix_seed,
+					gen_client,
+				)
+				.await
 			});
 
 			let pipeline_out = pipeline::run_block_capacity_pipeline(
@@ -239,7 +350,7 @@ pub async fn run_block_capacity_sweep(
 				dual,
 				ws_urls,
 				submitters,
-				payload_size,
+				store_payload.clone(),
 				client,
 				authorizer_signer,
 				nonce_tracker,
@@ -266,12 +377,12 @@ pub async fn run_block_capacity_sweep(
 			let result = scenario_result_from_bulk(
 				&bulk,
 				total_accounts as usize,
-				payload_size,
+				payload_size_report,
 				label,
 				chain_limits,
 			);
 
-			if payload_size >= 4 * 1024 * 1024 && result.total_confirmed == 0 {
+			if largest_payload_in_step >= MAX_STORE_PAYLOAD_BYTES && result.total_confirmed == 0 {
 				log::warn!(
 					"{label}: 0 txs confirmed (may be expected due to WASM heap limits) - \
 					 including result"
@@ -295,7 +406,7 @@ pub async fn run_block_capacity_sweep(
 					total_submitted: 0,
 					total_confirmed: 0,
 					total_errors: 0,
-					payload_size,
+					payload_size: payload_size_report,
 					throughput_tps: 0.0,
 					throughput_bytes_per_sec: 0.0,
 					avg_tx_per_block: 0.0,
@@ -303,7 +414,7 @@ pub async fn run_block_capacity_sweep(
 					inclusion_latency: None,
 					finalization_latency: None,
 					retrieval_latency: None,
-					theoretical: Some(chain_limits.compute_theoretical_limits(payload_size)),
+					theoretical: Some(chain_limits.compute_theoretical_limits(payload_size_report)),
 					chain_limits: None,
 					environment: None,
 					blocks: vec![],

--- a/stress-test/tests/zombienet.rs
+++ b/stress-test/tests/zombienet.rs
@@ -118,13 +118,6 @@ throughput_variant_test!(test_parachain_throughput_128kb, "128KB", 3);
 throughput_variant_test!(test_parachain_throughput_512kb, "512KB", 4);
 throughput_variant_test!(test_parachain_throughput_1mb, "1MB", 5);
 throughput_variant_test!(test_parachain_throughput_2mb, "2MB", 6);
-throughput_variant_test!(test_parachain_throughput_2050kb, "2050KB", 7);
-throughput_variant_test!(test_parachain_throughput_4mb, "4MB", 8);
-throughput_variant_test!(test_parachain_throughput_5mb, "5MB", 9);
-throughput_variant_test!(test_parachain_throughput_7mb, "7MB", 10);
-throughput_variant_test!(test_parachain_throughput_7_5mb, "7.5MB", 11);
-throughput_variant_test!(test_parachain_throughput_8mb, "8MB", 12);
-throughput_variant_test!(test_parachain_throughput_10mb, "10MB", 13);
 
 // ============================================================================
 // Bitswap read tests (B2: concurrent multi-client)

--- a/stress-test/tests/zombienet_common/expectations/parachain.rs
+++ b/stress-test/tests/zombienet_common/expectations/parachain.rs
@@ -2,15 +2,14 @@ use super::Expectation;
 
 // Parachain expected results for block capacity test.
 //
-// These sizes MUST match the array in `scenarios/throughput.rs::run_block_capacity_sweep`.
+// These sizes MUST match `ALL_PAYLOAD_SIZES` in `scenarios/throughput.rs`.
 // To update, run the test with `--nocapture` and look at the PASS/FAIL log lines
 // which print actual avg and peak values.
 //
 // Notes:
-//   - 2050KB is near the single-tx WASM boundary (~2MB safe on parachain)
-//   - 4MB+ OOMs during block import on non-authoring nodes (WASM freeing-bump allocator 16MB heap;
-//     chunking in do_store requires ~2x payload size)
-//   - 8MB+ exceeds MaxTransactionSize or OOMs at validate_transaction
+//   - Throughput variants are capped at **2 MiB** per store (`MAX_STORE_PAYLOAD_BYTES`).
+//   - Largest variant (2MB) may still hit WASM heap / PoV limits on some nodes; expectations remain
+//     optimistic for zombienet parachain CI.
 pub const EXPECTATIONS: &[Expectation] = &[
 	Expectation { payload_size: 1024, label: "1KB", expected: Some((1.0, 1)) },
 	Expectation { payload_size: 4096, label: "4KB", expected: Some((1.0, 1)) },
@@ -19,11 +18,4 @@ pub const EXPECTATIONS: &[Expectation] = &[
 	Expectation { payload_size: 512 * 1024, label: "512KB", expected: Some((1.0, 1)) },
 	Expectation { payload_size: 1024 * 1024, label: "1MB", expected: Some((1.0, 1)) },
 	Expectation { payload_size: 2 * 1024 * 1024, label: "2MB", expected: Some((1.0, 1)) },
-	Expectation { payload_size: 2050 * 1024, label: "2050KB", expected: Some((1.0, 1)) },
-	Expectation { payload_size: 4 * 1024 * 1024, label: "4MB", expected: None },
-	Expectation { payload_size: 5 * 1024 * 1024, label: "5MB", expected: None },
-	Expectation { payload_size: 7 * 1024 * 1024, label: "7MB", expected: None },
-	Expectation { payload_size: 7 * 1024 * 1024 + 512 * 1024, label: "7.5MB", expected: None },
-	Expectation { payload_size: 8 * 1024 * 1024, label: "8MB", expected: None },
-	Expectation { payload_size: 10 * 1024 * 1024, label: "10MB", expected: None },
 ];


### PR DESCRIPTION
`cargo run --release -p bulletin-stress-test -- --ws-url wss://bc-3000-rpc-node-3.parity-versi.parity.io,wss://bc-3000-rpc-node-2.parity-versi.parity.io,wss://bc-3000-rpc-node-1.parity-versi.parity.io,wss://bc-3000-rpc-node-0.parity-versi.parity.io --submitters 16 --output-file versi-results.json  throughput --variants MIXED --target-blocks 100 `