### PR TITLE
Bump node to 22

### DIFF
--- a/.github/workflows/check-console-ui.yml
+++ b/.github/workflows/check-console-ui.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    # TODO: remove before merging to main
-    branches: [ main, naren-client, bko-on-naren-client ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -24,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: console-ui/package-lock.json
 

--- a/.github/workflows/check-sdk.yml
+++ b/.github/workflows/check-sdk.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    # TODO: remove before merging to main
-    branches: [main, naren-client, bko-on-naren-client]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -66,7 +65,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: sdk/typescript/package-lock.json
 

--- a/.github/workflows/deploy-console-ui.yml
+++ b/.github/workflows/deploy-console-ui.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: console-ui/package-lock.json
 

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Validate version matches tag
         working-directory: sdk/typescript

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "22"
+          node-version: 22
 
       - name: Validate version matches tag
         working-directory: sdk/typescript

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -70,6 +70,6 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
- closes https://github.com/paritytech/polkadot-bulletin-chain/issues/399
- bumps node to 22 from 20
- `branches: [ main, naren-client, bko-on-naren-client ] ` -> `branches: [ main ]` - just noticed we were supposed to remove this
