### PR TITLE
Fix flaky SDK integration tests

### DIFF
--- a/sdk/typescript/test/integration/client.test.ts
+++ b/sdk/typescript/test/integration/client.test.ts
@@ -54,10 +54,11 @@ describe("AsyncBulletinClient Integration Tests", { timeout: 120_000 }, () => {
     aliceAddress = ss58Address(aliceKeyPair.publicKey, 42)
 
     // Create client directly with api, signer, and submit function
-    // Use a per-transaction timeout suitable for a local dev chain (~6s blocks).
-    // The default 420s is for production; 60s is plenty for CI zombienet nodes.
+    // Per-tx timeout for CI zombienet nodes. 60s was too aggressive —
+    // finalization regularly takes >60s under CI load, causing flaky
+    // "Transaction timed out" failures on chunked store tests.
     client = new AsyncBulletinClient(api, signer, papiClient.submit, {
-      txTimeout: 60_000,
+      txTimeout: 120_000,
     })
 
     // Authorize Alice's account for storage operations


### PR DESCRIPTION
## Summary
- Root cause: `txTimeout: 60_000` set in #389 is too aggressive for CI zombienet nodes
- Finalization regularly exceeds 60s under CI load, causing consistent ~66s failures (first chunk ~6s + second chunk hitting the 60s per-tx timeout)
- Affects all branches — seen on `main`, `ak-construct-runtime`, `rust-sdk-wait-for-block-inclusion`, `sandreim/stress-image`
- Both "should fire chunk events sequentially" and "should store chunked data with progress tracking" are affected
- Fix: increase `txTimeout` from 60s to 120s — gives 2x headroom while staying well under the production default (420s)