### PR TITLE
[CI] Separate Paseo & Westend runtime releases via tag suffix

### DIFF
--- a/.claude/skills/release/skill.md
+++ b/.claude/skills/release/skill.md
@@ -13,34 +13,36 @@ Guide the user through runtime releases. Reference `docs/playbook.md` for full d
 /release <network>
 ```
 
-**Networks**: `westend`, `paseo`, `pop`, `polkadot`
+**Networks**: `westend`, `paseo`
+
+Each runtime is released independently — one tag triggers one runtime build.
 
 ## Steps
 
 1. **Pre-checks** (optional): `cargo test && cargo clippy --all-targets --all-features --workspace -- -D warnings`
 
 2. **Bump spec_version** in the appropriate runtime file:
-   - westend/paseo/pop: `runtimes/bulletin-westend/src/lib.rs`
-   - polkadot: `runtimes/bulletin-polkadot/src/lib.rs`
+   - westend: `runtimes/bulletin-westend/src/lib.rs`
+   - paseo: `runtimes/bulletin-paseo/src/lib.rs`
 
 3. **Create a PR** with the version bump:
    ```bash
-   git checkout -b bump-<runtime>-spec-version-<VERSION> origin/main
+   git checkout -b bump-<network>-spec-version-<VERSION> origin/main
    git add runtimes/
-   git commit -m "Bump <runtime> spec_version to <VERSION>"
-   git push -u origin bump-<runtime>-spec-version-<VERSION>
-   gh pr create --title "Bump <runtime> spec_version to <VERSION>"
+   git commit -m "Bump <network> spec_version to <VERSION>"
+   git push -u origin bump-<network>-spec-version-<VERSION>
+   gh pr create --title "Bump <network> spec_version to <VERSION>"
    ```
 
-4. **Merge the PR** and **tag the release** on main — `v0.0.X` for testnets, `v1.x.y` for production (see Versioning below):
+4. **Merge the PR** and **tag the release** on main. Tag must end in `-westend` or `-paseo` — the suffix tells CI which runtime to build:
    ```bash
    gh pr merge <PR_NUMBER> --squash
    git checkout main && git pull
-   git tag -a v<VERSION> -m "Release v<VERSION>"
-   git push origin --tags
+   git tag -a v<VERSION>-<network> -m "Release v<VERSION>-<network>"
+   git push origin v<VERSION>-<network>
    ```
 
-5. **Download WASM**: The [Release CI](https://github.com/paritytech/polkadot-bulletin-chain/actions/workflows/release.yml) builds the WASM artifact. **Note:** CI takes a long time (15-30+ minutes). Do NOT poll or check CI status repeatedly — tell the user you are waiting and ask them to notify you when the release is ready. Once notified, download with: `gh release download <TAG> -p "*.wasm" -D .`
+5. **Download WASM**: The [Release CI](https://github.com/paritytech/polkadot-bulletin-chain/actions/workflows/release.yml) builds the WASM artifact for the runtime matching the tag suffix. **Note:** CI takes a long time (15-30+ minutes). Do NOT poll or check CI status repeatedly — tell the user you are waiting and ask them to notify you when the release is ready. Once notified, download with: `gh release download <TAG> -p "*.wasm" -D .`
 
 6. **Upgrade**: Use the upgrade script in `examples/`:
    ```bash
@@ -59,22 +61,29 @@ Guide the user through runtime releases. Reference `docs/playbook.md` for full d
 node upgrade_runtime.js <seed> <wasm_path> [options]
 
 Options:
-  --network <name>   westend, paseo, pop, polkadot (default: westend)
+  --network <name>   westend, paseo (default: westend)
   --rpc <url>        Custom RPC endpoint
   --verify-only      Only check current version
 ```
 
 ## Versioning Scheme
 
-Two separate version tracks for git tags:
+Each runtime has its own independent tag track, distinguished by suffix:
 
-| Track | Networks | Format | Examples |
-|-------|----------|--------|----------|
-| **Testnet** | westend, paseo | `v0.0.X` | v0.0.4 → v0.0.5 → v0.0.6 |
-| **Production** | polkadot, pop | `v1.x.y` | v1.0.0, v1.0.1, v1.1.0 |
+| Network  | Format             | Examples                                  |
+|----------|--------------------|-------------------------------------------|
+| westend  | `v0.0.X-westend`   | v0.0.10-westend → v0.0.11-westend         |
+| paseo    | `v0.0.X-paseo`     | v0.0.1-paseo → v0.0.2-paseo               |
 
-- Testnet: increment patch only (`v0.0.X` → `v0.0.X+1`)
-- Production: semver — minor for features, patch for fixes
-- Never mix tracks: no `v0.0.X` for production, no `v1.x.y` for testnets
+- Westend and paseo bump independently — bumping westend does not bump paseo.
+- Bare `vX.Y.Z` tags (no suffix) are not picked up by Release CI and will not produce artifacts.
 
-When determining the next version, check `git tag --sort=-v:refname` to find the latest tag in the appropriate track.
+When determining the next version for a network, filter tags by suffix:
+
+```bash
+# next westend version
+git tag --list 'v*-westend' --sort=-v:refname | head -1
+
+# next paseo version
+git tag --list 'v*-paseo' --sort=-v:refname | head -1
+```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,17 @@ jobs:
         run: |
           TAG="${GITHUB_REF_NAME}"
           if [[ "$TAG" == *-westend ]]; then
-            echo "name=bulletin-westend" >> "$GITHUB_OUTPUT"
-            echo "package=bulletin-westend-runtime" >> "$GITHUB_OUTPUT"
-            echo "path=runtimes/bulletin-westend" >> "$GITHUB_OUTPUT"
+            {
+              echo "name=bulletin-westend"
+              echo "package=bulletin-westend-runtime"
+              echo "path=runtimes/bulletin-westend"
+            } >> "$GITHUB_OUTPUT"
           elif [[ "$TAG" == *-paseo ]]; then
-            echo "name=bulletin-paseo" >> "$GITHUB_OUTPUT"
-            echo "package=bulletin-paseo-runtime" >> "$GITHUB_OUTPUT"
-            echo "path=runtimes/bulletin-paseo" >> "$GITHUB_OUTPUT"
+            {
+              echo "name=bulletin-paseo"
+              echo "package=bulletin-paseo-runtime"
+              echo "path=runtimes/bulletin-paseo"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "Tag $TAG does not end in -westend or -paseo" >&2
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,58 +3,70 @@ name: Release
 on:
   push:
     tags:
-      - v[0-9]*
+      - 'v[0-9]*-westend'
+      - 'v[0-9]*-paseo'
 
 permissions: {}
 
 jobs:
-  build-runtimes:
+  build-runtime:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      matrix:
-        include:
-          - name: bulletin-westend
-            package: bulletin-westend-runtime
-            path: runtimes/bulletin-westend
-          - name: bulletin-paseo
-            package: bulletin-paseo-runtime
-            path: runtimes/bulletin-paseo
+    outputs:
+      name: ${{ steps.config.outputs.name }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Build ${{ matrix.name }} runtime
+      - name: Determine runtime from tag
+        id: config
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [[ "$TAG" == *-westend ]]; then
+            echo "name=bulletin-westend" >> "$GITHUB_OUTPUT"
+            echo "package=bulletin-westend-runtime" >> "$GITHUB_OUTPUT"
+            echo "path=runtimes/bulletin-westend" >> "$GITHUB_OUTPUT"
+          elif [[ "$TAG" == *-paseo ]]; then
+            echo "name=bulletin-paseo" >> "$GITHUB_OUTPUT"
+            echo "package=bulletin-paseo-runtime" >> "$GITHUB_OUTPUT"
+            echo "path=runtimes/bulletin-paseo" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag $TAG does not end in -westend or -paseo" >&2
+            exit 1
+          fi
+
+      - name: Build ${{ steps.config.outputs.name }} runtime
         id: srtool_build
         uses: chevdor/srtool-actions@48e9baed50ca414936dfac59d34d8b9bbe581abd # v0.9.2
         env:
           BUILD_OPTS: "--features on-chain-release-build"
         with:
-          chain: ${{ matrix.name }}
-          package: ${{ matrix.package }}
-          runtime_dir: ${{ matrix.path }}
+          chain: ${{ steps.config.outputs.name }}
+          package: ${{ steps.config.outputs.package }}
+          runtime_dir: ${{ steps.config.outputs.path }}
           profile: production
 
       - name: Store srtool digest
         env:
           SRTOOL_JSON: ${{ steps.srtool_build.outputs.json }}
+          NAME: ${{ steps.config.outputs.name }}
         run: |
-          echo "$SRTOOL_JSON" | jq > ${{ matrix.name }}_srtool_output.json
+          echo "$SRTOOL_JSON" | jq > "${NAME}_srtool_output.json"
 
-      - name: Upload ${{ matrix.name }} wasm
+      - name: Upload ${{ steps.config.outputs.name }} wasm
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ matrix.name }}-runtime
+          name: ${{ steps.config.outputs.name }}-runtime
           path: |
             ${{ steps.srtool_build.outputs.wasm_compressed }}
-            ${{ matrix.name }}_srtool_output.json
+            ${{ steps.config.outputs.name }}_srtool_output.json
 
   publish-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [build-runtimes]
+    needs: [build-runtime]
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -103,6 +115,7 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
+          name: ${{ needs.build-runtime.outputs.name }} ${{ github.ref_name }}
           files: |
             release-assets/*.wasm
           body_path: RELEASE_NOTES.md


### PR DESCRIPTION
## Summary

  - Switch the runtime release workflow to per-runtime tag suffixes so westend and paseo can be released independently.
  - Tag pattern `v[0-9]*-westend` builds & publishes only the westend runtime; `v[0-9]*-paseo` does the same for paseo. Bare `vX.Y.Z` tags no longer trigger a release.
  - Replace the matrix build with a single `Determine runtime from tag` step that derives `name` / `package` / `path` from the suffix; release title now includes the runtime name so the two
  tracks don't collide.
  - Update the `/release` skill: networks pruned to `westend` / `paseo` (the `pop` / `polkadot` entries pointed at a runtime that no longer exists), tag command updated to
  `v<VERSION>-<network>`, versioning table rewritten with per-suffix `git tag --list` lookups.

  ## Motivation

  Previously every `v*` tag built both runtimes into a single release. That coupled the two cadences — bumping westend forced a paseo artifact to ship at the same version, and vice versa. Tag  history already had ad-hoc per-network tags (`v1.0.3-westend`, `v1.0.3-westend-recovery`); this PR makes that the documented, CI-supported flow.
