### PR TITLE
Bump paseo spec_version to `1_000_011`

### DIFF
--- a/examples/native_ipfs_dag_pb_chunked_data.js
+++ b/examples/native_ipfs_dag_pb_chunked_data.js
@@ -3,7 +3,7 @@ import { getWsProvider } from 'polkadot-api/ws-provider';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { cidFromBytes, buildUnixFSDagPB, convertCid } from './cid_dag_metadata.js';
 import { generateTextImage, fileToDisk, filesAreEqual, newSigner, waitForBlockProduction, DEFAULT_IPFS_GATEWAY_URL } from './common.js';
-import { authorizeAccount, store, storeChunkedFile, fetchCid } from './api.js';
+import { authorizeAccount, store, storeChunkedFile, fetchCid, TX_MODE_FINALIZED_BLOCK } from './api.js';
 import { bulletin } from './.papi/descriptors/dist/index.mjs';
 import { withPolkadotSdkCompat } from "polkadot-api/polkadot-sdk-compat"
 import assert from "assert";
@@ -47,7 +47,7 @@ async function main() {
         console.log(`💳 Using account: ${whoAddress}`)
 
         // Make sure an account can store data.
-        await authorizeAccount(typedApi, authorizationSigner, whoAddress, 128, BigInt(64 * 1024 * 1024));
+        await authorizeAccount(typedApi, authorizationSigner, whoAddress, 128, BigInt(64 * 1024 * 1024), TX_MODE_FINALIZED_BLOCK);
 
         // Read the file, chunk it, store in Bulletin and return CIDs.
         let { chunks } = await storeChunkedFile(typedApi, whoSigner, filePath, CHUNK_SIZE);

--- a/runtimes/bulletin-paseo/src/lib.rs
+++ b/runtimes/bulletin-paseo/src/lib.rs
@@ -195,7 +195,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("bulletin-paseo"),
 	impl_name: alloc::borrow::Cow::Borrowed("bulletin-paseo"),
 	authoring_version: 1,
-	spec_version: 1_000_010,
+	spec_version: 1_000_011,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Bumps bulletin-paseo runtime spec_version from `1_000_010` to `1_000_011` ahead of the `v0.0.11-paseo` release