### PR TITLE
Make `transaction_storage::renew` feeles

### DIFF
--- a/pallets/transaction-storage/src/lib.rs
+++ b/pallets/transaction-storage/src/lib.rs
@@ -492,6 +492,7 @@ pub mod pallet {
 		/// O(1).
 		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::renew())]
+		#[pallet::feeless_if(|_origin: &OriginFor<T>, _block: &BlockNumberFor<T>, _index: &u32| -> bool { true })]
 		pub fn renew(
 			origin: OriginFor<T>,
 			block: BlockNumberFor<T>,

--- a/runtimes/bulletin-paseo/tests/tests.rs
+++ b/runtimes/bulletin-paseo/tests/tests.rs
@@ -326,15 +326,27 @@ fn authorized_storage_transactions_are_for_free() {
 					InvalidTransaction::Payment
 				)
 			);
-			// Authorize user.
+			// Authorize user for two transactions (store + renew).
 			assert_ok!(TransactionStorage::authorize_account(
 				RuntimeOrigin::root(),
 				who.clone(),
 				0,
-				24
+				48
 			));
-			// Now should work.
+			// Store should now work without funding (feeless).
+			let stored_block = System::block_number();
 			let res = construct_and_apply_extrinsic(Some(account.pair()), call);
+			assert_ok!(res);
+			assert_ok!(res.unwrap());
+
+			advance_block();
+
+			// Renew should also work without funding (feeless).
+			let renew_call = RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::renew {
+				block: stored_block,
+				index: 0,
+			});
+			let res = construct_and_apply_extrinsic(Some(account.pair()), renew_call);
 			assert_ok!(res);
 			assert_ok!(res.unwrap());
 		});
@@ -1190,7 +1202,9 @@ fn renew_must_be_direct_extrinsic() {
 		let who: AccountId = account.to_account_id();
 		let data = vec![42u8; 100];
 
-		// Fund for fees and authorize a store.
+		// Fund Alice so utility::batch wrappers (not feeless) reach the wrapper rejection
+		// in ValidateStorageCalls instead of failing earlier on payment. Direct store and
+		// renew are themselves feeless, so the funding is irrelevant for those calls.
 		use frame_support::traits::fungible::Mutate;
 		Balances::mint_into(&who, 1_000_000_000_000).unwrap();
 		assert_ok!(TransactionStorage::authorize_account(

--- a/runtimes/bulletin-westend/tests/tests.rs
+++ b/runtimes/bulletin-westend/tests/tests.rs
@@ -326,15 +326,27 @@ fn authorized_storage_transactions_are_for_free() {
 					InvalidTransaction::Payment
 				)
 			);
-			// Authorize user.
+			// Authorize user for two transactions (store + renew).
 			assert_ok!(TransactionStorage::authorize_account(
 				RuntimeOrigin::root(),
 				who.clone(),
 				0,
-				24
+				48
 			));
-			// Now should work.
+			// Store should now work without funding (feeless).
+			let stored_block = System::block_number();
 			let res = construct_and_apply_extrinsic(Some(account.pair()), call);
+			assert_ok!(res);
+			assert_ok!(res.unwrap());
+
+			advance_block();
+
+			// Renew should also work without funding (feeless).
+			let renew_call = RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::renew {
+				block: stored_block,
+				index: 0,
+			});
+			let res = construct_and_apply_extrinsic(Some(account.pair()), renew_call);
 			assert_ok!(res);
 			assert_ok!(res.unwrap());
 		});
@@ -1190,7 +1202,9 @@ fn renew_must_be_direct_extrinsic() {
 		let who: AccountId = account.to_account_id();
 		let data = vec![42u8; 100];
 
-		// Fund for fees and authorize a store.
+		// Fund Alice so utility::batch wrappers (not feeless) reach the wrapper rejection
+		// in ValidateStorageCalls instead of failing earlier on payment. Direct store and
+		// renew are themselves feeless, so the funding is irrelevant for those calls.
 		use frame_support::traits::fungible::Mutate;
 		Balances::mint_into(&who, 1_000_000_000_000).unwrap();
 		assert_ok!(TransactionStorage::authorize_account(


### PR DESCRIPTION
## Description

  Mirrors the `store` / `store_with_cid_config` behavior: `renew` no longer charges
  transaction fees when called by an authorized account. Authorization (account or
  preimage) remains the sole gate.

  ### Changes

  - `pallets/transaction-storage/src/lib.rs`: add `#[pallet::feeless_if(...)]` to
    `renew()`.
  - `runtimes/bulletin-{westend,paseo}/tests/tests.rs`:
    - Extend `authorized_storage_transactions_are_for_free` to also exercise
      `renew` on an unfunded account, proving feeless end-to-end through the
      runtime's TxExtension chain (incl. `SkipCheckIfFeeless`).
    - Document why `renew_must_be_direct_extrinsic` still funds the caller:
      `utility::batch` wrappers are not feeless, so funding is needed to reach
      the `Invalid(Call)` wrapper-rejection path in `ValidateStorageCalls`
      rather than failing earlier with `Invalid(Payment)`.
