### PR TITLE
Bump westend & paseo spec_version to 1_000_013

### DIFF
--- a/runtimes/bulletin-paseo/src/lib.rs
+++ b/runtimes/bulletin-paseo/src/lib.rs
@@ -199,7 +199,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("bulletin-paseo"),
 	impl_name: alloc::borrow::Cow::Borrowed("bulletin-paseo"),
 	authoring_version: 1,
-	spec_version: 1_000_012,
+	spec_version: 1_000_013,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtimes/bulletin-westend/src/lib.rs
+++ b/runtimes/bulletin-westend/src/lib.rs
@@ -190,7 +190,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("bulletin-westend"),
 	impl_name: alloc::borrow::Cow::Borrowed("bulletin-westend"),
 	authoring_version: 1,
-	spec_version: 1_000_012,
+	spec_version: 1_000_013,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Bump bulletin-westend runtime spec_version to 1_000_013
Bump bulletin-paseo runtime spec_version to 1_000_013