### PR TITLE
test-utils: extract XCM authorize_account conformance suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,6 +2016,7 @@ name = "bulletin-paseo-runtime"
 version = "0.1.0"
 dependencies = [
  "bulletin-pallets-common",
+ "bulletin-runtimes-test-utils",
  "bulletin-transaction-storage-primitives",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -2083,6 +2084,22 @@ dependencies = [
  "substrate-wasm-builder",
  "tracing",
  "xcm-runtime-apis",
+]
+
+[[package]]
+name = "bulletin-runtimes-test-utils"
+version = "0.1.0"
+dependencies = [
+ "frame-system",
+ "pallet-bulletin-transaction-storage",
+ "pallet-utility",
+ "parachains-common",
+ "parity-scale-codec",
+ "polkadot-sdk-frame",
+ "sp-io",
+ "sp-keyring",
+ "staging-xcm",
+ "staging-xcm-executor",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ westend-runtime-constants = { version = "27.0.0", package = "westend-runtime-con
 # Local workspace members
 bulletin-pallets-common = { version = "0.1.0", path = "pallets/common", default-features = false }
 bulletin-paseo-runtime = { path = "runtimes/bulletin-paseo" }
+bulletin-runtimes-test-utils = { version = "0.1.0", path = "runtimes/test-utils" }
 bulletin-sdk-rust = { path = "sdk/rust", default-features = false }
 bulletin-transaction-storage-primitives = { version = "0.1.0", path = "pallets/transaction-storage/primitives", default-features = false }
 bulletin-westend-runtime = { path = "runtimes/bulletin-westend" }
@@ -127,6 +128,7 @@ members = [
 	"runtimes/bulletin-paseo",
 	"runtimes/bulletin-westend",
 	"runtimes/bulletin-westend/integration-tests",
+	"runtimes/test-utils",
 	"sdk/rust",
 	"stress-test",
 ]

--- a/runtimes/bulletin-paseo/Cargo.toml
+++ b/runtimes/bulletin-paseo/Cargo.toml
@@ -86,9 +86,10 @@ parachain-info = { workspace = true }
 parachains-common = { workspace = true }
 
 [dev-dependencies]
+bulletin-runtimes-test-utils = { workspace = true }
+bulletin-transaction-storage-primitives = { workspace = true }
 parachains-runtimes-test-utils = { workspace = true, default-features = true }
 sp-io = { workspace = true }
-bulletin-transaction-storage-primitives = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true, default-features = true }

--- a/runtimes/bulletin-paseo/tests/pc_xcm_integration.rs
+++ b/runtimes/bulletin-paseo/tests/pc_xcm_integration.rs
@@ -14,17 +14,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! People Chain → Bulletin Chain `authorize_account` integration tests.
+//! People Chain → Bulletin Chain `authorize_account` integration tests for the
+//! Paseo runtime. The conformance suite lives in
+//! `bulletin-runtimes-test-utils`; each scenario file under
+//! `tests/pc_xcm_integration/` is a thin wrapper that supplies Paseo's runtime
+//! types, the People Chain location, an externalities builder, and an
+//! `advance_block` callback.
 //!
-//! Drives `XcmExecutor::prepare_and_execute` directly with messages shaped the
-//! way People Chain sends them (sibling parachain origin, `OriginKind::Xcm`,
-//! unpaid execution + Transact). Exercises the full receive-side pipeline:
-//! barrier, origin conversion, `SafeCallFilter`, `Authorizer = EnsureXcm<
-//! IsSiblingParachain>`, and the pallet's `authorize_account` /
-//! `refresh_account_authorization` semantics.
-//!
-//! Each scenario lives in its own submodule file under
-//! `tests/pc_xcm_integration/`. This file holds the shared helpers.
+//! The end-to-end scenario stays runtime-local because it constructs signed
+//! extrinsics with the runtime's tx-extension stack.
 
 #![cfg(test)]
 
@@ -44,92 +42,20 @@ mod safe_call_filter;
 use bulletin_paseo_runtime::{
 	paseo_constants::locations::PeopleLocation,
 	xcm_config::{LocationToAccountId, XcmConfig},
-	Runtime, RuntimeCall, RuntimeGenesisConfig, RuntimeOrigin, System, TransactionStorage,
+	Runtime, RuntimeCall, RuntimeGenesisConfig, System, TransactionStorage,
 };
+use bulletin_runtimes_test_utils as utils;
 use common::{advance_block, assert_extrinsic_ok, construct_and_apply_extrinsic};
-use frame_support::{assert_ok, traits::Get};
-use pallet_bulletin_transaction_storage::{
-	AuthorizationExtent, Call as TxStorageCall, Config as TxStorageConfig,
-};
-use parachains_common::{AccountId, BlockNumber};
-use sp_core::Encode;
+use pallet_bulletin_transaction_storage::{AuthorizationExtent, Call as TxStorageCall};
+use parachains_common::AccountId;
 use sp_keyring::Sr25519Keyring;
 use sp_runtime::BuildStorage;
-use xcm::latest::{prelude::*, InstructionError};
-use xcm_executor::traits::ConvertLocation;
+use xcm::latest::Location;
 
-/// People Chain location on Paseo. Matches `paseo_constants::PeopleLocation`.
 fn pc_location() -> Location {
 	PeopleLocation::get()
 }
 
-fn auth_period() -> BlockNumber {
-	<<Runtime as TxStorageConfig>::AuthorizationPeriod as Get<BlockNumber>>::get()
-}
-
-fn empty() -> AuthorizationExtent {
-	AuthorizationExtent::default()
-}
-
-fn extent(
-	bytes: u64,
-	bytes_allowance: u64,
-	transactions: u32,
-	transactions_allowance: u32,
-) -> AuthorizationExtent {
-	AuthorizationExtent {
-		bytes,
-		bytes_permanent: 0,
-		bytes_allowance,
-		transactions,
-		transactions_allowance,
-	}
-}
-
-fn extent_of(who: &AccountId) -> AuthorizationExtent {
-	TransactionStorage::account_authorization_extent(who.clone())
-}
-
-/// Build an XCM message in the shape PC uses: free unpaid execution + Transact.
-fn xcm_transact(call: RuntimeCall, kind: OriginKind) -> Xcm<RuntimeCall> {
-	Xcm::builder_unsafe()
-		.unpaid_execution(Unlimited, None)
-		.transact(kind, None, call.encode())
-		.build()
-}
-
-fn execute_from(origin: Location, message: Xcm<RuntimeCall>) -> Result<(), InstructionError> {
-	let mut id = [0u8; 32];
-	xcm_executor::XcmExecutor::<XcmConfig>::prepare_and_execute(
-		origin,
-		message,
-		&mut id,
-		Weight::MAX,
-		Weight::MAX,
-	)
-	.ensure_complete()
-}
-
-fn pc_authorize(who: AccountId, transactions: u32, bytes: u64) -> Result<(), InstructionError> {
-	let call = RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::authorize_account {
-		who,
-		transactions,
-		bytes,
-	});
-	execute_from(pc_location(), xcm_transact(call, OriginKind::Xcm))
-}
-
-fn pc_refresh(who: AccountId) -> Result<(), InstructionError> {
-	let call =
-		RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::refresh_account_authorization {
-			who,
-		});
-	execute_from(pc_location(), xcm_transact(call, OriginKind::Xcm))
-}
-
 fn new_test_ext() -> sp_io::TestExternalities {
-	let mut ext =
-		sp_io::TestExternalities::new(RuntimeGenesisConfig::default().build_storage().unwrap());
-	ext.execute_with(advance_block);
-	ext
+	sp_io::TestExternalities::new(RuntimeGenesisConfig::default().build_storage().unwrap())
 }

--- a/runtimes/bulletin-paseo/tests/pc_xcm_integration/authorize_semantics.rs
+++ b/runtimes/bulletin-paseo/tests/pc_xcm_integration/authorize_semantics.rs
@@ -15,106 +15,43 @@
 // limitations under the License.
 
 //! `authorize_account` semantics: happy path, additivity, replacement on
-//! expiry, and per-account scoping.
+//! expiry, and per-account scoping. Thin wrappers around
+//! `bulletin-runtimes-test-utils`.
 
 use super::*;
 
 #[test]
 fn happy_path_from_sibling() {
-	new_test_ext().execute_with(|| {
-		let who: AccountId = Sr25519Keyring::Alice.to_account_id();
-
-		assert_ok!(pc_authorize(who.clone(), 10, 1_000_000));
-
-		assert_eq!(extent_of(&who), extent(0, 1_000_000, 0, 10));
-		assert!(TransactionStorage::account_has_active_authorization(&who));
-	});
+	utils::xcm_authorize_happy_path::<Runtime, XcmConfig>(
+		pc_location(),
+		new_test_ext,
+		advance_block,
+	);
 }
 
-// Authorizations are additive within an unexpired window.
-// Each people chain claim adds to the existing allowance
-// and does NOT push expiry forward.
-// Consumed counters are preserved.
 #[test]
 fn additive_within_window() {
-	new_test_ext().execute_with(|| {
-		let account = Sr25519Keyring::Alice;
-		let who: AccountId = account.to_account_id();
-
-		assert_ok!(pc_authorize(who.clone(), 5, 1_000));
-		assert_eq!(extent_of(&who), extent(0, 1_000, 0, 5));
-
-		advance_block();
-		assert_extrinsic_ok(construct_and_apply_extrinsic(
-			Some(account.pair()),
-			RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::store {
-				data: vec![0u8; 200],
-			}),
-		));
-		assert_eq!(extent_of(&who), extent(200, 1_000, 1, 5));
-
-		assert_ok!(pc_authorize(who.clone(), 3, 500));
-		assert_eq!(extent_of(&who), extent(200, 1_500, 1, 8));
-
-		assert_ok!(pc_authorize(who.clone(), 2, 250));
-		assert_eq!(extent_of(&who), extent(200, 1_750, 1, 10));
-
-		// Expiry must not have been pushed forward by additive claims.
-		let now = System::block_number();
-		System::set_block_number(now + auth_period());
-		assert_eq!(extent_of(&who), empty(), "additive claims must not have extended expiry",);
-	});
+	utils::xcm_authorize_is_additive_within_window::<Runtime, XcmConfig>(
+		pc_location(),
+		new_test_ext,
+		advance_block,
+	);
 }
 
-// Replace after expiry.
 #[test]
 fn replaces_after_expiry() {
-	new_test_ext().execute_with(|| {
-		let account = Sr25519Keyring::Alice;
-		let who: AccountId = account.to_account_id();
-
-		assert_ok!(pc_authorize(who.clone(), 5, 1_000));
-
-		advance_block();
-		assert_extrinsic_ok(construct_and_apply_extrinsic(
-			Some(account.pair()),
-			RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::store {
-				data: vec![0u8; 400],
-			}),
-		));
-		assert_eq!(extent_of(&who), extent(400, 1_000, 1, 5));
-
-		let now = System::block_number();
-		System::set_block_number(now + auth_period() + 1);
-		assert_eq!(extent_of(&who), empty(), "extent must read empty once expired");
-
-		assert_ok!(pc_authorize(who.clone(), 1, 100));
-		assert_eq!(extent_of(&who), extent(0, 100, 0, 1));
-	});
+	utils::xcm_authorize_replaces_after_expiry::<Runtime, XcmConfig>(
+		pc_location(),
+		new_test_ext,
+		advance_block,
+	);
 }
 
 #[test]
 fn account_scopes_are_independent() {
-	new_test_ext().execute_with(|| {
-		let alice: AccountId = Sr25519Keyring::Alice.to_account_id();
-		let bob: AccountId = Sr25519Keyring::Bob.to_account_id();
-
-		assert_ok!(pc_authorize(alice.clone(), 5, 1_000));
-		assert_ok!(pc_authorize(bob.clone(), 10, 2_000));
-
-		assert_eq!(extent_of(&alice), extent(0, 1_000, 0, 5));
-		assert_eq!(extent_of(&bob), extent(0, 2_000, 0, 10));
-
-		let now = System::block_number();
-		System::set_block_number(now + auth_period() + 1);
-		assert_ok!(TransactionStorage::remove_expired_account_authorization(
-			RuntimeOrigin::none(),
-			alice.clone(),
-		));
-		assert_eq!(extent_of(&alice), empty());
-		// Bob's entry is still in storage — re-authorize lands as a
-		// fresh entry rather than failing.
-		assert_ok!(pc_authorize(bob.clone(), 1, 50));
-		assert_eq!(extent_of(&bob), extent(0, 50, 0, 1));
-	});
+	utils::xcm_account_scopes_are_independent::<Runtime, XcmConfig>(
+		pc_location(),
+		new_test_ext,
+		advance_block,
+	);
 }

--- a/runtimes/bulletin-paseo/tests/pc_xcm_integration/end_to_end.rs
+++ b/runtimes/bulletin-paseo/tests/pc_xcm_integration/end_to_end.rs
@@ -15,21 +15,39 @@
 // limitations under the License.
 
 //! End-to-end: People Chain authorizes, then the user submits a signed
-//! `store` and a signed `renew` on Bulletin Chain.
+//! `store` and a signed `renew` on Bulletin Chain. Stays runtime-local
+//! because it constructs signed extrinsics with the runtime's
+//! tx-extension stack.
 
 use super::*;
+use frame_support::assert_ok;
 
 #[test]
 fn authorize_then_user_stores_and_renews() {
-	new_test_ext().execute_with(|| {
+	let mut ext = new_test_ext();
+	ext.execute_with(|| {
+		advance_block();
 		let account = Sr25519Keyring::Alice;
 		let who: AccountId = account.to_account_id();
 
-		// PC issues a 2-tx, 4_000-byte allowance via XCM.
-		assert_ok!(pc_authorize(who.clone(), 2, 4_000));
-		assert_eq!(extent_of(&who), extent(0, 4_000, 0, 2));
+		assert_ok!(utils::xcm_authorize::<Runtime, XcmConfig>(
+			pc_location(),
+			who.clone(),
+			2,
+			4_000,
+		)
+		.ensure_complete());
+		assert_eq!(
+			TransactionStorage::account_authorization_extent(who.clone()),
+			AuthorizationExtent {
+				bytes: 0,
+				bytes_permanent: 0,
+				bytes_allowance: 4_000,
+				transactions: 0,
+				transactions_allowance: 2,
+			},
+		);
 
-		// Authorized user stores 1_000 bytes (feeless, boost-tier).
 		advance_block();
 		let stored_block = System::block_number();
 		assert_extrinsic_ok(construct_and_apply_extrinsic(
@@ -38,10 +56,17 @@ fn authorize_then_user_stores_and_renews() {
 				data: vec![0u8; 1_000],
 			}),
 		));
-		assert_eq!(extent_of(&who), extent(1_000, 4_000, 1, 2));
+		assert_eq!(
+			TransactionStorage::account_authorization_extent(who.clone()),
+			AuthorizationExtent {
+				bytes: 1_000,
+				bytes_permanent: 0,
+				bytes_allowance: 4_000,
+				transactions: 1,
+				transactions_allowance: 2,
+			},
+		);
 
-		// Same user renews against the just-stored block/index. `renew`
-		// charges the per-window permanent quota (`bytes_permanent`).
 		advance_block();
 		assert_extrinsic_ok(construct_and_apply_extrinsic(
 			Some(account.pair()),
@@ -51,7 +76,7 @@ fn authorize_then_user_stores_and_renews() {
 			}),
 		));
 		assert_eq!(
-			extent_of(&who),
+			TransactionStorage::account_authorization_extent(who),
 			AuthorizationExtent {
 				bytes: 1_000,
 				bytes_permanent: 1_000,

--- a/runtimes/bulletin-paseo/tests/pc_xcm_integration/origin_rejections.rs
+++ b/runtimes/bulletin-paseo/tests/pc_xcm_integration/origin_rejections.rs
@@ -14,88 +14,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Origin and barrier rejections.
-//!
-//! XCM `Transact` reports a successful `Outcome` even when the inner call's
-//! dispatch fails with `BadOrigin` or returns a runtime error. The signal
-//! that the rejection happened is therefore the absence of any storage
-//! mutation, which is what these tests assert.
+//! Origin and barrier rejections. Thin wrappers around
+//! `bulletin-runtimes-test-utils`.
 
 use super::*;
 
 #[test]
 fn relay_chain_origin_cannot_authorize() {
-	new_test_ext().execute_with(|| {
-		let target: AccountId = Sr25519Keyring::Ferdie.to_account_id();
-		let call = RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::authorize_account {
-			who: target.clone(),
-			transactions: 5,
-			bytes: 1_000,
-		});
-
-		assert_ok!(execute_from(Location::parent(), xcm_transact(call, OriginKind::Xcm)));
-
-		assert_eq!(extent_of(&target), empty(), "relay-chain origin must not authorize");
-	});
+	utils::relay_chain_origin_cannot_authorize::<Runtime, XcmConfig>(new_test_ext, advance_block);
 }
 
 #[test]
 fn sibling_with_sovereign_origin_kind_cannot_authorize() {
-	new_test_ext().execute_with(|| {
-		let target: AccountId = Sr25519Keyring::Ferdie.to_account_id();
-		let call = RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::authorize_account {
-			who: target.clone(),
-			transactions: 5,
-			bytes: 1_000,
-		});
-
-		assert_ok!(execute_from(pc_location(), xcm_transact(call, OriginKind::SovereignAccount)));
-
-		assert_eq!(
-			extent_of(&target),
-			empty(),
-			"sibling with OriginKind::SovereignAccount must not authorize",
-		);
-
-		let sovereign = LocationToAccountId::convert_location(&pc_location())
-			.expect("sibling sovereign account must derive");
-		assert_eq!(
-			extent_of(&sovereign),
-			empty(),
-			"derived sibling sovereign must not gain authorization",
-		);
-	});
+	utils::sovereign_origin_kind_cannot_authorize::<Runtime, XcmConfig, LocationToAccountId>(
+		pc_location(),
+		new_test_ext,
+		advance_block,
+	);
 }
 
 #[test]
 fn random_local_origin_cannot_authorize() {
-	new_test_ext().execute_with(|| {
-		let target: AccountId = Sr25519Keyring::Ferdie.to_account_id();
-		let stranger_loc =
-			Location::new(0, [Junction::AccountId32 { network: None, id: [0x42u8; 32] }]);
-		let call = RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::authorize_account {
-			who: target.clone(),
-			transactions: 5,
-			bytes: 1_000,
-		});
-
-		assert_ok!(execute_from(stranger_loc, xcm_transact(call, OriginKind::Xcm)));
-
-		// `XcmPassthrough` resolves the origin to `pallet_xcm::Origin::Xcm(stranger)`,
-		// which does not match `IsSiblingParachain` and is not in `TestAccounts`,
-		// so the inner `authorize_account` dispatch is rejected with `BadOrigin`.
-		assert_eq!(extent_of(&target), empty());
-	});
+	utils::random_local_origin_cannot_authorize::<Runtime, XcmConfig>(new_test_ext, advance_block);
 }
 
 #[test]
 fn authorize_with_zero_bytes_fails() {
-	new_test_ext().execute_with(|| {
-		let who: AccountId = Sr25519Keyring::Alice.to_account_id();
-
-		assert_ok!(pc_authorize(who.clone(), 1, 0));
-
-		assert_eq!(extent_of(&who), empty());
-		assert!(!TransactionStorage::account_has_active_authorization(&who));
-	});
+	utils::xcm_authorize_with_zero_bytes_fails::<Runtime, XcmConfig>(
+		pc_location(),
+		new_test_ext,
+		advance_block,
+	);
 }

--- a/runtimes/bulletin-paseo/tests/pc_xcm_integration/refresh.rs
+++ b/runtimes/bulletin-paseo/tests/pc_xcm_integration/refresh.rs
@@ -14,47 +14,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! `refresh_account_authorization` semantics.
+//! `refresh_account_authorization` semantics. Thin wrappers around
+//! `bulletin-runtimes-test-utils`.
 
 use super::*;
 
 #[test]
 fn extends_only_expiration() {
-	new_test_ext().execute_with(|| {
-		let who: AccountId = Sr25519Keyring::Alice.to_account_id();
-
-		assert_ok!(pc_authorize(who.clone(), 5, 1_000));
-		assert_eq!(extent_of(&who), extent(0, 1_000, 0, 5));
-
-		let half = auth_period() / 2;
-		let now = System::block_number();
-		System::set_block_number(now + half);
-
-		assert_ok!(pc_refresh(who.clone()));
-
-		assert_eq!(extent_of(&who), extent(0, 1_000, 0, 5));
-
-		// A block past the *original* expiry must still be active because
-		// refresh extended the window.
-		System::set_block_number(now + auth_period());
-		assert!(
-			TransactionStorage::account_has_active_authorization(&who),
-			"refresh must have extended expiry past the original window",
-		);
-	});
+	utils::xcm_refresh_extends_only_expiration::<Runtime, XcmConfig>(
+		pc_location(),
+		new_test_ext,
+		advance_block,
+	);
 }
 
 #[test]
 fn without_prior_authorize_fails() {
-	new_test_ext().execute_with(|| {
-		let who: AccountId = Sr25519Keyring::Alice.to_account_id();
-
-		// XCM completes; the inner `refresh_account_authorization` returns
-		// `Error::AccountNotAuthorized` which is reported via runtime events,
-		// not as an XCM-level instruction error.
-		assert_ok!(pc_refresh(who.clone()));
-
-		assert_eq!(extent_of(&who), empty());
-		assert!(!TransactionStorage::account_has_active_authorization(&who));
-	});
+	utils::xcm_refresh_without_prior_authorize_fails::<Runtime, XcmConfig>(
+		pc_location(),
+		new_test_ext,
+		advance_block,
+	);
 }

--- a/runtimes/bulletin-paseo/tests/pc_xcm_integration/safe_call_filter.rs
+++ b/runtimes/bulletin-paseo/tests/pc_xcm_integration/safe_call_filter.rs
@@ -14,86 +14,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! `SafeCallFilter`.
-//!
-//! Storage-mutating calls must not reach dispatch over XCM, even when the
-//! origin is otherwise valid. The filter inspects through `Utility::batch*`.
+//! `SafeCallFilter`: storage-mutating calls must not reach dispatch over XCM.
+//! Thin wrappers around `bulletin-runtimes-test-utils`.
 
 use super::*;
 
 #[test]
 fn sibling_xcm_store_is_blocked() {
-	new_test_ext().execute_with(|| {
-		let who: AccountId = Sr25519Keyring::Alice.to_account_id();
-		assert_ok!(TransactionStorage::authorize_account(
-			RuntimeOrigin::root(),
-			who.clone(),
-			1,
-			1_000
-		));
-
-		let store_call = RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::store {
-			data: vec![0u8; 100],
-		});
-
-		assert!(execute_from(pc_location(), xcm_transact(store_call, OriginKind::Xcm)).is_err());
-		assert_eq!(extent_of(&who), extent(0, 1_000, 0, 1));
-	});
+	utils::xcm_store_is_blocked::<Runtime, XcmConfig>(pc_location(), new_test_ext, advance_block);
 }
 
 #[test]
 fn sibling_xcm_batch_with_store_is_entirely_blocked() {
-	new_test_ext().execute_with(|| {
-		let target: AccountId = Sr25519Keyring::Bob.to_account_id();
-		let store_target: AccountId = Sr25519Keyring::Alice.to_account_id();
-
-		let authorize_call =
-			RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::authorize_account {
-				who: target.clone(),
-				transactions: 5,
-				bytes: 1_000,
-			});
-		let store_call = RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::store {
-			data: vec![0u8; 50],
-		});
-		let batch_call = RuntimeCall::Utility(pallet_utility::Call::batch {
-			calls: vec![authorize_call, store_call],
-		});
-
-		assert!(execute_from(pc_location(), xcm_transact(batch_call, OriginKind::Xcm)).is_err());
-		assert_eq!(
-			extent_of(&target),
-			empty(),
-			"the inner authorize_account must NOT have executed alongside a filtered store",
-		);
-		assert_eq!(extent_of(&store_target), empty());
-	});
+	utils::xcm_batch_with_store_is_entirely_blocked::<Runtime, XcmConfig>(
+		pc_location(),
+		new_test_ext,
+		advance_block,
+	);
 }
 
 #[test]
 fn sibling_xcm_batch_of_only_authorize_calls_succeeds() {
-	new_test_ext().execute_with(|| {
-		let alice: AccountId = Sr25519Keyring::Alice.to_account_id();
-		let bob: AccountId = Sr25519Keyring::Bob.to_account_id();
-
-		let authorize_alice =
-			RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::authorize_account {
-				who: alice.clone(),
-				transactions: 5,
-				bytes: 1_000,
-			});
-		let authorize_bob =
-			RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::authorize_account {
-				who: bob.clone(),
-				transactions: 10,
-				bytes: 2_000,
-			});
-		let batch_call = RuntimeCall::Utility(pallet_utility::Call::batch {
-			calls: vec![authorize_alice, authorize_bob],
-		});
-
-		assert_ok!(execute_from(pc_location(), xcm_transact(batch_call, OriginKind::Xcm)));
-		assert_eq!(extent_of(&alice), extent(0, 1_000, 0, 5));
-		assert_eq!(extent_of(&bob), extent(0, 2_000, 0, 10));
-	});
+	utils::xcm_batch_of_only_authorize_calls_succeeds::<Runtime, XcmConfig>(
+		pc_location(),
+		new_test_ext,
+		advance_block,
+	);
 }

--- a/runtimes/test-utils/Cargo.toml
+++ b/runtimes/test-utils/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bulletin-runtimes-test-utils"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Conformance tests for Bulletin Chain runtimes. Used as a dev-dependency by runtime crates to share generic XCM-driven authorize_account integration tests."
+
+[dependencies]
+codec = { workspace = true, default-features = true }
+frame-system = { workspace = true, default-features = true }
+pallet-bulletin-transaction-storage = { workspace = true, default-features = true }
+pallet-utility = { workspace = true, default-features = true }
+parachains-common = { workspace = true, default-features = true }
+polkadot-sdk-frame = { workspace = true, default-features = true }
+sp-io = { workspace = true, default-features = true }
+sp-keyring = { workspace = true, default-features = true }
+xcm = { workspace = true, default-features = true }
+xcm-executor = { workspace = true, default-features = true }

--- a/runtimes/test-utils/src/lib.rs
+++ b/runtimes/test-utils/src/lib.rs
@@ -1,0 +1,576 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Conformance tests for the XCM `authorize_account` integration on Bulletin
+//! Chain runtimes.
+//!
+//! Each helper is a generic function over the runtime and its `XcmConfig`,
+//! mirroring the pattern in `parachains-runtimes-test-utils`. The authorizer's
+//! `Location` is a parameter so the same suite covers People Chain today and
+//! any future authorizer (Fellows, others) without duplication.
+//!
+//! Runtime crates depend on this from `[dev-dependencies]` and call each
+//! function from a thin `#[test]` wrapper that supplies the runtime types,
+//! the authorizer location, an externalities builder, and an
+//! `advance_block` callback.
+
+use codec::Encode;
+use frame_system::RawOrigin;
+use pallet_bulletin_transaction_storage::{
+	AuthorizationExtent, Call as TxStorageCall, Config as TxStorageConfig,
+	Pallet as TxStoragePallet,
+};
+use parachains_common::AccountId;
+use polkadot_sdk_frame::prelude::Get;
+use sp_io::TestExternalities;
+use sp_keyring::Sr25519Keyring;
+use xcm::latest::prelude::*;
+use xcm_executor::traits::ConvertLocation;
+
+/// Convenience alias for the runtime's `RuntimeCall`.
+pub type RuntimeCallOf<R> = <R as frame_system::Config>::RuntimeCall;
+
+/// Bound bundle every conformance test in this module shares: `R` is a
+/// runtime that includes `pallet_bulletin_transaction_storage` and
+/// `pallet_utility`, uses `AccountId32`, and has a single `RuntimeCall` enum
+/// across the `frame_system` and `pallet_utility` configs (the standard setup
+/// produced by `construct_runtime!`). The `RuntimeCall` constraints sit on
+/// the supertrait so they propagate to consumers.
+pub trait BulletinXcmTestRuntime:
+	TxStorageConfig
+	+ pallet_utility::Config<RuntimeCall = <Self as frame_system::Config>::RuntimeCall>
+	+ frame_system::Config<
+		AccountId = AccountId,
+		RuntimeCall: From<TxStorageCall<Self>> + From<pallet_utility::Call<Self>> + Encode,
+	>
+{
+}
+
+impl<R> BulletinXcmTestRuntime for R where
+	R: TxStorageConfig
+		+ pallet_utility::Config<RuntimeCall = <Self as frame_system::Config>::RuntimeCall>
+		+ frame_system::Config<
+			AccountId = AccountId,
+			RuntimeCall: From<TxStorageCall<Self>> + From<pallet_utility::Call<Self>> + Encode,
+		>
+{
+}
+
+// ---------------------------------------------------------------------------
+// XCM helpers
+// ---------------------------------------------------------------------------
+
+fn xcm_transact<Call: Encode>(call: Call, kind: OriginKind) -> Xcm<Call> {
+	Xcm::builder_unsafe()
+		.unpaid_execution(Unlimited, None)
+		.transact(kind, None, call.encode())
+		.build()
+}
+
+fn execute_from<Cfg: xcm_executor::Config>(
+	origin: Location,
+	message: Xcm<<Cfg as xcm_executor::Config>::RuntimeCall>,
+) -> Outcome {
+	let mut id = [0u8; 32];
+	xcm_executor::XcmExecutor::<Cfg>::prepare_and_execute(
+		origin,
+		message,
+		&mut id,
+		Weight::MAX,
+		Weight::MAX,
+	)
+}
+
+fn authorize_call<R: BulletinXcmTestRuntime>(
+	who: AccountId,
+	transactions: u32,
+	bytes: u64,
+) -> RuntimeCallOf<R> {
+	TxStorageCall::<R>::authorize_account { who, transactions, bytes }.into()
+}
+
+fn refresh_call<R: BulletinXcmTestRuntime>(who: AccountId) -> RuntimeCallOf<R> {
+	TxStorageCall::<R>::refresh_account_authorization { who }.into()
+}
+
+fn store_call<R: BulletinXcmTestRuntime>(data: Vec<u8>) -> RuntimeCallOf<R> {
+	TxStorageCall::<R>::store { data }.into()
+}
+
+fn batch_call<R: BulletinXcmTestRuntime>(calls: Vec<RuntimeCallOf<R>>) -> RuntimeCallOf<R> {
+	pallet_utility::Call::<R>::batch { calls }.into()
+}
+
+/// Send an XCM `Transact { authorize_account }` from the given authorizer
+/// location to the runtime under test. Public so runtime crates can compose it
+/// into runtime-specific flows (e.g. authorize then submit a signed extrinsic).
+pub fn xcm_authorize<R, Cfg>(
+	authorizer: Location,
+	who: AccountId,
+	transactions: u32,
+	bytes: u64,
+) -> Outcome
+where
+	R: BulletinXcmTestRuntime,
+	Cfg: xcm_executor::Config<RuntimeCall = RuntimeCallOf<R>>,
+{
+	execute_from::<Cfg>(
+		authorizer,
+		xcm_transact(authorize_call::<R>(who, transactions, bytes), OriginKind::Xcm),
+	)
+}
+
+/// Send an XCM `Transact { refresh_account_authorization }` from the given
+/// authorizer location.
+pub fn xcm_refresh<R, Cfg>(authorizer: Location, who: AccountId) -> Outcome
+where
+	R: BulletinXcmTestRuntime,
+	Cfg: xcm_executor::Config<RuntimeCall = RuntimeCallOf<R>>,
+{
+	execute_from::<Cfg>(authorizer, xcm_transact(refresh_call::<R>(who), OriginKind::Xcm))
+}
+
+// ---------------------------------------------------------------------------
+// State helpers
+// ---------------------------------------------------------------------------
+
+fn extent_of<R: BulletinXcmTestRuntime>(who: &AccountId) -> AuthorizationExtent {
+	TxStoragePallet::<R>::account_authorization_extent(who.clone())
+}
+
+fn empty() -> AuthorizationExtent {
+	AuthorizationExtent::default()
+}
+
+fn extent(
+	bytes: u64,
+	bytes_allowance: u64,
+	transactions: u32,
+	transactions_allowance: u32,
+) -> AuthorizationExtent {
+	AuthorizationExtent {
+		bytes,
+		bytes_permanent: 0,
+		bytes_allowance,
+		transactions,
+		transactions_allowance,
+	}
+}
+
+fn authorization_period<R: BulletinXcmTestRuntime>(
+) -> frame_system::pallet_prelude::BlockNumberFor<R> {
+	<R as TxStorageConfig>::AuthorizationPeriod::get()
+}
+
+/// Consume `bytes` of `store` quota for `who` directly via the pallet,
+/// without going through the runtime's signed-extrinsic stack. Used by
+/// scenarios that need the consumed counters to advance before re-authorizing.
+fn consume_store_via_pallet<R: BulletinXcmTestRuntime>(who: &AccountId, bytes: usize) {
+	let call = TxStorageCall::<R>::store { data: vec![0u8; bytes] };
+	TxStoragePallet::<R>::pre_dispatch_signed(who, &call)
+		.expect("pre_dispatch_signed must consume authorization in tests");
+}
+
+/// Set the system block number directly. Used to jump past
+/// `AuthorizationPeriod` without iterating block hooks (which would be
+/// hundreds of thousands of iterations on real-runtime parameters).
+fn set_block_number<R: BulletinXcmTestRuntime>(n: frame_system::pallet_prelude::BlockNumberFor<R>) {
+	frame_system::Pallet::<R>::set_block_number(n);
+}
+
+fn block_number<R: BulletinXcmTestRuntime>() -> frame_system::pallet_prelude::BlockNumberFor<R> {
+	frame_system::Pallet::<R>::block_number()
+}
+
+// ---------------------------------------------------------------------------
+// Conformance tests
+// ---------------------------------------------------------------------------
+
+/// Happy path. The authorizer grants caps to a single account from a fresh
+/// state; the stored extent matches the granted caps and the entry is active.
+pub fn xcm_authorize_happy_path<R, Cfg>(
+	authorizer: Location,
+	new_ext: impl FnOnce() -> TestExternalities,
+	advance_block: impl Fn(),
+) where
+	R: BulletinXcmTestRuntime,
+	Cfg: xcm_executor::Config<RuntimeCall = RuntimeCallOf<R>>,
+{
+	let mut ext = new_ext();
+	ext.execute_with(|| {
+		advance_block();
+		let who = Sr25519Keyring::Alice.to_account_id();
+
+		assert!(xcm_authorize::<R, Cfg>(authorizer, who.clone(), 10, 1_000_000)
+			.ensure_complete()
+			.is_ok());
+
+		assert_eq!(extent_of::<R>(&who), extent(0, 1_000_000, 0, 10));
+		assert!(TxStoragePallet::<R>::account_has_active_authorization(&who));
+	});
+}
+
+/// Authorizations are additive within an unexpired window. Each grant adds to
+/// the existing allowance and does NOT push expiry forward. Consumed
+/// counters are preserved.
+pub fn xcm_authorize_is_additive_within_window<R, Cfg>(
+	authorizer: Location,
+	new_ext: impl FnOnce() -> TestExternalities,
+	advance_block: impl Fn(),
+) where
+	R: BulletinXcmTestRuntime,
+	Cfg: xcm_executor::Config<RuntimeCall = RuntimeCallOf<R>>,
+{
+	let mut ext = new_ext();
+	ext.execute_with(|| {
+		advance_block();
+		let who = Sr25519Keyring::Alice.to_account_id();
+
+		assert!(xcm_authorize::<R, Cfg>(authorizer.clone(), who.clone(), 5, 1_000)
+			.ensure_complete()
+			.is_ok());
+		assert_eq!(extent_of::<R>(&who), extent(0, 1_000, 0, 5));
+
+		consume_store_via_pallet::<R>(&who, 200);
+		assert_eq!(extent_of::<R>(&who), extent(200, 1_000, 1, 5));
+
+		assert!(xcm_authorize::<R, Cfg>(authorizer.clone(), who.clone(), 3, 500)
+			.ensure_complete()
+			.is_ok());
+		assert_eq!(extent_of::<R>(&who), extent(200, 1_500, 1, 8));
+
+		assert!(xcm_authorize::<R, Cfg>(authorizer, who.clone(), 2, 250)
+			.ensure_complete()
+			.is_ok());
+		assert_eq!(extent_of::<R>(&who), extent(200, 1_750, 1, 10));
+
+		// Expiry must not have been pushed forward by the additive grants.
+		set_block_number::<R>(block_number::<R>() + authorization_period::<R>());
+		assert_eq!(extent_of::<R>(&who), empty());
+	});
+}
+
+/// Replace after expiry. On an expired-but-present entry, a new grant resets
+/// all consumed counters and replaces (not adds) the allowances.
+pub fn xcm_authorize_replaces_after_expiry<R, Cfg>(
+	authorizer: Location,
+	new_ext: impl FnOnce() -> TestExternalities,
+	advance_block: impl Fn(),
+) where
+	R: BulletinXcmTestRuntime,
+	Cfg: xcm_executor::Config<RuntimeCall = RuntimeCallOf<R>>,
+	frame_system::pallet_prelude::BlockNumberFor<R>: From<u32>,
+{
+	let mut ext = new_ext();
+	ext.execute_with(|| {
+		advance_block();
+		let who = Sr25519Keyring::Alice.to_account_id();
+
+		assert!(xcm_authorize::<R, Cfg>(authorizer.clone(), who.clone(), 5, 1_000)
+			.ensure_complete()
+			.is_ok());
+
+		consume_store_via_pallet::<R>(&who, 400);
+		assert_eq!(extent_of::<R>(&who), extent(400, 1_000, 1, 5));
+
+		set_block_number::<R>(block_number::<R>() + authorization_period::<R>() + 1u32.into());
+		assert_eq!(extent_of::<R>(&who), empty());
+
+		assert!(xcm_authorize::<R, Cfg>(authorizer, who.clone(), 1, 100)
+			.ensure_complete()
+			.is_ok());
+		assert_eq!(extent_of::<R>(&who), extent(0, 100, 0, 1));
+	});
+}
+
+/// Independent account scopes. Two accounts authorized separately. Removing
+/// one does not affect the other.
+pub fn xcm_account_scopes_are_independent<R, Cfg>(
+	authorizer: Location,
+	new_ext: impl FnOnce() -> TestExternalities,
+	advance_block: impl Fn(),
+) where
+	R: BulletinXcmTestRuntime,
+	Cfg: xcm_executor::Config<RuntimeCall = RuntimeCallOf<R>>,
+	frame_system::pallet_prelude::BlockNumberFor<R>: From<u32>,
+{
+	let mut ext = new_ext();
+	ext.execute_with(|| {
+		advance_block();
+		let alice = Sr25519Keyring::Alice.to_account_id();
+		let bob = Sr25519Keyring::Bob.to_account_id();
+
+		assert!(xcm_authorize::<R, Cfg>(authorizer.clone(), alice.clone(), 5, 1_000)
+			.ensure_complete()
+			.is_ok());
+		assert!(xcm_authorize::<R, Cfg>(authorizer.clone(), bob.clone(), 10, 2_000)
+			.ensure_complete()
+			.is_ok());
+		assert_eq!(extent_of::<R>(&alice), extent(0, 1_000, 0, 5));
+		assert_eq!(extent_of::<R>(&bob), extent(0, 2_000, 0, 10));
+
+		set_block_number::<R>(block_number::<R>() + authorization_period::<R>() + 1u32.into());
+		// Permissionless `remove_expired_account_authorization` accepts any
+		// origin; pass `RawOrigin::None`.
+		TxStoragePallet::<R>::remove_expired_account_authorization(
+			RawOrigin::None.into(),
+			alice.clone(),
+		)
+		.expect("Alice's authorization is past its expiry and should be removable");
+		assert_eq!(extent_of::<R>(&alice), empty());
+
+		assert!(xcm_authorize::<R, Cfg>(authorizer, bob.clone(), 1, 50)
+			.ensure_complete()
+			.is_ok());
+		assert_eq!(extent_of::<R>(&bob), extent(0, 50, 0, 1));
+	});
+}
+
+/// Relay-chain origin cannot authorize. The dispatch resolves to
+/// `pallet_xcm::Origin::Xcm(parent)` which does not match the runtime's
+/// authorizer filter; the inner call fails with `BadOrigin`. XCM's `Outcome`
+/// stays `Complete` because the failure is at dispatch level, not at the
+/// XCM-instruction level. The signal is the absence of any storage mutation.
+pub fn relay_chain_origin_cannot_authorize<R, Cfg>(
+	new_ext: impl FnOnce() -> TestExternalities,
+	advance_block: impl Fn(),
+) where
+	R: BulletinXcmTestRuntime,
+	Cfg: xcm_executor::Config<RuntimeCall = RuntimeCallOf<R>>,
+{
+	let mut ext = new_ext();
+	ext.execute_with(|| {
+		advance_block();
+		let target = Sr25519Keyring::Ferdie.to_account_id();
+		let outcome = execute_from::<Cfg>(
+			Location::parent(),
+			xcm_transact(authorize_call::<R>(target.clone(), 5, 1_000), OriginKind::Xcm),
+		);
+		assert!(outcome.ensure_complete().is_ok());
+		assert_eq!(extent_of::<R>(&target), empty());
+	});
+}
+
+/// Sibling sending Transact with `OriginKind::SovereignAccount` resolves to a
+/// `Signed(authorizer_sovereign)` origin. The sovereign is not an
+/// `pallet_xcm::Origin::Xcm`, so the dispatch fails with `BadOrigin`. The
+/// derived sovereign account is also asserted not to gain an authorization as
+/// a side effect.
+pub fn sovereign_origin_kind_cannot_authorize<R, Cfg, LocationToAccount>(
+	authorizer: Location,
+	new_ext: impl FnOnce() -> TestExternalities,
+	advance_block: impl Fn(),
+) where
+	R: BulletinXcmTestRuntime,
+	Cfg: xcm_executor::Config<RuntimeCall = RuntimeCallOf<R>>,
+	LocationToAccount: ConvertLocation<AccountId>,
+{
+	let mut ext = new_ext();
+	ext.execute_with(|| {
+		advance_block();
+		let target = Sr25519Keyring::Ferdie.to_account_id();
+		let outcome = execute_from::<Cfg>(
+			authorizer.clone(),
+			xcm_transact(
+				authorize_call::<R>(target.clone(), 5, 1_000),
+				OriginKind::SovereignAccount,
+			),
+		);
+		assert!(outcome.ensure_complete().is_ok());
+		assert_eq!(extent_of::<R>(&target), empty());
+
+		let sovereign = LocationToAccount::convert_location(&authorizer)
+			.expect("sibling sovereign account must derive");
+		assert_eq!(extent_of::<R>(&sovereign), empty());
+	});
+}
+
+/// Random local AccountId32 origin cannot authorize.
+pub fn random_local_origin_cannot_authorize<R, Cfg>(
+	new_ext: impl FnOnce() -> TestExternalities,
+	advance_block: impl Fn(),
+) where
+	R: BulletinXcmTestRuntime,
+	Cfg: xcm_executor::Config<RuntimeCall = RuntimeCallOf<R>>,
+{
+	let mut ext = new_ext();
+	ext.execute_with(|| {
+		advance_block();
+		let target = Sr25519Keyring::Ferdie.to_account_id();
+		let stranger_loc =
+			Location::new(0, [Junction::AccountId32 { network: None, id: [0x42u8; 32] }]);
+		let outcome = execute_from::<Cfg>(
+			stranger_loc,
+			xcm_transact(authorize_call::<R>(target.clone(), 5, 1_000), OriginKind::Xcm),
+		);
+		assert!(outcome.ensure_complete().is_ok());
+		assert_eq!(extent_of::<R>(&target), empty());
+	});
+}
+
+/// `SafeCallFilter` blocks `store` arriving over XCM, even when the caller is
+/// otherwise valid and the target has a real allowance.
+pub fn xcm_store_is_blocked<R, Cfg>(
+	authorizer: Location,
+	new_ext: impl FnOnce() -> TestExternalities,
+	advance_block: impl Fn(),
+) where
+	R: BulletinXcmTestRuntime,
+	Cfg: xcm_executor::Config<RuntimeCall = RuntimeCallOf<R>>,
+{
+	let mut ext = new_ext();
+	ext.execute_with(|| {
+		advance_block();
+		let who = Sr25519Keyring::Alice.to_account_id();
+		assert!(xcm_authorize::<R, Cfg>(authorizer.clone(), who.clone(), 1, 1_000)
+			.ensure_complete()
+			.is_ok());
+
+		let outcome = execute_from::<Cfg>(
+			authorizer,
+			xcm_transact(store_call::<R>(vec![0u8; 100]), OriginKind::Xcm),
+		);
+		assert!(
+			outcome.clone().ensure_complete().is_err(),
+			"SafeCallFilter must block sibling-XCM `store`, got: {outcome:?}"
+		);
+		assert_eq!(extent_of::<R>(&who), extent(0, 1_000, 0, 1));
+	});
+}
+
+/// `Utility::batch([authorize_account, store])` is rejected as a whole;
+/// neither half executes.
+pub fn xcm_batch_with_store_is_entirely_blocked<R, Cfg>(
+	authorizer: Location,
+	new_ext: impl FnOnce() -> TestExternalities,
+	advance_block: impl Fn(),
+) where
+	R: BulletinXcmTestRuntime,
+	Cfg: xcm_executor::Config<RuntimeCall = RuntimeCallOf<R>>,
+{
+	let mut ext = new_ext();
+	ext.execute_with(|| {
+		advance_block();
+		let target = Sr25519Keyring::Bob.to_account_id();
+		let store_target = Sr25519Keyring::Alice.to_account_id();
+
+		let inner =
+			vec![authorize_call::<R>(target.clone(), 5, 1_000), store_call::<R>(vec![0u8; 50])];
+		let outcome =
+			execute_from::<Cfg>(authorizer, xcm_transact(batch_call::<R>(inner), OriginKind::Xcm));
+
+		assert!(
+			outcome.clone().ensure_complete().is_err(),
+			"SafeCallFilter must reject the whole batch when any inner call is filtered, got: {outcome:?}",
+		);
+		assert_eq!(extent_of::<R>(&target), empty());
+		assert_eq!(extent_of::<R>(&store_target), empty());
+	});
+}
+
+/// `Utility::batch([authorize_account, authorize_account])` is allowed and
+/// both extents land. Boundary case proving the filter does not over-block
+/// legitimate XCM-driven authorization batches.
+pub fn xcm_batch_of_only_authorize_calls_succeeds<R, Cfg>(
+	authorizer: Location,
+	new_ext: impl FnOnce() -> TestExternalities,
+	advance_block: impl Fn(),
+) where
+	R: BulletinXcmTestRuntime,
+	Cfg: xcm_executor::Config<RuntimeCall = RuntimeCallOf<R>>,
+{
+	let mut ext = new_ext();
+	ext.execute_with(|| {
+		advance_block();
+		let alice = Sr25519Keyring::Alice.to_account_id();
+		let bob = Sr25519Keyring::Bob.to_account_id();
+
+		let inner = vec![
+			authorize_call::<R>(alice.clone(), 5, 1_000),
+			authorize_call::<R>(bob.clone(), 10, 2_000),
+		];
+		let outcome =
+			execute_from::<Cfg>(authorizer, xcm_transact(batch_call::<R>(inner), OriginKind::Xcm));
+
+		assert!(
+			outcome.clone().ensure_complete().is_ok(),
+			"sibling XCM batch of authorize_account calls must complete, got: {outcome:?}"
+		);
+		assert_eq!(extent_of::<R>(&alice), extent(0, 1_000, 0, 5));
+		assert_eq!(extent_of::<R>(&bob), extent(0, 2_000, 0, 10));
+	});
+}
+
+/// `authorize_account(_, bytes: 0)` is rejected by the pallet at dispatch
+/// level.
+pub fn xcm_authorize_with_zero_bytes_fails<R, Cfg>(
+	authorizer: Location,
+	new_ext: impl FnOnce() -> TestExternalities,
+	advance_block: impl Fn(),
+) where
+	R: BulletinXcmTestRuntime,
+	Cfg: xcm_executor::Config<RuntimeCall = RuntimeCallOf<R>>,
+{
+	let mut ext = new_ext();
+	ext.execute_with(|| {
+		advance_block();
+		let who = Sr25519Keyring::Alice.to_account_id();
+		assert!(xcm_authorize::<R, Cfg>(authorizer, who.clone(), 1, 0).ensure_complete().is_ok());
+		assert_eq!(extent_of::<R>(&who), empty());
+		assert!(!TxStoragePallet::<R>::account_has_active_authorization(&who));
+	});
+}
+
+/// `refresh_account_authorization` only extends expiry. Allowances and
+/// consumed counters are unchanged.
+pub fn xcm_refresh_extends_only_expiration<R, Cfg>(
+	authorizer: Location,
+	new_ext: impl FnOnce() -> TestExternalities,
+	advance_block: impl Fn(),
+) where
+	R: BulletinXcmTestRuntime,
+	Cfg: xcm_executor::Config<RuntimeCall = RuntimeCallOf<R>>,
+	frame_system::pallet_prelude::BlockNumberFor<R>: From<u32>,
+{
+	let mut ext = new_ext();
+	ext.execute_with(|| {
+		advance_block();
+		let who = Sr25519Keyring::Alice.to_account_id();
+
+		assert!(xcm_authorize::<R, Cfg>(authorizer.clone(), who.clone(), 5, 1_000)
+			.ensure_complete()
+			.is_ok());
+		assert_eq!(extent_of::<R>(&who), extent(0, 1_000, 0, 5));
+
+		let now = block_number::<R>();
+		let half = authorization_period::<R>() / 2u32.into();
+		set_block_number::<R>(now + half);
+
+		assert!(xcm_refresh::<R, Cfg>(authorizer, who.clone()).ensure_complete().is_ok());
+		assert_eq!(extent_of::<R>(&who), extent(0, 1_000, 0, 5));
+
+		// Past the original expiry: still active because refresh extended it.
+		set_block_number::<R>(now + authorization_period::<R>());
+		assert!(TxStoragePallet::<R>::account_has_active_authorization(&who));
+	});
+}
+
+/// `refresh_account_authorization` without a prior authorize fails; no entry
+/// is created.
+pub fn xcm_refresh_without_prior_authorize_fails<R, Cfg>(
+	authorizer: Location,
+	new_ext: impl FnOnce() -> TestExternalities,
+	advance_block: impl Fn(),
+) where
+	R: BulletinXcmTestRuntime,
+	Cfg: xcm_executor::Config<RuntimeCall = RuntimeCallOf<R>>,
+{
+	let mut ext = new_ext();
+	ext.execute_with(|| {
+		advance_block();
+		let who = Sr25519Keyring::Alice.to_account_id();
+		assert!(xcm_refresh::<R, Cfg>(authorizer, who.clone()).ensure_complete().is_ok());
+		assert_eq!(extent_of::<R>(&who), empty());
+		assert!(!TxStoragePallet::<R>::account_has_active_authorization(&who));
+	});
+}


### PR DESCRIPTION
Follow-up to #497.

Moves 13 of the 14 People Chain → Bulletin Chain XCM integration tests into a new `bulletin-runtimes-test-utils` crate as generic functions over the runtime and its `XcmConfig`. The authorizer's `Location` is a parameter, so the same suite covers People Chain today and any future authorizer (Fellows, others) without duplication.

The Paseo runtime calls them as thin wrappers under `runtimes/bulletin-paseo/tests/pc_xcm_integration/`, one file per scenario.

The end-to-end test (XCM authorize → signed `store` → signed `renew`) stays runtime-local because it constructs signed extrinsics with Paseo's tx-extension stack.

Per review:

- Lives in its own crate (`runtimes/test-utils`) rather than as a feature on `bulletin-pallets-common`, to keep production and test surfaces separate and avoid feature-propagation churn.
- Authorizer is a `Location` parameter; helper and test names are authorizer-agnostic.

Stacked on `ndk/test-pc-authorize-account-490`. Should merge after #497.