### PR TITLE
Wait for authorize to be finalized in authorize_and_store

### DIFF
--- a/examples/typescript/authorize_and_store.js
+++ b/examples/typescript/authorize_and_store.js
@@ -63,7 +63,7 @@ async function main() {
             user.address,
             100,
             BigInt(100 * 1024 * 1024), // 100 MiB
-        ).withSudo().send();
+        ).withSudo().withWaitFor('finalized').send();
         console.log('Account authorized successfully!');
 
         // Step 2: Store data using the SDK


### PR DESCRIPTION
authorize_and_store sometimes flakes e.g. here: https://github.com/paritytech/polkadot-bulletin-chain/actions/runs/25499853619/job/74829929950. Same change could be made in integration tests but i haven't seen them fail due to this.