### PR TITLE
feat: migrate from construct_runtime to frame_support::runtime

### DIFF
--- a/pallets/hop-promotion/src/mock.rs
+++ b/pallets/hop-promotion/src/mock.rs
@@ -17,20 +17,45 @@
 
 use crate as pallet_bulletin_hop_promotion;
 use bulletin_pallets_common::NoCurrency;
-use polkadot_sdk_frame::{prelude::*, runtime::prelude::*, testing_prelude::*};
+use polkadot_sdk_frame::{
+	deps::{frame_support, frame_system},
+	prelude::*,
+	runtime::prelude::*,
+	testing_prelude::*,
+};
 use sp_runtime::{traits::IdentityLookup, AccountId32};
 
 type Block = MockBlock<Test>;
 
-construct_runtime!(
-	pub enum Test
-	{
-		System: frame_system,
-		Timestamp: pallet_timestamp,
-		TransactionStorage: pallet_bulletin_transaction_storage,
-		HopPromotion: pallet_bulletin_hop_promotion,
-	}
-);
+#[frame_support::runtime]
+mod runtime {
+	#[runtime::runtime]
+	#[runtime::derive(
+		RuntimeCall,
+		RuntimeEvent,
+		RuntimeError,
+		RuntimeOrigin,
+		RuntimeTask,
+		RuntimeFreezeReason,
+		RuntimeHoldReason,
+		RuntimeSlashReason,
+		RuntimeLockId,
+		RuntimeViewFunction
+	)]
+	pub struct Test;
+
+	#[runtime::pallet_index(0)]
+	pub type System = frame_system::Pallet<Test>;
+
+	#[runtime::pallet_index(1)]
+	pub type Timestamp = pallet_timestamp::Pallet<Test>;
+
+	#[runtime::pallet_index(2)]
+	pub type TransactionStorage = pallet_bulletin_transaction_storage::Pallet<Test>;
+
+	#[runtime::pallet_index(3)]
+	pub type HopPromotion = pallet_bulletin_hop_promotion::Pallet<Test>;
+}
 
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl frame_system::Config for Test {

--- a/pallets/hop-promotion/src/mock.rs
+++ b/pallets/hop-promotion/src/mock.rs
@@ -45,16 +45,16 @@ mod runtime {
 	pub struct Test;
 
 	#[runtime::pallet_index(0)]
-	pub type System = frame_system::Pallet<Test>;
+	pub type System = frame_system;
 
 	#[runtime::pallet_index(1)]
-	pub type Timestamp = pallet_timestamp::Pallet<Test>;
+	pub type Timestamp = pallet_timestamp;
 
 	#[runtime::pallet_index(2)]
-	pub type TransactionStorage = pallet_bulletin_transaction_storage::Pallet<Test>;
+	pub type TransactionStorage = pallet_bulletin_transaction_storage;
 
 	#[runtime::pallet_index(3)]
-	pub type HopPromotion = pallet_bulletin_hop_promotion::Pallet<Test>;
+	pub type HopPromotion = pallet_bulletin_hop_promotion;
 }
 
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig)]

--- a/pallets/transaction-storage/src/mock.rs
+++ b/pallets/transaction-storage/src/mock.rs
@@ -23,19 +23,39 @@ use crate::{
 };
 use bulletin_pallets_common::NoCurrency;
 use polkadot_sdk_frame::{
-	prelude::*, runtime::prelude::*, testing_prelude::*, traits::EitherOfDiverse,
+	deps::{frame_support, frame_system},
+	prelude::*,
+	runtime::prelude::*,
+	testing_prelude::*,
+	traits::EitherOfDiverse,
 };
 
-type Block = MockBlock<Test>;
-
 // Configure a mock runtime to test the pallet.
-construct_runtime!(
-	pub enum Test
-	{
-		System: frame_system,
-		TransactionStorage: pallet_bulletin_transaction_storage,
-	}
-);
+#[frame_support::runtime]
+mod runtime {
+	#[runtime::runtime]
+	#[runtime::derive(
+		RuntimeCall,
+		RuntimeEvent,
+		RuntimeError,
+		RuntimeOrigin,
+		RuntimeTask,
+		RuntimeFreezeReason,
+		RuntimeHoldReason,
+		RuntimeSlashReason,
+		RuntimeLockId,
+		RuntimeViewFunction
+	)]
+	pub struct Test;
+
+	#[runtime::pallet_index(0)]
+	pub type System = frame_system::Pallet<Test>;
+
+	#[runtime::pallet_index(1)]
+	pub type TransactionStorage = pallet_bulletin_transaction_storage::Pallet<Test>;
+}
+
+type Block = MockBlock<Test>;
 
 parameter_types! {
 	pub const TestDbWeight: polkadot_sdk_frame::deps::frame_support::weights::RuntimeDbWeight =

--- a/pallets/transaction-storage/src/mock.rs
+++ b/pallets/transaction-storage/src/mock.rs
@@ -30,6 +30,8 @@ use polkadot_sdk_frame::{
 	traits::EitherOfDiverse,
 };
 
+type Block = MockBlock<Test>;
+
 // Configure a mock runtime to test the pallet.
 #[frame_support::runtime]
 mod runtime {
@@ -49,13 +51,11 @@ mod runtime {
 	pub struct Test;
 
 	#[runtime::pallet_index(0)]
-	pub type System = frame_system::Pallet<Test>;
+	pub type System = frame_system;
 
 	#[runtime::pallet_index(1)]
-	pub type TransactionStorage = pallet_bulletin_transaction_storage::Pallet<Test>;
+	pub type TransactionStorage = pallet_bulletin_transaction_storage;
 }
-
-type Block = MockBlock<Test>;
 
 parameter_types! {
 	pub const TestDbWeight: polkadot_sdk_frame::deps::frame_support::weights::RuntimeDbWeight =

--- a/pallets/transaction-storage/src/tests.rs
+++ b/pallets/transaction-storage/src/tests.rs
@@ -2562,8 +2562,7 @@ fn create_inherent_emits_call_when_pending_renewals_present() {
 			Some(Call::apply_block_inherents { proof: None }) => {},
 			other => panic!(
 				"expected Some(apply_block_inherents {{ proof: None }}) when only pending renewals \
-				 are present, got {:?}",
-				other
+				 are present, got {other:?}"
 			),
 		}
 	});
@@ -3037,8 +3036,7 @@ fn migrate_v2_to_v3_insufficient_weight_returns_err() {
 		let res = MigrateV2ToV3::<Test>::step(None, &mut meter);
 		assert!(
 			matches!(res, Err(SteppedMigrationError::InsufficientWeight { .. })),
-			"expected InsufficientWeight, got {:?}",
-			res,
+			"expected InsufficientWeight, got {res:?}"
 		);
 	});
 }


### PR DESCRIPTION
## Changes

Migrate from `construct_runtime!` to `frame_support::runtime` in 
- pallets/hop-promotion/src/mock.rs
- pallets/transaction-storage/src/mock.rs

## Issue
- Close https://github.com/paritytech/polkadot-bulletin-chain/issues/326