### PR TITLE
CI flaky tests fixes

### DIFF
--- a/justfile
+++ b/justfile
@@ -109,6 +109,7 @@ test-zombienet-auto-renew runtime="westend" group="all":
                 auto_renew_storage::parachain_check_proof_fails_under_pruning_test \
                 auto_renew_storage::parachain_auto_renew_under_pruning_chain_halts_test \
                 auto_renew_storage::parachain_auto_renew_many_items_worst_case_test \
+                auto_renew_storage::parachain_auto_renew_many_items_prune_eviction_test \
                 auto_renew_storage::parachain_on_initialize_cleanup_test \
                 auto_renew_storage::parachain_on_initialize_no_renewals_weight_test)
             ;;

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -9,14 +9,15 @@ use crate::{
 	utils::{
 		authorize_account_via_sudo, authorize_account_via_sudo_finalized, authorize_and_store_data,
 		blake2_256, build_parachain_network_config_three_relay_validators, content_hash_and_cid,
-		count_event, disable_auto_renew, enable_auto_renew, expect_bitswap_dont_have,
+		count_event, disable_auto_renew, enable_auto_renew,
+		expect_all_items_bitswap_dont_have_concurrent, expect_bitswap_dont_have,
 		generate_test_data, get_alice_nonce, initialize_network, override_alice_authorization,
 		resolve_canonical_store_block, set_retention_period, set_retention_period_finalized,
-		submit_renew_pair, submit_store_signed, top_up_alice_authorization, verify_node_bitswap,
-		verify_parachain_binaries, wait_for_block_height, wait_for_finalized_height,
-		wait_for_finalized_quiescence, wait_for_session_change_on_node, AuthorizationOverride,
-		BLOCK_PRODUCTION_TIMEOUT_SECS, NETWORK_READY_TIMEOUT_SECS, NODE_LOG_CONFIG,
-		PARACHAIN_TEST_DATA_PATTERN, TEST_DATA_SIZE,
+		submit_renew_pair, submit_store_signed, top_up_alice_authorization,
+		verify_all_items_bitswap_concurrent, verify_node_bitswap, verify_parachain_binaries,
+		wait_for_block_height, wait_for_finalized_height, wait_for_finalized_quiescence,
+		wait_for_session_change_on_node, AuthorizationOverride, BLOCK_PRODUCTION_TIMEOUT_SECS,
+		NETWORK_READY_TIMEOUT_SECS, NODE_LOG_CONFIG, PARACHAIN_TEST_DATA_PATTERN, TEST_DATA_SIZE,
 	},
 };
 use anyhow::{Context, Result};
@@ -57,6 +58,11 @@ async fn current_finalized_block(
 const SESSION_CHANGE_TIMEOUT_SECS: u64 = 300;
 const RETENTION_PERIOD: u32 = 10;
 const BITSWAP_TIMEOUT_SECS: u64 = 30;
+/// Per-test concurrency for batched bitswap probes over persistent litep2p connections.
+/// Each connection handles `MANY_ITEMS_COUNT / N` items sequentially; 16 keeps the collator's
+/// bitswap server load reasonable while avoiding the transport-service exhaustion that hit
+/// the previous per-item fresh-litep2p loop.
+const BITSWAP_VERIFY_CONCURRENCY: usize = 16;
 /// `--blocks-pruning` deletion + col11 refcount-zero cleanup runs asynchronously after the
 /// finalized-height metric crosses; under CI load that lag can be tens of seconds (paseo runs
 /// observed >180s before eviction). 300s gives margin without making fast-cleanup runs slow.
@@ -1181,23 +1187,17 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 
 	// Per-item bitswap probe: catches the case where `Stored` + `AutoRenewalEnabled` events
 	// fire on-chain but col11 didn't actually receive the chunks (or chunks have wrong hash).
-	// Sequential keeps the collator's bitswap server from queueing up `MANY_ITEMS_COUNT`
-	// requests at once.
-	tracing::info!(
-		"Verifying bitswap availability of all {} items (post-store, post-enable)...",
-		MANY_ITEMS_COUNT
-	);
-	for (i, data) in items.iter().enumerate() {
-		verify_node_bitswap(
-			collator1,
-			data,
-			BITSWAP_TIMEOUT_SECS,
-			&format!("post-enable item {}/{}", i + 1, MANY_ITEMS_COUNT),
-		)
-		.await
-		.with_context(|| format!("post-enable: item {i} not bitswap-fetchable"))?;
-	}
-	tracing::info!("✓ All {} items bitswap-fetchable post-enable", MANY_ITEMS_COUNT);
+	// `BITSWAP_VERIFY_CONCURRENCY` persistent connections each handle ~`MANY_ITEMS_COUNT/N`
+	// items — sequential per-item fetches over a fresh litep2p each (the original loop)
+	// exhausted litep2p's transport service around item 310/512.
+	verify_all_items_bitswap_concurrent(
+		collator1,
+		&items,
+		BITSWAP_VERIFY_CONCURRENCY,
+		BITSWAP_TIMEOUT_SECS,
+		"post-enable",
+	)
+	.await?;
 
 	// Pairwise diffs of `substrate_proposer_block_constructed_{sum,count}` give per-block
 	// wall-clock construction time, independent of the runtime's declared weight.
@@ -1475,21 +1475,14 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 	// exhaustion cycle, the chunks should still be col11-resident keyed to the latest
 	// successful renewal's block. Archive mode, so no pruning would have evicted them; any
 	// missing item here is a runtime/indexing bug we'd want to catch.
-	tracing::info!(
-		"Verifying bitswap availability of all {} items (post-exhaustion)...",
-		MANY_ITEMS_COUNT
-	);
-	for (i, data) in items.iter().enumerate() {
-		verify_node_bitswap(
-			collator1,
-			data,
-			BITSWAP_TIMEOUT_SECS,
-			&format!("post-exhaustion item {}/{}", i + 1, MANY_ITEMS_COUNT),
-		)
-		.await
-		.with_context(|| format!("post-exhaustion: item {i} not bitswap-fetchable"))?;
-	}
-	tracing::info!("✓ All {} items bitswap-fetchable post-exhaustion", MANY_ITEMS_COUNT);
+	verify_all_items_bitswap_concurrent(
+		collator1,
+		&items,
+		BITSWAP_VERIFY_CONCURRENCY,
+		BITSWAP_TIMEOUT_SECS,
+		"post-exhaustion",
+	)
+	.await?;
 
 	test_log!(TEST, "=== Auto-renew {} items PASSED ===", MANY_ITEMS_COUNT);
 	Ok(())
@@ -2195,7 +2188,8 @@ async fn parachain_auto_renew_many_items_prune_eviction_test() -> Result<()> {
 		.await?;
 
 	// First item: full timeout — col11 async cleanup may lag the finalized-height metric
-	// crossing by tens of seconds (paseo CI observed up to ~5min in the worst case).
+	// crossing by tens of seconds (paseo CI observed up to ~5min in the worst case). Single
+	// fresh-litep2p probe here is fine — it's just one fetch.
 	expect_bitswap_dont_have(
 		collator1,
 		&items[0],
@@ -2208,29 +2202,17 @@ async fn parachain_auto_renew_many_items_prune_eviction_test() -> Result<()> {
 		 a refcount/release bug or pruning isn't actually firing for the renewal block",
 	)?;
 
-	// Once the first item evicts, the rest should be fast (cleanup is batched). 30s per
-	// remaining item bounds the test if something else goes wrong.
-	tracing::info!(
-		"Verifying eviction of remaining {} items (short timeout each)...",
-		MANY_ITEMS_COUNT - 1
-	);
-	for (i, data) in items.iter().enumerate().skip(1) {
-		expect_bitswap_dont_have(
-			collator1,
-			data,
-			PRUNE_EVICTION_PER_ITEM_TIMEOUT_SECS,
-			&format!("item {}/{}", i + 1, MANY_ITEMS_COUNT),
-		)
-		.await
-		.with_context(|| {
-			format!(
-				"item {} still served after item 0 was evicted — partial col11 cleanup is a \
-				 stronger smoking-gun than full failure",
-				i
-			)
-		})?;
-	}
-	tracing::info!("✓ All {} items evicted via bitswap DONT_HAVE", MANY_ITEMS_COUNT);
+	// Once the first item evicts, the rest should be fast (cleanup is batched). Probe the
+	// remaining items via `BITSWAP_VERIFY_CONCURRENCY` persistent connections — sequential
+	// per-item fresh-litep2p (the original loop) exhausts the transport service.
+	expect_all_items_bitswap_dont_have_concurrent(
+		collator1,
+		&items[1..],
+		BITSWAP_VERIFY_CONCURRENCY,
+		PRUNE_EVICTION_PER_ITEM_TIMEOUT_SECS,
+		"post-pruning",
+	)
+	.await?;
 
 	test_log!(TEST, "=== Auto-renew {} items + pruning eviction PASSED ===", MANY_ITEMS_COUNT);
 	network.destroy().await?;

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -1096,6 +1096,19 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 	for (b, n) in hist_entries {
 		tracing::info!("  block {}: {} stores", b, n);
 	}
+	// The test premise is "MAX_BLOCK_TRANSACTIONS stores all land in one block, so the
+	// auto-renew inherent at `block + RP + 1` re-indexes the full set in one call". If
+	// stores spanned multiple blocks, the renewal load is split and we're not stressing
+	// the same-block scenario the test claims.
+	if store_block_histogram.len() != 1 {
+		anyhow::bail!(
+			"Expected all {} stores in a single block (= MAX_BLOCK_TRANSACTIONS), but they \
+			 spanned {} blocks. Histogram: {:?}",
+			MANY_ITEMS_COUNT,
+			store_block_histogram.len(),
+			store_block_histogram
+		);
+	}
 
 	let pre_enable_block = current_best_block(client).await?.number() as u64;
 	let mut enable_futs = Vec::with_capacity(content_hashes.len());
@@ -1165,6 +1178,26 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 	}
 	tracing::info!("Auto-renewal enabled for all {} items", MANY_ITEMS_COUNT);
 	let _ = nonce; // last use
+
+	// Per-item bitswap probe: catches the case where `Stored` + `AutoRenewalEnabled` events
+	// fire on-chain but col11 didn't actually receive the chunks (or chunks have wrong hash).
+	// Sequential keeps the collator's bitswap server from queueing up `MANY_ITEMS_COUNT`
+	// requests at once.
+	tracing::info!(
+		"Verifying bitswap availability of all {} items (post-store, post-enable)...",
+		MANY_ITEMS_COUNT
+	);
+	for (i, data) in items.iter().enumerate() {
+		verify_node_bitswap(
+			collator1,
+			data,
+			BITSWAP_TIMEOUT_SECS,
+			&format!("post-enable item {}/{}", i + 1, MANY_ITEMS_COUNT),
+		)
+		.await
+		.with_context(|| format!("post-enable: item {i} not bitswap-fetchable"))?;
+	}
+	tracing::info!("✓ All {} items bitswap-fetchable post-enable", MANY_ITEMS_COUNT);
 
 	// Pairwise diffs of `substrate_proposer_block_constructed_{sum,count}` give per-block
 	// wall-clock construction time, independent of the runtime's declared weight.
@@ -1438,6 +1471,26 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 		exhaustion_block + 1,
 	);
 
+	// Final bitswap sweep: after `RENEWAL_CYCLES_TO_OBSERVE` successful renewals + the
+	// exhaustion cycle, the chunks should still be col11-resident keyed to the latest
+	// successful renewal's block. Archive mode, so no pruning would have evicted them; any
+	// missing item here is a runtime/indexing bug we'd want to catch.
+	tracing::info!(
+		"Verifying bitswap availability of all {} items (post-exhaustion)...",
+		MANY_ITEMS_COUNT
+	);
+	for (i, data) in items.iter().enumerate() {
+		verify_node_bitswap(
+			collator1,
+			data,
+			BITSWAP_TIMEOUT_SECS,
+			&format!("post-exhaustion item {}/{}", i + 1, MANY_ITEMS_COUNT),
+		)
+		.await
+		.with_context(|| format!("post-exhaustion: item {i} not bitswap-fetchable"))?;
+	}
+	tracing::info!("✓ All {} items bitswap-fetchable post-exhaustion", MANY_ITEMS_COUNT);
+
 	test_log!(TEST, "=== Auto-renew {} items PASSED ===", MANY_ITEMS_COUNT);
 	Ok(())
 }
@@ -1679,6 +1732,18 @@ async fn parachain_auto_renew_many_items_worst_case_test() -> Result<()> {
 		latest_store,
 		store_block_histogram.len()
 	);
+	// The worst-case PoV model requires all WORST_CASE_WORKERS=MAX_BLOCK_TRANSACTIONS stores
+	// in one block, so the renewal inherent at `block + RP + 1` re-indexes the full set in
+	// one call and exercises the per-worker `Authorizations` lookup at saturation.
+	if store_block_histogram.len() != 1 {
+		anyhow::bail!(
+			"Expected all {} stores in a single block, but they spanned {} blocks. \
+			 Histogram: {:?}",
+			WORST_CASE_WORKERS,
+			store_block_histogram.len(),
+			store_block_histogram
+		);
+	}
 
 	let pre_enable_block = current_best_block(&client).await?.number() as u64;
 	let mut enable_futs = Vec::with_capacity(content_hashes.len());
@@ -1940,6 +2005,234 @@ async fn parachain_auto_renew_many_items_worst_case_test() -> Result<()> {
 		tokio::time::sleep(std::time::Duration::from_secs(inspect_hold_secs)).await;
 	}
 
+	network.destroy().await?;
+	Ok(())
+}
+
+/// Pruning window for the many-items eviction test. Must be > `BULK_ENABLE_RETENTION_PERIOD`
+/// or the proof inherent halts when `--blocks-pruning` evicts a store-block before its
+/// `store + RP` proof block fires.
+const PRUNE_EVICTION_BLOCKS_PRUNING: u32 = 35;
+/// After item 0 evicts, the remaining items should be near-instant — col11 cleanup is
+/// batched. 30s/item bounds the test if something else goes wrong.
+const PRUNE_EVICTION_PER_ITEM_TIMEOUT_SECS: u64 = 30;
+
+/// Verify pruning evicts col11 entries for all `MANY_ITEMS_COUNT` items after auto-renewal
+/// exhausts. The bulk variant: `MANY_ITEMS_COUNT` items stored + auto-renewed by Alice.
+/// Authorization is sized for exactly one renewal cycle, so cycle 2 fails for every item
+/// and the latest col11-anchoring block is cycle 1's renewal block. Once finalized crosses
+/// that block + `PRUNE_EVICTION_BLOCKS_PRUNING`, every chunk should age out and bitswap
+/// should return DONT_HAVE for all items.
+#[tokio::test(flavor = "multi_thread")]
+async fn parachain_auto_renew_many_items_prune_eviction_test() -> Result<()> {
+	const TEST: &str = "para_auto_renew_many_prune_eviction";
+	crate::utils::init_logging();
+
+	test_log!(
+		TEST,
+		"=== Auto-renew {} items + pruning eviction (blocks-pruning={}, retention={}) ===",
+		MANY_ITEMS_COUNT,
+		PRUNE_EVICTION_BLOCKS_PRUNING,
+		BULK_ENABLE_RETENTION_PERIOD,
+	);
+
+	verify_parachain_binaries()?;
+	let config = build_parachain_network_config_three_relay_validators(
+		get_para_node_args_with_pruning(PRUNE_EVICTION_BLOCKS_PRUNING),
+	)?;
+	let network = initialize_network(config).await?;
+	network.wait_until_is_up(NETWORK_READY_TIMEOUT_SECS).await?;
+	let relay_alice = network.get_node("alice").context("relay alice")?;
+	wait_for_session_change_on_node(relay_alice, SESSION_CHANGE_TIMEOUT_SECS).await?;
+	let collator1 = network.get_node("collator-1").context("collator-1")?;
+	let client: OnlineClient<SubstrateConfig> = collator1.wait_client().await?;
+
+	let mut nonce = get_alice_nonce(collator1).await?;
+	set_retention_period(&client, BULK_ENABLE_RETENTION_PERIOD, nonce).await?;
+	nonce += 1;
+
+	// Authorization for EXACTLY one renewal cycle (so cycle 2 fails for every item, draining
+	// `AutoRenewals` and leaving the chain idle for the pruning wait).
+	let bytes_per_item = TEST_DATA_SIZE as u64;
+	let bytes_allowance = bytes_per_item * MANY_ITEMS_COUNT as u64;
+	let transactions_allowance = MANY_ITEMS_COUNT * 2; // 1 store + 1 renewal each
+	override_alice_authorization(
+		&client,
+		AuthorizationOverride {
+			transactions: 0,
+			transactions_allowance,
+			bytes: 0,
+			bytes_permanent: 0,
+			bytes_allowance,
+			expiration: u32::MAX,
+		},
+		nonce,
+	)
+	.await?;
+	nonce += 1;
+
+	let items: Vec<Vec<u8>> = (0..MANY_ITEMS_COUNT)
+		.map(|i| {
+			let mut pattern = b"AUTO_RENEW_PRUNE_EVICTION_".to_vec();
+			pattern.extend_from_slice(format!("{:04}_", i).as_bytes());
+			generate_test_data(TEST_DATA_SIZE, &pattern)
+		})
+		.collect();
+	let content_hashes: Vec<[u8; 32]> = items.iter().map(|d| blake2_256(d)).collect();
+
+	// Submit MANY_ITEMS_COUNT stores in parallel.
+	let alice = dev::alice();
+	let pre_store_block = current_best_block(&client).await?.number() as u64;
+	tracing::info!("Submitting {} stores (pre-block={})", MANY_ITEMS_COUNT, pre_store_block);
+	let mut store_futs = Vec::with_capacity(items.len());
+	for (i, data) in items.iter().enumerate() {
+		let call = tx("TransactionStorage", "store", vec![Value::from_bytes(data)]);
+		let params = SubstrateExtrinsicParamsBuilder::new().nonce(nonce + i as u64).build();
+		let signer = alice.clone();
+		let cli = client.clone();
+		store_futs.push(async move {
+			cli.tx()
+				.sign_and_submit(&call, &signer, params)
+				.await
+				.map_err(anyhow::Error::from)
+		});
+	}
+	nonce += MANY_ITEMS_COUNT as u64;
+	let _: Vec<subxt::utils::H256> = futures::future::try_join_all(store_futs).await?;
+	tracing::info!("All {} stores accepted into pool", MANY_ITEMS_COUNT);
+
+	// Wait for stores to land on best chain. Capture a histogram so we can assert all
+	// MANY_ITEMS_COUNT = MAX_BLOCK_TRANSACTIONS stores landed in a single block — the test
+	// premise is that the on-init renewal at `block + RP + 1` re-indexes the full set in
+	// one inherent call.
+	let store_inclusion_target = pre_store_block + 5;
+	wait_for_block_height(collator1, store_inclusion_target, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	let mut store_block_histogram: HashMap<u64, u32> = HashMap::new();
+	{
+		let mut current = current_best_block(&client).await?;
+		while current.number() as u64 > pre_store_block {
+			let block_n = current.number() as u64;
+			let events = current.events().await?;
+			let stored_count = events
+				.iter()
+				.filter_map(|e| e.ok())
+				.filter(|e| e.pallet_name() == "TransactionStorage" && e.variant_name() == "Stored")
+				.count() as u32;
+			if stored_count > 0 {
+				store_block_histogram.insert(block_n, stored_count);
+			}
+			if block_n == 0 {
+				break;
+			}
+			let parent_hash = current.header().parent_hash;
+			current = client.blocks().at(parent_hash).await?;
+		}
+	}
+	let total_stored: u32 = store_block_histogram.values().sum();
+	if total_stored != MANY_ITEMS_COUNT {
+		anyhow::bail!(
+			"Expected {} Stored events, found {}. Histogram: {:?}",
+			MANY_ITEMS_COUNT,
+			total_stored,
+			store_block_histogram
+		);
+	}
+	if store_block_histogram.len() != 1 {
+		anyhow::bail!(
+			"Expected all {} stores in a single block (= MAX_BLOCK_TRANSACTIONS), but they \
+			 spanned {} blocks. Histogram: {:?}",
+			MANY_ITEMS_COUNT,
+			store_block_histogram.len(),
+			store_block_histogram
+		);
+	}
+	let latest_store = *store_block_histogram.keys().next().unwrap();
+	tracing::info!("All {} stores landed at block {}", MANY_ITEMS_COUNT, latest_store);
+
+	// Submit MANY_ITEMS_COUNT enable_auto_renew in parallel.
+	let mut enable_futs = Vec::with_capacity(content_hashes.len());
+	for (i, content_hash) in content_hashes.iter().enumerate() {
+		let call = tx(
+			"TransactionStorage",
+			"enable_auto_renew",
+			vec![Value::from_bytes(content_hash.as_slice())],
+		);
+		let params = SubstrateExtrinsicParamsBuilder::new().nonce(nonce + i as u64).build();
+		let signer = alice.clone();
+		let cli = client.clone();
+		enable_futs.push(async move {
+			cli.tx()
+				.sign_and_submit(&call, &signer, params)
+				.await
+				.map_err(anyhow::Error::from)
+		});
+	}
+	nonce += MANY_ITEMS_COUNT as u64;
+	let _: Vec<subxt::utils::H256> = futures::future::try_join_all(enable_futs).await?;
+	let _ = nonce;
+	tracing::info!("All {} enable_auto_renew calls accepted into pool", MANY_ITEMS_COUNT);
+
+	// Sanity: at least 1 AutoRenewalEnabled event must appear before items expire. If 0,
+	// fail fast — pruning_window > RP timing got broken.
+	let cadence = BULK_ENABLE_RETENTION_PERIOD as u64 + 1;
+	let cycle1_block = latest_store + cadence;
+	let exhaustion_block = cycle1_block + cadence;
+	let pruning_eligible_finalized = cycle1_block + PRUNE_EVICTION_BLOCKS_PRUNING as u64 + 5;
+	tracing::info!(
+		"cycle1={}, exhaustion={}, wait_finalized={} (last_renewal + pruning + 5)",
+		cycle1_block,
+		exhaustion_block,
+		pruning_eligible_finalized
+	);
+
+	// Wait for finalized to cross the pruning boundary of the cycle-1 renewal block. By then,
+	// cycle 2 has fired and failed for every item (exhausted authorization), and the chain
+	// has been idle from `AutoRenewals` for a while — col11 cleanup has had time to run.
+	// Custom timeout: pruning_eligible_finalized is ~71 blocks past store (cadence + pruning
+	// + buffer); at 6s/block + finality lag this is ~7-8 min, more than the default 300s.
+	const LONG_FINALIZED_WAIT_SECS: u64 = 600;
+	wait_for_finalized_height(collator1, pruning_eligible_finalized, LONG_FINALIZED_WAIT_SECS)
+		.await?;
+
+	// First item: full timeout — col11 async cleanup may lag the finalized-height metric
+	// crossing by tens of seconds (paseo CI observed up to ~5min in the worst case).
+	expect_bitswap_dont_have(
+		collator1,
+		&items[0],
+		BITSWAP_EVICTION_TIMEOUT_SECS,
+		&format!("item 1/{}", MANY_ITEMS_COUNT),
+	)
+	.await
+	.context(
+		"first item never evicted — col11 cleanup isn't propagating past pruning, indicates \
+		 a refcount/release bug or pruning isn't actually firing for the renewal block",
+	)?;
+
+	// Once the first item evicts, the rest should be fast (cleanup is batched). 30s per
+	// remaining item bounds the test if something else goes wrong.
+	tracing::info!(
+		"Verifying eviction of remaining {} items (short timeout each)...",
+		MANY_ITEMS_COUNT - 1
+	);
+	for (i, data) in items.iter().enumerate().skip(1) {
+		expect_bitswap_dont_have(
+			collator1,
+			data,
+			PRUNE_EVICTION_PER_ITEM_TIMEOUT_SECS,
+			&format!("item {}/{}", i + 1, MANY_ITEMS_COUNT),
+		)
+		.await
+		.with_context(|| {
+			format!(
+				"item {} still served after item 0 was evicted — partial col11 cleanup is a \
+				 stronger smoking-gun than full failure",
+				i
+			)
+		})?;
+	}
+	tracing::info!("✓ All {} items evicted via bitswap DONT_HAVE", MANY_ITEMS_COUNT);
+
+	test_log!(TEST, "=== Auto-renew {} items + pruning eviction PASSED ===", MANY_ITEMS_COUNT);
 	network.destroy().await?;
 	Ok(())
 }

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -10,9 +10,9 @@ use crate::{
 		authorize_account_via_sudo, authorize_account_via_sudo_finalized, authorize_and_store_data,
 		blake2_256, build_parachain_network_config_three_relay_validators, content_hash_and_cid,
 		count_event, disable_auto_renew, enable_auto_renew, expect_bitswap_dont_have,
-		finalized_store_block_for_hash, generate_test_data, get_alice_nonce, initialize_network,
-		override_alice_authorization, set_retention_period, set_retention_period_finalized,
-		submit_renew_pair, submit_store_signed, top_up_alice_authorization, verify_node_bitswap,
+		generate_test_data, get_alice_nonce, initialize_network, override_alice_authorization,
+		set_retention_period, set_retention_period_finalized, submit_renew_pair,
+		submit_store_signed, top_up_alice_authorization, verify_node_bitswap,
 		verify_parachain_binaries, wait_for_block_height, wait_for_finalized_height,
 		wait_for_finalized_quiescence, wait_for_session_change_on_node, AuthorizationOverride,
 		BLOCK_PRODUCTION_TIMEOUT_SECS, NETWORK_READY_TIMEOUT_SECS, NODE_LOG_CONFIG,
@@ -743,20 +743,16 @@ async fn parachain_auto_renew_vs_no_renew_eviction_test() -> Result<()> {
 	let (store_block, next_nonce) =
 		authorize_and_store_data(collator1, &data_renewed, nonce).await?;
 	nonce = next_nonce;
-	tracing::info!("data_renewed stored at block {} (best, pre-finality)", store_block);
+	tracing::info!("data_renewed stored at block {}", store_block);
 
 	top_up_alice_authorization(client, 5, 4 * data_renewed.len() as u64, nonce).await?;
 	nonce += 1;
 
 	let data_not_renewed_block = submit_store_signed(client, &data_not_renewed, nonce).await?;
 	nonce += 1;
-	tracing::info!(
-		"data_not_renewed stored at block {} (best, pre-finality)",
-		data_not_renewed_block
-	);
+	tracing::info!("data_not_renewed stored at block {}", data_not_renewed_block);
 
 	let content_hash_renewed = blake2_256(&data_renewed);
-	let content_hash_not_renewed = blake2_256(&data_not_renewed);
 	enable_auto_renew(client, &content_hash_renewed, nonce).await?;
 	tracing::info!("Auto-renewal enabled for data_renewed");
 
@@ -785,19 +781,6 @@ async fn parachain_auto_renew_vs_no_renew_eviction_test() -> Result<()> {
 		store_block
 	);
 	wait_for_finalized_height(collator1, wait_until, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
-
-	// Re-resolve canonical store blocks from the finalized chain — if a reorg between
-	// best-inclusion and finality moved either store to a different block, the captured
-	// best-chain numbers above would point at orphans and `assert_proof_checked_at` would
-	// read the wrong finalized block.
-	let store_block = finalized_store_block_for_hash(client, &content_hash_renewed).await?;
-	let data_not_renewed_block =
-		finalized_store_block_for_hash(client, &content_hash_not_renewed).await?;
-	tracing::info!(
-		"Canonical (finalized) store blocks: data_renewed={}, data_not_renewed={}",
-		store_block,
-		data_not_renewed_block
-	);
 
 	// Proof for each store-block (one per store, since they landed in different blocks)
 	// fires at `block + RP`. Single ProofChecked event per source-block.

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -77,13 +77,16 @@ const HALT_DETECTION_TIMEOUT_SECS: u64 = 120;
 /// enough for pruning to actually evict col11. Bumping retention to 20 pushes the proof
 /// block out past the (finality + pruning) lag so col11 is reliably empty.
 const RETENTION_PERIOD_FOR_PRUNING_HALT: u32 = 20;
-/// Tests that submit a bulk batch of `enable_auto_renew` after `wait_for_finalized_height`
-/// on the store block (`parachain_on_initialize_cleanup_test`,
-/// `parachain_auto_renew_many_items_test`, `parachain_auto_renew_many_items_worst_case_test`)
-/// race finality lag. On CI, lag is commonly ~6-10 blocks, which pushes best past
-/// `store_block + RP` before enables get submitted; the enables then land in a block where
-/// `Transactions[store_block]` has already been swept and every dispatch returns
-/// `RenewedNotFound`. RP=30 gives ~15-block margin over the observed lag.
+/// Standalone tests that submit a bulk batch of `enable_auto_renew` after
+/// `wait_for_finalized_height` on the store block (`parachain_on_initialize_cleanup_test`,
+/// `parachain_auto_renew_many_items_worst_case_test`) race finality lag. On CI, lag is
+/// commonly ~6-10 blocks, which pushes best past `store_block + RP` before enables get
+/// submitted; the enables then land in a block where `Transactions[store_block]` has already
+/// been swept and every dispatch returns `RenewedNotFound`. RP=30 gives ~15-block margin.
+///
+/// `parachain_auto_renew_many_items_test` shares `archive_harness` with siblings and can't
+/// safely bump RP mid-chain (prior tests' stored data + new RP produces an inherent/proof
+/// mismatch and finality halts), so it stays on `RETENTION_PERIOD` and accepts the risk.
 const BULK_ENABLE_RETENTION_PERIOD: u32 = 30;
 const MANY_ITEMS_COUNT: u32 = pallet_bulletin_transaction_storage::DEFAULT_MAX_BLOCK_TRANSACTIONS;
 const RENEWAL_CYCLES_TO_OBSERVE: u32 = 3;
@@ -840,13 +843,6 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 
 	let mut nonce = get_alice_nonce(collator1).await?;
 
-	// Bump RP locally: the shared archive_harness initializes RP=RETENTION_PERIOD, but the
-	// bulk `store → wait_for_finalized → enable` flow needs extra headroom over finality lag
-	// (see `BULK_ENABLE_RETENTION_PERIOD`). Restored at the success path below so siblings
-	// in the archive group still observe RETENTION_PERIOD.
-	set_retention_period(client, BULK_ENABLE_RETENTION_PERIOD, nonce).await?;
-	nonce += 1;
-
 	// Overwrite the Authorizations entry so cycle N+1 reliably trips
 	// `PERMANENT_ALLOWANCE_EXCEEDED` (drains `AutoRenewals`, leaving the shared harness idle).
 	// `authorize_account` is additive on the unexpired path, so it can't shrink the existing
@@ -1079,7 +1075,7 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 
 	// Pairwise diffs of `substrate_proposer_block_constructed_{sum,count}` give per-block
 	// wall-clock construction time, independent of the runtime's declared weight.
-	let renewal_cadence = BULK_ENABLE_RETENTION_PERIOD as u64 + 1;
+	let renewal_cadence = RETENTION_PERIOD as u64 + 1;
 	let first_renewal_block = earliest_store + renewal_cadence;
 	let last_renewal_block = latest_store + renewal_cadence * RENEWAL_CYCLES_TO_OBSERVE as u64;
 	let wait_until = last_renewal_block + 1;
@@ -1348,10 +1344,6 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 		exhaustion_block,
 		exhaustion_block + 1,
 	);
-
-	// Restore RP so sibling tests in the archive_harness group see RETENTION_PERIOD.
-	let restore_nonce = get_alice_nonce(collator1).await?;
-	set_retention_period(client, RETENTION_PERIOD, restore_nonce).await?;
 
 	test_log!(TEST, "=== Auto-renew {} items PASSED ===", MANY_ITEMS_COUNT);
 	Ok(())

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -182,10 +182,21 @@ async fn spawn_shared_harness(
 }
 
 fn get_para_node_args_with_pruning(blocks_pruning: u32) -> Vec<String> {
+	// Extends NODE_LOG_CONFIG with pruning-side targets so a "bitswap still has data after
+	// pruning should have fired" failure has the corresponding node events to read:
+	//   - `db=debug`: `Removing block #N` from sc-client-db::prune_block (the
+	//     pruning-actually-fired confirmation)
+	//   - `state-db=debug` / `state-db::pin=debug`: canonicalization + pin/unpin
+	// (Node uses RocksDB — `parity-db` target would never fire.)
+	let log_targets = format!(
+		"{},db=debug,state-db=debug,state-db::pin=debug",
+		// Strip the leading "-l" so we can append more comma-separated targets.
+		NODE_LOG_CONFIG.strip_prefix("-l").unwrap_or(NODE_LOG_CONFIG)
+	);
 	vec![
 		"--ipfs-server".into(),
 		format!("--blocks-pruning={}", blocks_pruning),
-		NODE_LOG_CONFIG.into(),
+		format!("-l{}", log_targets),
 		"--".into(),
 		"--network-backend=libp2p".into(),
 	]

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -77,6 +77,14 @@ const HALT_DETECTION_TIMEOUT_SECS: u64 = 120;
 /// enough for pruning to actually evict col11. Bumping retention to 20 pushes the proof
 /// block out past the (finality + pruning) lag so col11 is reliably empty.
 const RETENTION_PERIOD_FOR_PRUNING_HALT: u32 = 20;
+/// Tests that submit a bulk batch of `enable_auto_renew` after `wait_for_finalized_height`
+/// on the store block (`parachain_on_initialize_cleanup_test`,
+/// `parachain_auto_renew_many_items_test`, `parachain_auto_renew_many_items_worst_case_test`)
+/// race finality lag. On CI, lag is commonly ~6-10 blocks, which pushes best past
+/// `store_block + RP` before enables get submitted; the enables then land in a block where
+/// `Transactions[store_block]` has already been swept and every dispatch returns
+/// `RenewedNotFound`. RP=30 gives ~15-block margin over the observed lag.
+const BULK_ENABLE_RETENTION_PERIOD: u32 = 30;
 const MANY_ITEMS_COUNT: u32 = pallet_bulletin_transaction_storage::DEFAULT_MAX_BLOCK_TRANSACTIONS;
 const RENEWAL_CYCLES_TO_OBSERVE: u32 = 3;
 
@@ -832,6 +840,13 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 
 	let mut nonce = get_alice_nonce(collator1).await?;
 
+	// Bump RP locally: the shared archive_harness initializes RP=RETENTION_PERIOD, but the
+	// bulk `store → wait_for_finalized → enable` flow needs extra headroom over finality lag
+	// (see `BULK_ENABLE_RETENTION_PERIOD`). Restored at the success path below so siblings
+	// in the archive group still observe RETENTION_PERIOD.
+	set_retention_period(client, BULK_ENABLE_RETENTION_PERIOD, nonce).await?;
+	nonce += 1;
+
 	// Overwrite the Authorizations entry so cycle N+1 reliably trips
 	// `PERMANENT_ALLOWANCE_EXCEEDED` (drains `AutoRenewals`, leaving the shared harness idle).
 	// `authorize_account` is additive on the unexpired path, so it can't shrink the existing
@@ -1064,7 +1079,7 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 
 	// Pairwise diffs of `substrate_proposer_block_constructed_{sum,count}` give per-block
 	// wall-clock construction time, independent of the runtime's declared weight.
-	let renewal_cadence = RETENTION_PERIOD as u64 + 1;
+	let renewal_cadence = BULK_ENABLE_RETENTION_PERIOD as u64 + 1;
 	let first_renewal_block = earliest_store + renewal_cadence;
 	let last_renewal_block = latest_store + renewal_cadence * RENEWAL_CYCLES_TO_OBSERVE as u64;
 	let wait_until = last_renewal_block + 1;
@@ -1334,6 +1349,10 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 		exhaustion_block + 1,
 	);
 
+	// Restore RP so sibling tests in the archive_harness group see RETENTION_PERIOD.
+	let restore_nonce = get_alice_nonce(collator1).await?;
+	set_retention_period(client, RETENTION_PERIOD, restore_nonce).await?;
+
 	test_log!(TEST, "=== Auto-renew {} items PASSED ===", MANY_ITEMS_COUNT);
 	Ok(())
 }
@@ -1369,8 +1388,8 @@ async fn parachain_auto_renew_many_items_worst_case_test() -> Result<()> {
 	let client: OnlineClient<SubstrateConfig> = collator1.wait_client().await?;
 
 	let mut alice_nonce = get_alice_nonce(collator1).await?;
-	tracing::info!("Setting RetentionPeriod to {} blocks", RETENTION_PERIOD);
-	set_retention_period(&client, RETENTION_PERIOD, alice_nonce).await?;
+	tracing::info!("Setting RetentionPeriod to {} blocks", BULK_ENABLE_RETENTION_PERIOD);
+	set_retention_period(&client, BULK_ENABLE_RETENTION_PERIOD, alice_nonce).await?;
 	alice_nonce += 1;
 
 	let workers: Vec<Keypair> = (0..WORST_CASE_WORKERS)
@@ -1598,7 +1617,7 @@ async fn parachain_auto_renew_many_items_worst_case_test() -> Result<()> {
 	wait_for_finalized_height(collator1, enable_inclusion_target, BLOCK_PRODUCTION_TIMEOUT_SECS)
 		.await?;
 
-	let renewal_cadence = RETENTION_PERIOD as u64 + 1;
+	let renewal_cadence = BULK_ENABLE_RETENTION_PERIOD as u64 + 1;
 	let first_renewal_block = earliest_store + renewal_cadence;
 	let last_renewal_block = latest_store + renewal_cadence * RENEWAL_CYCLES_TO_OBSERVE as u64;
 	let wait_until = last_renewal_block + 1;
@@ -1867,7 +1886,7 @@ async fn parachain_on_initialize_cleanup_test() -> Result<()> {
 	let client: OnlineClient<SubstrateConfig> = collator1.wait_client().await?;
 
 	let mut nonce = get_alice_nonce(collator1).await?;
-	set_retention_period(&client, RETENTION_PERIOD, nonce).await?;
+	set_retention_period(&client, BULK_ENABLE_RETENTION_PERIOD, nonce).await?;
 	nonce += 1;
 
 	let bytes_per_item = TEST_DATA_SIZE as u64;
@@ -1981,28 +2000,31 @@ async fn parachain_on_initialize_cleanup_test() -> Result<()> {
 
 	// Verify every enable_auto_renew landed before the items expire. If the test's pre-enable
 	// finality wait gives the chain time to advance past `store_block + RP`, enables would
-	// silently fail (the item has already expired) → no renewals → assertion below sees 0/N.
+	// fail with `RenewedNotFound` (the item has already expired) → no renewals → assertion
+	// below sees 0/N. We also count `frame_system::ExtrinsicFailed` so the diagnostic
+	// distinguishes "enables never landed" from "enables landed but were rejected".
 	wait_for_finalized_height(collator1, pre_enable_block + 5, BLOCK_PRODUCTION_TIMEOUT_SECS)
 		.await?;
 	let mut enabled_count = 0usize;
+	let mut extrinsic_failed_count = 0usize;
 	let mut latest_enable_block = pre_enable_block;
 	{
 		let mut current = current_finalized_block(&client).await?;
 		while current.number() as u64 > pre_enable_block {
 			let block_n = current.number() as u64;
 			let events = current.events().await?;
-			let count = events
-				.iter()
-				.filter_map(|e| e.ok())
-				.filter(|e| {
-					e.pallet_name() == "TransactionStorage" &&
-						e.variant_name() == "AutoRenewalEnabled"
-				})
-				.count();
-			if count > 0 && block_n > latest_enable_block {
-				latest_enable_block = block_n;
+			for ev in events.iter().filter_map(|e| e.ok()) {
+				if ev.pallet_name() == "TransactionStorage" &&
+					ev.variant_name() == "AutoRenewalEnabled"
+				{
+					enabled_count += 1;
+					if block_n > latest_enable_block {
+						latest_enable_block = block_n;
+					}
+				} else if ev.pallet_name() == "System" && ev.variant_name() == "ExtrinsicFailed" {
+					extrinsic_failed_count += 1;
+				}
 			}
-			enabled_count += count;
 			if block_n == 0 {
 				break;
 			}
@@ -2012,10 +2034,12 @@ async fn parachain_on_initialize_cleanup_test() -> Result<()> {
 	}
 	if enabled_count != ON_INIT_CLEANUP_ITEMS_PER_SET as usize {
 		anyhow::bail!(
-			"Expected {} AutoRenewalEnabled events, found {} (latest enable at block {})",
+			"Expected {} AutoRenewalEnabled events, found {} (latest enable at block {}, \
+			 {} ExtrinsicFailed events observed in same window)",
 			ON_INIT_CLEANUP_ITEMS_PER_SET,
 			enabled_count,
-			latest_enable_block
+			latest_enable_block,
+			extrinsic_failed_count
 		);
 	}
 	tracing::info!(
@@ -2026,22 +2050,22 @@ async fn parachain_on_initialize_cleanup_test() -> Result<()> {
 	// Renewal at `n = store_block + RP + 1` is driven by `on_initialize`, which reads
 	// `AutoRenewals` *before* any extrinsics in block `n`. So enables must be in a block
 	// ≤ `store_block + RP` — strict equality is fine.
-	if latest_enable_block > store_block + RETENTION_PERIOD as u64 {
+	if latest_enable_block > store_block + BULK_ENABLE_RETENTION_PERIOD as u64 {
 		anyhow::bail!(
 			"Auto-renew enables landed at block {} > store_block ({}) + RP ({}); items would \
 			 already be expired. Need a longer RP or earlier enables for this test to be valid.",
 			latest_enable_block,
 			store_block,
-			RETENTION_PERIOD
+			BULK_ENABLE_RETENTION_PERIOD
 		);
 	}
 
-	let expiry_block = store_block + RETENTION_PERIOD as u64 + 1;
+	let expiry_block = store_block + BULK_ENABLE_RETENTION_PERIOD as u64 + 1;
 	tracing::info!(
 		"Waiting for expiry block {} (= store_block {} + RP {} + 1)",
 		expiry_block,
 		store_block,
-		RETENTION_PERIOD
+		BULK_ENABLE_RETENTION_PERIOD
 	);
 	wait_for_finalized_height(collator1, expiry_block + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
 

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -58,8 +58,9 @@ const SESSION_CHANGE_TIMEOUT_SECS: u64 = 300;
 const RETENTION_PERIOD: u32 = 10;
 const BITSWAP_TIMEOUT_SECS: u64 = 30;
 /// `--blocks-pruning` deletion + col11 refcount-zero cleanup runs asynchronously after the
-/// finalized-height metric crosses; under CI load that lag can be tens of seconds.
-const BITSWAP_EVICTION_TIMEOUT_SECS: u64 = 180;
+/// finalized-height metric crosses; under CI load that lag can be tens of seconds (paseo runs
+/// observed >180s before eviction). 300s gives margin without making fast-cleanup runs slow.
+const BITSWAP_EVICTION_TIMEOUT_SECS: u64 = 300;
 
 const NUM_RENEWAL_CYCLES: u64 = 2;
 const TOPUP_TX_COUNT: u32 = 5;
@@ -683,6 +684,10 @@ async fn parachain_auto_renew_with_concurrent_store_test() -> Result<()> {
 	}
 
 	// Submit data2 at R-1 so it lands in the renewal block R = S + RetentionPeriod + 1.
+	// Tx propagation + block-author timing on slower CI sometimes pushes data2 to R+1; the
+	// test still exercises the intended pruning behaviour (a new store landing inside the
+	// auto-renew cadence) — same-block coexistence is the happy path, but we tolerate ±1
+	// and recompute the downstream block math from the observed `data2_block`.
 	let renewal_block = store_block + RETENTION_PERIOD as u64 + 1;
 	let wait_until_pre_renewal = renewal_block - 1;
 	tracing::info!(
@@ -693,20 +698,21 @@ async fn parachain_auto_renew_with_concurrent_store_test() -> Result<()> {
 	wait_for_block_height(collator1, wait_until_pre_renewal, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
 
 	let data2_block = submit_store_signed(client, &data2, nonce).await?;
-	tracing::info!("data2 store landed at block {}", data2_block);
-	if data2_block != renewal_block {
-		anyhow::bail!(
-			"Timing missed: expected data2 to land in renewal block {}, but it landed at \
-			 block {}. Re-run the test, or adjust the wait_until math if this is consistent.",
-			renewal_block,
-			data2_block
+	if data2_block == renewal_block {
+		tracing::info!(
+			"✓ data2 store and auto-renewal inherent coexist in block {}",
+			renewal_block
+		);
+	} else {
+		tracing::warn!(
+			"data2 landed at block {} (expected renewal block {}); proceeding with adjusted \
+			 pruning math",
+			data2_block,
+			renewal_block
 		);
 	}
-	tracing::info!("✓ data2 store and auto-renewal inherent coexist in block {}", renewal_block);
 
-	// Proof for data1's store-block lands at `store_block + RP` = `renewal_block - 1`. data2
-	// landed in the renewal block itself, so its proof block is `renewal_block + RP` (asserted
-	// after the wait_for_finalized_height below).
+	// Proof for data1's store-block lands at `store_block + RP` = `renewal_block - 1`.
 	assert_proof_checked_at(client, store_block + RETENTION_PERIOD as u64, "post-store data1")
 		.await?;
 
@@ -714,22 +720,23 @@ async fn parachain_auto_renew_with_concurrent_store_test() -> Result<()> {
 	verify_node_bitswap(collator1, &data2, BITSWAP_TIMEOUT_SECS, "Collator-1 / data2").await?;
 
 	// Pruning fires off FINALIZED head — wait on finalized to cross the boundary directly.
-	let after_renewal_pruned_finalized =
-		renewal_block + BLOCKS_PRUNING_GREATER_THAN_RETENTION as u64 + 1;
+	// Use the later of the two refcounted blocks (renewal_block holds data1's renewed entry,
+	// data2_block holds data2). Both must be past the pruning window for col11 cleanup.
+	let last_refcounted_block = renewal_block.max(data2_block);
+	let after_pruning_finalized =
+		last_refcounted_block + BLOCKS_PRUNING_GREATER_THAN_RETENTION as u64 + 1;
 	tracing::info!(
-		"Waiting for FINALIZED block {} so the renewal block is past the pruning boundary",
-		after_renewal_pruned_finalized
+		"Waiting for FINALIZED block {} so renewal_block={} and data2_block={} are past pruning",
+		after_pruning_finalized,
+		renewal_block,
+		data2_block
 	);
-	wait_for_finalized_height(
-		collator1,
-		after_renewal_pruned_finalized,
-		BLOCK_PRODUCTION_TIMEOUT_SECS,
-	)
-	.await?;
+	wait_for_finalized_height(collator1, after_pruning_finalized, BLOCK_PRODUCTION_TIMEOUT_SECS)
+		.await?;
 
-	// Proof for the renewal-block's contents (data1's renewal + data2's store) lands at
-	// `renewal_block + RP`. Both items were indexed in Transactions[renewal_block].
-	assert_proof_checked_at(client, renewal_block + RETENTION_PERIOD as u64, "post-renewal-block")
+	// Proof for data2's stored block fires at `data2_block + RP`. When data2 == renewal_block,
+	// this is also the proof block for data1's renewed entry (same block).
+	assert_proof_checked_at(client, data2_block + RETENTION_PERIOD as u64, "post-data2-block")
 		.await?;
 
 	expect_bitswap_dont_have(

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -11,8 +11,8 @@ use crate::{
 		blake2_256, build_parachain_network_config_three_relay_validators, content_hash_and_cid,
 		count_event, disable_auto_renew, enable_auto_renew, expect_bitswap_dont_have,
 		generate_test_data, get_alice_nonce, initialize_network, override_alice_authorization,
-		set_retention_period, set_retention_period_finalized, submit_renew_pair,
-		submit_store_signed, top_up_alice_authorization, verify_node_bitswap,
+		resolve_canonical_store_block, set_retention_period, set_retention_period_finalized,
+		submit_renew_pair, submit_store_signed, top_up_alice_authorization, verify_node_bitswap,
 		verify_parachain_binaries, wait_for_block_height, wait_for_finalized_height,
 		wait_for_finalized_quiescence, wait_for_session_change_on_node, AuthorizationOverride,
 		BLOCK_PRODUCTION_TIMEOUT_SECS, NETWORK_READY_TIMEOUT_SECS, NODE_LOG_CONFIG,
@@ -276,8 +276,8 @@ async fn parachain_auto_renew_test() -> Result<()> {
 	tracing::info!("Test data: {} bytes, hash={}, CID={}", data.len(), hash_hex, cid);
 
 	let nonce = get_alice_nonce(collator1).await?;
-	let (store_block, mut nonce) = authorize_and_store_data(collator1, &data, nonce).await?;
-	tracing::info!("Data stored at block {}", store_block);
+	let (best_store_block, mut nonce) = authorize_and_store_data(collator1, &data, nonce).await?;
+	tracing::info!("Data stored at best-chain block {}", best_store_block);
 
 	verify_node_bitswap(collator1, &data, BITSWAP_TIMEOUT_SECS, "Collator-1 (post-store)").await?;
 
@@ -294,6 +294,23 @@ async fn parachain_auto_renew_test() -> Result<()> {
 	enable_auto_renew(client, &content_hash, nonce).await?;
 	nonce += 1;
 	tracing::info!("Auto-renewal enabled for content_hash {}", hash_hex);
+
+	// Re-anchor `store_block` against the finalized chain — `authorize_and_store_data` reads
+	// the canonical block at the best-block inclusion hash, which a reorg between inclusion
+	// and finality can leave pointing at an orphan. All cycle math + `assert_proof_checked_at`
+	// reads downstream are gated on the finalized chain, so they need the finalized value.
+	wait_for_finalized_height(collator1, best_store_block + 2, BLOCK_PRODUCTION_TIMEOUT_SECS)
+		.await?;
+	let store_block =
+		resolve_canonical_store_block(client, &content_hash, best_store_block.saturating_sub(3))
+			.await?;
+	if store_block != best_store_block {
+		tracing::info!(
+			"Canonical store block on finalized chain is {} (best-chain reported {})",
+			store_block,
+			best_store_block
+		);
+	}
 
 	// Renewal cadence is `RP + 1`; wait one extra block so the inherent is observable.
 	let cadence = RETENTION_PERIOD as u64 + 1;
@@ -740,19 +757,20 @@ async fn parachain_auto_renew_vs_no_renew_eviction_test() -> Result<()> {
 	let data_renewed = generate_test_data(TEST_DATA_SIZE, b"DATA_VS_NO_RENEW_RENEWED_");
 	let data_not_renewed = generate_test_data(TEST_DATA_SIZE, b"DATA_VS_NO_RENEW_NOT_RENEWED_");
 
-	let (store_block, next_nonce) =
+	let (best_store_block, next_nonce) =
 		authorize_and_store_data(collator1, &data_renewed, nonce).await?;
 	nonce = next_nonce;
-	tracing::info!("data_renewed stored at block {}", store_block);
+	tracing::info!("data_renewed stored at best-chain block {}", best_store_block);
 
 	top_up_alice_authorization(client, 5, 4 * data_renewed.len() as u64, nonce).await?;
 	nonce += 1;
 
-	let data_not_renewed_block = submit_store_signed(client, &data_not_renewed, nonce).await?;
+	let best_data_not_renewed_block = submit_store_signed(client, &data_not_renewed, nonce).await?;
 	nonce += 1;
-	tracing::info!("data_not_renewed stored at block {}", data_not_renewed_block);
+	tracing::info!("data_not_renewed stored at best-chain block {}", best_data_not_renewed_block);
 
 	let content_hash_renewed = blake2_256(&data_renewed);
+	let content_hash_not_renewed = blake2_256(&data_not_renewed);
 	enable_auto_renew(client, &content_hash_renewed, nonce).await?;
 	tracing::info!("Auto-renewal enabled for data_renewed");
 
@@ -774,13 +792,34 @@ async fn parachain_auto_renew_vs_no_renew_eviction_test() -> Result<()> {
 
 	// Pruning is gated on FINALIZED crossing store_block + RP; +5 buffer covers the async
 	// col11 refcount cleanup that follows pruning.
-	let wait_until = store_block + RETENTION_PERIOD as u64 + 5;
+	let wait_until = best_store_block + RETENTION_PERIOD as u64 + 5;
 	tracing::info!(
 		"Waiting for FINALIZED block {} (store + RP + 5) so block {} is pruned",
 		wait_until,
-		store_block
+		best_store_block
 	);
 	wait_for_finalized_height(collator1, wait_until, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+
+	// Re-anchor both store blocks on the finalized chain: a reorg between best-block
+	// inclusion and finality can leave the captured best-chain numbers pointing at orphans
+	// while the assertions below read the finalized chain.
+	let store_block = resolve_canonical_store_block(
+		client,
+		&content_hash_renewed,
+		best_store_block.saturating_sub(3),
+	)
+	.await?;
+	let data_not_renewed_block = resolve_canonical_store_block(
+		client,
+		&content_hash_not_renewed,
+		best_data_not_renewed_block.saturating_sub(3),
+	)
+	.await?;
+	tracing::info!(
+		"Canonical (finalized) store blocks: data_renewed={}, data_not_renewed={}",
+		store_block,
+		data_not_renewed_block
+	);
 
 	// Proof for each store-block (one per store, since they landed in different blocks)
 	// fires at `block + RP`. Single ProofChecked event per source-block.

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -761,14 +761,15 @@ async fn parachain_auto_renew_vs_no_renew_eviction_test() -> Result<()> {
 	.await?;
 	tracing::info!("✓ Both items fetchable shortly after upload");
 
-	// Pruning fires off FINALIZED head; with ~3-5 block finality lag, S + RP + 15 is past it.
-	let wait_until = store_block + RETENTION_PERIOD as u64 + 15;
+	// Pruning is gated on FINALIZED crossing store_block + RP; +5 buffer covers the async
+	// col11 refcount cleanup that follows pruning.
+	let wait_until = store_block + RETENTION_PERIOD as u64 + 5;
 	tracing::info!(
-		"Waiting for block {} (store + RP + 15) so block {} is pruned",
+		"Waiting for FINALIZED block {} (store + RP + 5) so block {} is pruned",
 		wait_until,
 		store_block
 	);
-	wait_for_block_height(collator1, wait_until, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	wait_for_finalized_height(collator1, wait_until, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
 
 	// Proof for each store-block (one per store, since they landed in different blocks)
 	// fires at `block + RP`. Single ProofChecked event per source-block.
@@ -922,7 +923,8 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 	}
 
 	let store_inclusion_target = pre_store_block + 5;
-	wait_for_block_height(collator1, store_inclusion_target, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	wait_for_finalized_height(collator1, store_inclusion_target, BLOCK_PRODUCTION_TIMEOUT_SECS)
+		.await?;
 
 	// Walk chain backward counting `Stored` events — avoids per-submission block lookups
 	// which race against chainHead pinning when done concurrently.
@@ -930,19 +932,19 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 		let poll_timeout = std::time::Duration::from_secs(60);
 		let start = std::time::Instant::now();
 		loop {
-			let head = current_best_block(client).await?;
+			let head = current_finalized_block(client).await?;
 			if head.number() as u64 >= store_inclusion_target {
 				break head.number() as u64;
 			}
 			if start.elapsed() > poll_timeout {
-				anyhow::bail!("Timed out waiting for at_latest >= {}", store_inclusion_target);
+				anyhow::bail!("Timed out waiting for finalized >= {}", store_inclusion_target);
 			}
 			tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 		}
 	};
 	let mut store_blocks: Vec<u64> = Vec::with_capacity(items.len());
 	{
-		let mut current = current_best_block(client).await?;
+		let mut current = current_finalized_block(client).await?;
 		while current.number() as u64 > pre_store_block {
 			let block_n = current.number() as u64;
 			let events = current.events().await?;
@@ -1014,25 +1016,25 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 	tracing::info!("All {} enable_auto_renew calls accepted into pool", MANY_ITEMS_COUNT);
 
 	let enable_inclusion_target = pre_enable_block + 5;
-	wait_for_block_height(collator1, enable_inclusion_target, BLOCK_PRODUCTION_TIMEOUT_SECS)
+	wait_for_finalized_height(collator1, enable_inclusion_target, BLOCK_PRODUCTION_TIMEOUT_SECS)
 		.await?;
 	{
 		let poll_timeout = std::time::Duration::from_secs(60);
 		let start = std::time::Instant::now();
 		loop {
-			let head = current_best_block(client).await?;
+			let head = current_finalized_block(client).await?;
 			if head.number() as u64 >= enable_inclusion_target {
 				break;
 			}
 			if start.elapsed() > poll_timeout {
-				anyhow::bail!("Timed out waiting for at_latest >= {}", enable_inclusion_target);
+				anyhow::bail!("Timed out waiting for finalized >= {}", enable_inclusion_target);
 			}
 			tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 		}
 	}
 	let mut enabled_count = 0usize;
 	{
-		let mut current = current_best_block(client).await?;
+		let mut current = current_finalized_block(client).await?;
 		while current.number() as u64 > pre_enable_block {
 			let events = current.events().await?;
 			enabled_count += events
@@ -1526,12 +1528,13 @@ async fn parachain_auto_renew_many_items_worst_case_test() -> Result<()> {
 	tracing::info!("All {} stores accepted into pool", WORST_CASE_WORKERS);
 
 	let store_inclusion_target = pre_store_block + 5;
-	wait_for_block_height(collator1, store_inclusion_target, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	wait_for_finalized_height(collator1, store_inclusion_target, BLOCK_PRODUCTION_TIMEOUT_SECS)
+		.await?;
 
-	let post_store_head_n = current_best_block(&client).await?.number() as u64;
+	let post_store_head_n = current_finalized_block(&client).await?.number() as u64;
 	let mut store_blocks: Vec<u64> = Vec::with_capacity(items.len());
 	{
-		let mut current = current_best_block(&client).await?;
+		let mut current = current_finalized_block(&client).await?;
 		while current.number() as u64 > pre_store_block {
 			let block_n = current.number() as u64;
 			let events = current.events().await?;
@@ -1592,7 +1595,7 @@ async fn parachain_auto_renew_many_items_worst_case_test() -> Result<()> {
 	tracing::info!("All {} enable_auto_renew calls accepted into pool", WORST_CASE_WORKERS);
 
 	let enable_inclusion_target = pre_enable_block + 5;
-	wait_for_block_height(collator1, enable_inclusion_target, BLOCK_PRODUCTION_TIMEOUT_SECS)
+	wait_for_finalized_height(collator1, enable_inclusion_target, BLOCK_PRODUCTION_TIMEOUT_SECS)
 		.await?;
 
 	let renewal_cadence = RETENTION_PERIOD as u64 + 1;
@@ -1647,24 +1650,8 @@ async fn parachain_auto_renew_many_items_worst_case_test() -> Result<()> {
 		);
 	}
 
-	let head = {
-		let poll_timeout = std::time::Duration::from_secs(60);
-		let start = std::time::Instant::now();
-		loop {
-			let head = current_best_block(&client).await?;
-			if head.number() as u64 >= wait_until {
-				break head;
-			}
-			if start.elapsed() > poll_timeout {
-				anyhow::bail!(
-					"Timed out waiting for at_latest() to see block {} (last seen: {})",
-					wait_until,
-					head.number()
-				);
-			}
-			tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-		}
-	};
+	wait_for_finalized_height(collator1, wait_until, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	let head = current_finalized_block(&client).await?;
 	let stats_range_start = first_renewal_block.saturating_sub(15).max(1);
 	let stats_range_end = last_renewal_block + 2;
 
@@ -1803,11 +1790,12 @@ async fn parachain_auto_renew_many_items_worst_case_test() -> Result<()> {
 		exhaustion_block,
 		last_renewal_block
 	);
-	wait_for_block_height(collator1, exhaustion_wait_until, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	wait_for_finalized_height(collator1, exhaustion_wait_until, BLOCK_PRODUCTION_TIMEOUT_SECS)
+		.await?;
 	let mut total_failed: u32 = 0;
 	let mut total_renewed_post_window: u32 = 0;
 	for n in exhaustion_block..=exhaustion_block + 1 {
-		let hash = block_hash_at(&client, n).await?;
+		let hash = finalized_block_hash_at(&client, n).await?;
 		let events = client.blocks().at(hash).await?.events().await?;
 		total_failed += count_event(&events, "AutoRenewalFailed");
 		total_renewed_post_window += count_event(&events, "DataAutoRenewed");
@@ -1937,25 +1925,12 @@ async fn parachain_on_initialize_cleanup_test() -> Result<()> {
 	let _: Vec<subxt::utils::H256> = futures::future::try_join_all(futs).await?;
 	tracing::info!("All {} stores accepted into pool", total_items);
 
-	wait_for_block_height(collator1, pre_store_block + 5, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	wait_for_finalized_height(collator1, pre_store_block + 5, BLOCK_PRODUCTION_TIMEOUT_SECS)
+		.await?;
 
 	let mut store_block: u64 = 0;
 	{
-		let poll_timeout = std::time::Duration::from_secs(60);
-		let start = std::time::Instant::now();
-		loop {
-			let head = current_best_block(&client).await?;
-			if head.number() as u64 >= pre_store_block + 5 {
-				break;
-			}
-			if start.elapsed() > poll_timeout {
-				anyhow::bail!("Timed out waiting for at_latest >= {}", pre_store_block + 5);
-			}
-			tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-		}
-	}
-	{
-		let mut current = current_best_block(&client).await?;
+		let mut current = current_finalized_block(&client).await?;
 		while current.number() as u64 > pre_store_block {
 			let block_n = current.number() as u64;
 			let events = current.events().await?;
@@ -2008,35 +1983,13 @@ async fn parachain_on_initialize_cleanup_test() -> Result<()> {
 		store_block,
 		RETENTION_PERIOD
 	);
-	wait_for_block_height(collator1, expiry_block + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	wait_for_finalized_height(collator1, expiry_block + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
 
 	// Proof for the store-block fires at `store_block + RP = expiry_block - 1`, one block
 	// before `on_initialize` takes `Transactions[store_block]`.
 	assert_proof_checked_at(&client, expiry_block - 1, "on_init_cleanup post-store").await?;
-	{
-		let poll_timeout = std::time::Duration::from_secs(60);
-		let start = std::time::Instant::now();
-		loop {
-			let head = current_best_block(&client).await?;
-			if head.number() as u64 > expiry_block {
-				break;
-			}
-			if start.elapsed() > poll_timeout {
-				anyhow::bail!("Timed out waiting for at_latest >= {}", expiry_block + 1);
-			}
-			tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-		}
-	}
 
-	let expiry_hash = {
-		let mut current = current_best_block(&client).await?;
-		while (current.number() as u64) > expiry_block {
-			let parent_hash = current.header().parent_hash;
-			current = client.blocks().at(parent_hash).await?;
-		}
-		assert_eq!(current.number() as u64, expiry_block);
-		current.hash()
-	};
+	let expiry_hash = finalized_block_hash_at(&client, expiry_block).await?;
 
 	// Transactions[store_block] is None at expiry block (taken by on_initialize).
 	{
@@ -2266,24 +2219,11 @@ async fn parachain_on_initialize_no_renewals_weight_test() -> Result<()> {
 	let _: Vec<subxt::utils::H256> = futures::future::try_join_all(futs).await?;
 	tracing::info!("All {} stores accepted into pool", ON_INIT_NO_RENEWALS_ITEMS);
 
-	wait_for_block_height(collator1, pre_store_block + 5, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
-	{
-		let poll_timeout = std::time::Duration::from_secs(60);
-		let start = std::time::Instant::now();
-		loop {
-			let head = current_best_block(&client).await?;
-			if head.number() as u64 >= pre_store_block + 5 {
-				break;
-			}
-			if start.elapsed() > poll_timeout {
-				anyhow::bail!("Timed out waiting for at_latest >= {}", pre_store_block + 5);
-			}
-			tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-		}
-	}
+	wait_for_finalized_height(collator1, pre_store_block + 5, BLOCK_PRODUCTION_TIMEOUT_SECS)
+		.await?;
 	let mut store_block: u64 = 0;
 	{
-		let mut current = current_best_block(&client).await?;
+		let mut current = current_finalized_block(&client).await?;
 		while current.number() as u64 > pre_store_block {
 			let block_n = current.number() as u64;
 			let events = current.events().await?;
@@ -2308,7 +2248,7 @@ async fn parachain_on_initialize_no_renewals_weight_test() -> Result<()> {
 	tracing::info!("Stores landed at block {}", store_block);
 
 	let expiry_block = store_block + RETENTION_PERIOD as u64 + 1;
-	wait_for_block_height(collator1, expiry_block + 2, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	wait_for_finalized_height(collator1, expiry_block + 2, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
 
 	// Proof for the stores fires at `store_block + RP = expiry_block - 1`, one block before
 	// `on_initialize` takes `Transactions[store_block]` as obsolete.
@@ -2316,24 +2256,7 @@ async fn parachain_on_initialize_no_renewals_weight_test() -> Result<()> {
 
 	let stats_range_start = store_block.saturating_sub(2).max(1);
 	let stats_range_end = expiry_block + 2;
-	let head = {
-		let poll_timeout = std::time::Duration::from_secs(60);
-		let start = std::time::Instant::now();
-		loop {
-			let head = current_best_block(&client).await?;
-			if head.number() as u64 >= stats_range_end {
-				break head;
-			}
-			if start.elapsed() > poll_timeout {
-				anyhow::bail!(
-					"Timed out waiting for at_latest >= {} (last seen: {})",
-					stats_range_end,
-					head.number()
-				);
-			}
-			tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-		}
-	};
+	let head = current_finalized_block(&client).await?;
 	let mut block_hashes_by_number: HashMap<u64, subxt::utils::H256> = HashMap::new();
 	let mut current = head;
 	loop {
@@ -3014,14 +2937,14 @@ async fn parachain_auto_renew_quota_exhaustion_test() -> Result<()> {
 			wait_until,
 			renewal_block
 		);
-		wait_for_block_height(collator1, wait_until, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+		wait_for_finalized_height(collator1, wait_until, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
 		dump_renewal_window(client, renewal_block, &format!("quota_exhaustion cycle {}", cycle))
 			.await?;
 
 		// Proof for cycle k's source tx_info lands at `renewal_block - 1`.
 		assert_proof_checked_at(client, renewal_block - 1, &format!("cycle {}", cycle)).await?;
 
-		let renewal_hash = block_hash_at(client, renewal_block).await?;
+		let renewal_hash = finalized_block_hash_at(client, renewal_block).await?;
 		let events = client.blocks().at(renewal_hash).await?.events().await?;
 		let renewed = count_event(&events, "DataAutoRenewed");
 		let failed = count_event(&events, "AutoRenewalFailed");
@@ -3049,13 +2972,13 @@ async fn parachain_auto_renew_quota_exhaustion_test() -> Result<()> {
 	// Cycle 3: bytes_permanent (= 2L) + L > bytes_allowance (= 2L).
 	let wait_until = r3 + 1;
 	tracing::info!(
-		"[cycle 3] Waiting for block {} (renewal at {}) — expected to fail",
+		"[cycle 3] Waiting for FINALIZED block {} (renewal at {}) — expected to fail",
 		wait_until,
 		r3
 	);
-	wait_for_block_height(collator1, wait_until, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	wait_for_finalized_height(collator1, wait_until, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
 
-	let r3_hash = block_hash_at(client, r3).await?;
+	let r3_hash = finalized_block_hash_at(client, r3).await?;
 	let events = client.blocks().at(r3_hash).await?.events().await?;
 	let failed = count_event(&events, "AutoRenewalFailed");
 	let renewed = count_event(&events, "DataAutoRenewed");

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -1955,7 +1955,9 @@ async fn parachain_on_initialize_cleanup_test() -> Result<()> {
 	tracing::info!("Stores landed at (or before) block {}", store_block);
 
 	tracing::info!("Enabling auto-renew for {} items (set 1)", ON_INIT_CLEANUP_ITEMS_PER_SET);
-	let pre_enable_block = current_finalized_block(&client).await?.number() as u64;
+	// BEST not FINALIZED — otherwise `+5` is short by the finality lag and the walk misses
+	// enables that landed in best blocks not yet finalized.
+	let pre_enable_block = current_best_block(&client).await?.number() as u64;
 	let mut futs = Vec::with_capacity(ON_INIT_CLEANUP_ITEMS_PER_SET as usize);
 	for (i, content_hash) in set1_hashes.iter().enumerate() {
 		let call = tx(

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -1955,6 +1955,7 @@ async fn parachain_on_initialize_cleanup_test() -> Result<()> {
 	tracing::info!("Stores landed at (or before) block {}", store_block);
 
 	tracing::info!("Enabling auto-renew for {} items (set 1)", ON_INIT_CLEANUP_ITEMS_PER_SET);
+	let pre_enable_block = current_finalized_block(&client).await?.number() as u64;
 	let mut futs = Vec::with_capacity(ON_INIT_CLEANUP_ITEMS_PER_SET as usize);
 	for (i, content_hash) in set1_hashes.iter().enumerate() {
 		let call = tx(
@@ -1975,6 +1976,60 @@ async fn parachain_on_initialize_cleanup_test() -> Result<()> {
 	nonce += ON_INIT_CLEANUP_ITEMS_PER_SET as u64;
 	let _: Vec<subxt::utils::H256> = futures::future::try_join_all(futs).await?;
 	let _ = nonce;
+
+	// Verify every enable_auto_renew landed before the items expire. If the test's pre-enable
+	// finality wait gives the chain time to advance past `store_block + RP`, enables would
+	// silently fail (the item has already expired) → no renewals → assertion below sees 0/N.
+	wait_for_finalized_height(collator1, pre_enable_block + 5, BLOCK_PRODUCTION_TIMEOUT_SECS)
+		.await?;
+	let mut enabled_count = 0usize;
+	let mut latest_enable_block = pre_enable_block;
+	{
+		let mut current = current_finalized_block(&client).await?;
+		while current.number() as u64 > pre_enable_block {
+			let block_n = current.number() as u64;
+			let events = current.events().await?;
+			let count = events
+				.iter()
+				.filter_map(|e| e.ok())
+				.filter(|e| {
+					e.pallet_name() == "TransactionStorage" &&
+						e.variant_name() == "AutoRenewalEnabled"
+				})
+				.count();
+			if count > 0 && block_n > latest_enable_block {
+				latest_enable_block = block_n;
+			}
+			enabled_count += count;
+			if block_n == 0 {
+				break;
+			}
+			let parent_hash = current.header().parent_hash;
+			current = client.blocks().at(parent_hash).await?;
+		}
+	}
+	if enabled_count != ON_INIT_CLEANUP_ITEMS_PER_SET as usize {
+		anyhow::bail!(
+			"Expected {} AutoRenewalEnabled events, found {} (latest enable at block {})",
+			ON_INIT_CLEANUP_ITEMS_PER_SET,
+			enabled_count,
+			latest_enable_block
+		);
+	}
+	tracing::info!(
+		"Auto-renew enabled for all {} set-1 items (latest enable at block {})",
+		ON_INIT_CLEANUP_ITEMS_PER_SET,
+		latest_enable_block
+	);
+	if latest_enable_block >= store_block + RETENTION_PERIOD as u64 {
+		anyhow::bail!(
+			"Auto-renew enables landed at block {} >= store_block ({}) + RP ({}); items would \
+			 already be expired. Need a longer RP or earlier enables for this test to be valid.",
+			latest_enable_block,
+			store_block,
+			RETENTION_PERIOD
+		);
+	}
 
 	let expiry_block = store_block + RETENTION_PERIOD as u64 + 1;
 	tracing::info!(

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -8,7 +8,7 @@ use crate::{
 	test_log,
 	utils::{
 		authorize_account_via_sudo, authorize_account_via_sudo_finalized, authorize_and_store_data,
-		blake2_256, build_parachain_network_config_single_collator, content_hash_and_cid,
+		blake2_256, build_parachain_network_config_three_relay_validators, content_hash_and_cid,
 		count_event, disable_auto_renew, enable_auto_renew, expect_bitswap_dont_have,
 		generate_test_data, get_alice_nonce, initialize_network, override_alice_authorization,
 		set_retention_period, set_retention_period_finalized, submit_renew_pair,
@@ -44,6 +44,14 @@ async fn current_best_block(
 		.await
 		.ok_or_else(|| anyhow::anyhow!("subscribe_best stream empty"))??;
 	Ok(block)
+}
+
+/// Fetch the latest finalized block. Use this when event/storage reads must be stable —
+/// best-view can briefly follow a non-canonical branch as chainHead_v2 resolves.
+async fn current_finalized_block(
+	client: &OnlineClient<SubstrateConfig>,
+) -> Result<subxt::blocks::Block<SubstrateConfig, OnlineClient<SubstrateConfig>>> {
+	Ok(client.blocks().at_latest().await?)
 }
 
 const SESSION_CHANGE_TIMEOUT_SECS: u64 = 300;
@@ -135,7 +143,10 @@ async fn spawn_shared_harness(
 ) -> Result<std::sync::Arc<SharedHarness>> {
 	tracing::info!("[{}] spawning shared zombienet network", label);
 	verify_parachain_binaries()?;
-	let config = build_parachain_network_config_single_collator(para_node_args)?;
+	// 3 relay validators give a fault-tolerant GRANDPA quorum; with only 2, any brief stall
+	// halts finality and widens the best-vs-finalized window, which leaks into event-reading
+	// race conditions.
+	let config = build_parachain_network_config_three_relay_validators(para_node_args)?;
 	let network = initialize_network(config).await?;
 	network.wait_until_is_up(NETWORK_READY_TIMEOUT_SECS).await?;
 	let relay_alice = network
@@ -342,7 +353,7 @@ async fn parachain_check_proof_fails_under_pruning_test() -> Result<()> {
 	verify_parachain_binaries()?;
 
 	let para_args = get_para_node_args_with_pruning(BLOCKS_PRUNING_LESS_THAN_RETENTION);
-	let config = build_parachain_network_config_single_collator(para_args)?;
+	let config = build_parachain_network_config_three_relay_validators(para_args)?;
 	let network = initialize_network(config).await?;
 	network.wait_until_is_up(NETWORK_READY_TIMEOUT_SECS).await?;
 
@@ -417,7 +428,7 @@ async fn parachain_auto_renew_under_pruning_chain_halts_test() -> Result<()> {
 	verify_parachain_binaries()?;
 
 	let para_args = get_para_node_args_with_pruning(BLOCKS_PRUNING_LESS_THAN_RETENTION);
-	let config = build_parachain_network_config_single_collator(para_args)?;
+	let config = build_parachain_network_config_three_relay_validators(para_args)?;
 	let network = initialize_network(config).await?;
 	network.wait_until_is_up(NETWORK_READY_TIMEOUT_SECS).await?;
 
@@ -1290,11 +1301,12 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 		exhaustion_block,
 		last_renewal_block
 	);
-	wait_for_block_height(collator1, exhaustion_wait_until, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	wait_for_finalized_height(collator1, exhaustion_wait_until, BLOCK_PRODUCTION_TIMEOUT_SECS)
+		.await?;
 	let mut total_failed: u32 = 0;
 	let mut total_renewed_post_window: u32 = 0;
 	for n in exhaustion_block..=exhaustion_block + 1 {
-		let hash = block_hash_at(client, n).await?;
+		let hash = finalized_block_hash_at(client, n).await?;
 		let events = client.blocks().at(hash).await?.events().await?;
 		total_failed += count_event(&events, "AutoRenewalFailed");
 		total_renewed_post_window += count_event(&events, "DataAutoRenewed");
@@ -1344,7 +1356,7 @@ async fn parachain_auto_renew_many_items_worst_case_test() -> Result<()> {
 
 	verify_parachain_binaries()?;
 
-	let config = build_parachain_network_config_single_collator(get_para_node_args())?;
+	let config = build_parachain_network_config_three_relay_validators(get_para_node_args())?;
 	let network = initialize_network(config).await?;
 	network.wait_until_is_up(NETWORK_READY_TIMEOUT_SECS).await?;
 
@@ -1858,7 +1870,7 @@ async fn parachain_on_initialize_cleanup_test() -> Result<()> {
 	);
 
 	verify_parachain_binaries()?;
-	let config = build_parachain_network_config_single_collator(get_para_node_args())?;
+	let config = build_parachain_network_config_three_relay_validators(get_para_node_args())?;
 	let network = initialize_network(config).await?;
 	network.wait_until_is_up(NETWORK_READY_TIMEOUT_SECS).await?;
 	let relay_alice = network.get_node("alice").context("relay alice")?;
@@ -2200,7 +2212,7 @@ async fn parachain_on_initialize_no_renewals_weight_test() -> Result<()> {
 	);
 
 	verify_parachain_binaries()?;
-	let config = build_parachain_network_config_single_collator(get_para_node_args())?;
+	let config = build_parachain_network_config_three_relay_validators(get_para_node_args())?;
 	let network = initialize_network(config).await?;
 	network.wait_until_is_up(NETWORK_READY_TIMEOUT_SECS).await?;
 	let relay_alice = network.get_node("alice").context("relay alice")?;
@@ -2853,7 +2865,7 @@ async fn run_pruning_restart_scenario(
 		Some(n) => get_para_node_args_with_pruning(n),
 		None => get_para_node_args(),
 	};
-	let config = build_parachain_network_config_single_collator(para_args)?;
+	let config = build_parachain_network_config_three_relay_validators(para_args)?;
 	let network = initialize_network(config).await?;
 	network.wait_until_is_up(NETWORK_READY_TIMEOUT_SECS).await?;
 
@@ -3095,14 +3107,37 @@ async fn block_hash_at(
 	Ok(current.hash())
 }
 
+/// Locate the canonical block at `target` by walking back from the latest finalized block.
+/// Caller is responsible for ensuring finalized has reached `target` first
+/// (e.g. via `wait_for_finalized_height`).
+async fn finalized_block_hash_at(
+	client: &OnlineClient<SubstrateConfig>,
+	target: u64,
+) -> Result<subxt::utils::H256> {
+	let mut current = current_finalized_block(client).await?;
+	if (current.number() as u64) < target {
+		anyhow::bail!(
+			"finalized height {} has not reached target {}; wait for finalization first",
+			current.number(),
+			target
+		);
+	}
+	while (current.number() as u64) > target {
+		let parent_hash = current.header().parent_hash;
+		current = client.blocks().at(parent_hash).await?;
+	}
+	Ok(current.hash())
+}
+
 /// Assert exactly one `ProofChecked` event at the given block; verifies the storage-proof
 /// step of `apply_block_inherents` actually ran for `Transactions[block - RetentionPeriod]`.
+/// Reads at the canonical (finalized) block — caller must ensure finality has reached `block`.
 async fn assert_proof_checked_at(
 	client: &OnlineClient<SubstrateConfig>,
 	block: u64,
 	context: &str,
 ) -> Result<()> {
-	let hash = block_hash_at(client, block).await?;
+	let hash = finalized_block_hash_at(client, block).await?;
 	let events = client.blocks().at(hash).await?.events().await?;
 	let count = count_event(&events, "ProofChecked");
 	assert_eq!(count, 1, "{}: expected 1 ProofChecked at block {}, saw {}", context, block, count);
@@ -3211,11 +3246,11 @@ async fn parachain_auto_renew_authorization_expires_mid_cycle_test() -> Result<(
 	nonce += 1;
 	tracing::info!("Auto-renewal enabled");
 
-	wait_for_block_height(collator1, r1 + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	wait_for_finalized_height(collator1, r1 + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
 	// Proof for the original store fires at `r1 - 1 = store_block + RP`.
 	assert_proof_checked_at(client, r1 - 1, "auth_expires cycle 1").await?;
 	dump_renewal_window(client, r1, "auth_expires cycle 1").await?;
-	let r1_hash = block_hash_at(client, r1).await?;
+	let r1_hash = finalized_block_hash_at(client, r1).await?;
 	let r1_events = client.blocks().at(r1_hash).await?.events().await?;
 	assert_eq!(
 		count_event(&r1_events, "DataAutoRenewed"),
@@ -3231,10 +3266,10 @@ async fn parachain_auto_renew_authorization_expires_mid_cycle_test() -> Result<(
 	);
 	tracing::info!("[cycle 1] ✓ DataAutoRenewed at block {}", r1);
 
-	wait_for_block_height(collator1, r2 + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	wait_for_finalized_height(collator1, r2 + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
 	// Proof for the cycle-1 renewal at r1 fires at `r2 - 1 = r1 + RP`.
 	assert_proof_checked_at(client, r2 - 1, "auth_expires cycle 2").await?;
-	let r2_hash = block_hash_at(client, r2).await?;
+	let r2_hash = finalized_block_hash_at(client, r2).await?;
 	let r2_events = client.blocks().at(r2_hash).await?.events().await?;
 	assert_eq!(
 		count_event(&r2_events, "AutoRenewalFailed"),
@@ -3295,10 +3330,10 @@ async fn parachain_auto_renew_authorization_expires_mid_cycle_test() -> Result<(
 	tracing::info!("Auto-renewal enabled for second item");
 
 	let r1_after = store2_block + cadence;
-	wait_for_block_height(collator1, r1_after + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	wait_for_finalized_height(collator1, r1_after + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
 	// Proof for the second store fires at `r1_after - 1 = store2_block + RP`.
 	assert_proof_checked_at(client, r1_after - 1, "post-reauth cycle 1").await?;
-	let r1_after_hash = block_hash_at(client, r1_after).await?;
+	let r1_after_hash = finalized_block_hash_at(client, r1_after).await?;
 	let r1_after_events = client.blocks().at(r1_after_hash).await?.events().await?;
 	assert_eq!(
 		count_event(&r1_after_events, "DataAutoRenewed"),

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -2023,9 +2023,12 @@ async fn parachain_on_initialize_cleanup_test() -> Result<()> {
 		ON_INIT_CLEANUP_ITEMS_PER_SET,
 		latest_enable_block
 	);
-	if latest_enable_block >= store_block + RETENTION_PERIOD as u64 {
+	// Renewal at `n = store_block + RP + 1` is driven by `on_initialize`, which reads
+	// `AutoRenewals` *before* any extrinsics in block `n`. So enables must be in a block
+	// ≤ `store_block + RP` — strict equality is fine.
+	if latest_enable_block > store_block + RETENTION_PERIOD as u64 {
 		anyhow::bail!(
-			"Auto-renew enables landed at block {} >= store_block ({}) + RP ({}); items would \
+			"Auto-renew enables landed at block {} > store_block ({}) + RP ({}); items would \
 			 already be expired. Need a longer RP or earlier enables for this test to be valid.",
 			latest_enable_block,
 			store_block,

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -3108,19 +3108,27 @@ async fn block_hash_at(
 }
 
 /// Locate the canonical block at `target` by walking back from the latest finalized block.
-/// Caller is responsible for ensuring finalized has reached `target` first
-/// (e.g. via `wait_for_finalized_height`).
+/// Polls until finality reaches `target` so callers can chain it directly after a best-block
+/// wait without manually re-waiting on finality.
 async fn finalized_block_hash_at(
 	client: &OnlineClient<SubstrateConfig>,
 	target: u64,
 ) -> Result<subxt::utils::H256> {
+	const POLL_INTERVAL_SECS: u64 = 2;
+	const POLL_TIMEOUT_SECS: u64 = 120;
+	let start = std::time::Instant::now();
 	let mut current = current_finalized_block(client).await?;
-	if (current.number() as u64) < target {
-		anyhow::bail!(
-			"finalized height {} has not reached target {}; wait for finalization first",
-			current.number(),
-			target
-		);
+	while (current.number() as u64) < target {
+		if start.elapsed().as_secs() > POLL_TIMEOUT_SECS {
+			anyhow::bail!(
+				"finalized height {} did not reach target {} within {}s",
+				current.number(),
+				target,
+				POLL_TIMEOUT_SECS
+			);
+		}
+		tokio::time::sleep(std::time::Duration::from_secs(POLL_INTERVAL_SECS)).await;
+		current = current_finalized_block(client).await?;
 	}
 	while (current.number() as u64) > target {
 		let parent_hash = current.header().parent_hash;

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -10,9 +10,9 @@ use crate::{
 		authorize_account_via_sudo, authorize_account_via_sudo_finalized, authorize_and_store_data,
 		blake2_256, build_parachain_network_config_three_relay_validators, content_hash_and_cid,
 		count_event, disable_auto_renew, enable_auto_renew, expect_bitswap_dont_have,
-		generate_test_data, get_alice_nonce, initialize_network, override_alice_authorization,
-		set_retention_period, set_retention_period_finalized, submit_renew_pair,
-		submit_store_signed, top_up_alice_authorization, verify_node_bitswap,
+		finalized_store_block_for_hash, generate_test_data, get_alice_nonce, initialize_network,
+		override_alice_authorization, set_retention_period, set_retention_period_finalized,
+		submit_renew_pair, submit_store_signed, top_up_alice_authorization, verify_node_bitswap,
 		verify_parachain_binaries, wait_for_block_height, wait_for_finalized_height,
 		wait_for_finalized_quiescence, wait_for_session_change_on_node, AuthorizationOverride,
 		BLOCK_PRODUCTION_TIMEOUT_SECS, NETWORK_READY_TIMEOUT_SECS, NODE_LOG_CONFIG,
@@ -743,16 +743,20 @@ async fn parachain_auto_renew_vs_no_renew_eviction_test() -> Result<()> {
 	let (store_block, next_nonce) =
 		authorize_and_store_data(collator1, &data_renewed, nonce).await?;
 	nonce = next_nonce;
-	tracing::info!("data_renewed stored at block {}", store_block);
+	tracing::info!("data_renewed stored at block {} (best, pre-finality)", store_block);
 
 	top_up_alice_authorization(client, 5, 4 * data_renewed.len() as u64, nonce).await?;
 	nonce += 1;
 
 	let data_not_renewed_block = submit_store_signed(client, &data_not_renewed, nonce).await?;
 	nonce += 1;
-	tracing::info!("data_not_renewed stored at block {}", data_not_renewed_block);
+	tracing::info!(
+		"data_not_renewed stored at block {} (best, pre-finality)",
+		data_not_renewed_block
+	);
 
 	let content_hash_renewed = blake2_256(&data_renewed);
+	let content_hash_not_renewed = blake2_256(&data_not_renewed);
 	enable_auto_renew(client, &content_hash_renewed, nonce).await?;
 	tracing::info!("Auto-renewal enabled for data_renewed");
 
@@ -781,6 +785,19 @@ async fn parachain_auto_renew_vs_no_renew_eviction_test() -> Result<()> {
 		store_block
 	);
 	wait_for_finalized_height(collator1, wait_until, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+
+	// Re-resolve canonical store blocks from the finalized chain — if a reorg between
+	// best-inclusion and finality moved either store to a different block, the captured
+	// best-chain numbers above would point at orphans and `assert_proof_checked_at` would
+	// read the wrong finalized block.
+	let store_block = finalized_store_block_for_hash(client, &content_hash_renewed).await?;
+	let data_not_renewed_block =
+		finalized_store_block_for_hash(client, &content_hash_not_renewed).await?;
+	tracing::info!(
+		"Canonical (finalized) store blocks: data_renewed={}, data_not_renewed={}",
+		store_block,
+		data_not_renewed_block
+	);
 
 	// Proof for each store-block (one per store, since they landed in different blocks)
 	// fires at `block + RP`. Single ProofChecked event per source-block.
@@ -933,9 +950,14 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 		tracing::info!("Submitted 1 proof-decoy store (no auto-renew enabled)");
 	}
 
+	// Use BEST not FINALIZED here: with RP=10 from the shared archive_harness, waiting for
+	// finality (~6-10 block lag) plus `+5` would push `pre_enable_block` past `store_block + RP`
+	// and every `enable_auto_renew` below would land after expiry. Bumping RP locally would
+	// break sibling archive_harness tests (mid-chain RP change halts finality). Reading store
+	// blocks from the best chain is fine — the cycle math below only needs earliest/latest
+	// store-block as anchors, not stable finalized values.
 	let store_inclusion_target = pre_store_block + 5;
-	wait_for_finalized_height(collator1, store_inclusion_target, BLOCK_PRODUCTION_TIMEOUT_SECS)
-		.await?;
+	wait_for_block_height(collator1, store_inclusion_target, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
 
 	// Walk chain backward counting `Stored` events — avoids per-submission block lookups
 	// which race against chainHead pinning when done concurrently.
@@ -943,19 +965,19 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 		let poll_timeout = std::time::Duration::from_secs(60);
 		let start = std::time::Instant::now();
 		loop {
-			let head = current_finalized_block(client).await?;
+			let head = current_best_block(client).await?;
 			if head.number() as u64 >= store_inclusion_target {
 				break head.number() as u64;
 			}
 			if start.elapsed() > poll_timeout {
-				anyhow::bail!("Timed out waiting for finalized >= {}", store_inclusion_target);
+				anyhow::bail!("Timed out waiting for best >= {}", store_inclusion_target);
 			}
 			tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 		}
 	};
 	let mut store_blocks: Vec<u64> = Vec::with_capacity(items.len());
 	{
-		let mut current = current_finalized_block(client).await?;
+		let mut current = current_best_block(client).await?;
 		while current.number() as u64 > pre_store_block {
 			let block_n = current.number() as u64;
 			let events = current.events().await?;

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -539,9 +539,9 @@ async fn parachain_renew_twice_within_block_with_pruning_test() -> Result<()> {
 	let (hash_hex, _) = content_hash_and_cid(&data);
 	tracing::info!("Test data: {} bytes, hash={}", data.len(), hash_hex);
 
-	let (store_block, next_nonce) = authorize_and_store_data(collator1, &data, nonce).await?;
+	let (best_store_block, next_nonce) = authorize_and_store_data(collator1, &data, nonce).await?;
 	nonce = next_nonce;
-	tracing::info!("Data stored at block {}", store_block);
+	tracing::info!("Data stored at best-chain block {}", best_store_block);
 
 	// `validate_signed` tags renewals with `(who, content_hash)`, so two renews from the
 	// same signer would conflict in the pool — use Bob as a second signer. Bob has no prior
@@ -556,6 +556,18 @@ async fn parachain_renew_twice_within_block_with_pruning_test() -> Result<()> {
 		.await?;
 
 	let content_hash = blake2_256(&data);
+	// Re-anchor against the finalized chain (Bob's authorize_via_sudo_finalized already
+	// pushed finality forward, so the resolver should find the Stored event immediately).
+	let store_block =
+		resolve_canonical_store_block(client, &content_hash, best_store_block.saturating_sub(3))
+			.await?;
+	if store_block != best_store_block {
+		tracing::info!(
+			"Canonical store block on finalized chain is {} (best-chain reported {})",
+			store_block,
+			best_store_block
+		);
+	}
 	let (renew_block_a, renew_block_b) =
 		submit_renew_pair(client, store_block as u32, 0, &content_hash, nonce, bob_nonce).await?;
 	if renew_block_a != renew_block_b {
@@ -639,9 +651,9 @@ async fn parachain_auto_renew_with_concurrent_store_test() -> Result<()> {
 	tracing::info!("data1 hash={}", content_hash_and_cid(&data1).0);
 	tracing::info!("data2 hash={}", content_hash_and_cid(&data2).0);
 
-	let (store_block, next_nonce) = authorize_and_store_data(collator1, &data1, nonce).await?;
+	let (best_store_block, next_nonce) = authorize_and_store_data(collator1, &data1, nonce).await?;
 	nonce = next_nonce;
-	tracing::info!("data1 stored at block {}", store_block);
+	tracing::info!("data1 stored at best-chain block {}", best_store_block);
 
 	top_up_alice_authorization(client, 5, 4 * data1.len() as u64, nonce).await?;
 	nonce += 1;
@@ -650,6 +662,25 @@ async fn parachain_auto_renew_with_concurrent_store_test() -> Result<()> {
 	enable_auto_renew(client, &content_hash_data1, nonce).await?;
 	nonce += 1;
 	tracing::info!("Auto-renewal enabled for data1");
+
+	// Re-anchor store_block on the finalized chain so the renewal_block computation below
+	// uses the canonical value — a reorg between best-inclusion and finality would otherwise
+	// shift renewal_block by ±1 and break the "data2 lands in renewal block" timing assert.
+	wait_for_finalized_height(collator1, best_store_block + 2, BLOCK_PRODUCTION_TIMEOUT_SECS)
+		.await?;
+	let store_block = resolve_canonical_store_block(
+		client,
+		&content_hash_data1,
+		best_store_block.saturating_sub(3),
+	)
+	.await?;
+	if store_block != best_store_block {
+		tracing::info!(
+			"Canonical store block on finalized chain is {} (best-chain reported {})",
+			store_block,
+			best_store_block
+		);
+	}
 
 	// Submit data2 at R-1 so it lands in the renewal block R = S + RetentionPeriod + 1.
 	let renewal_block = store_block + RETENTION_PERIOD as u64 + 1;
@@ -3014,7 +3045,7 @@ async fn parachain_auto_renew_quota_exhaustion_test() -> Result<()> {
 	tracing::info!("Test data: {} bytes, hash={}", data.len(), hash_hex);
 
 	let nonce = get_alice_nonce(collator1).await?;
-	let (store_block, mut nonce) = authorize_and_store_data(collator1, &data, nonce).await?;
+	let (best_store_block, mut nonce) = authorize_and_store_data(collator1, &data, nonce).await?;
 	verify_node_bitswap(collator1, &data, BITSWAP_TIMEOUT_SECS, "post-store").await?;
 
 	// Alice's genesis authorization is ~10 MiB and `authorize_account` is additive — overwrite
@@ -3035,14 +3066,30 @@ async fn parachain_auto_renew_quota_exhaustion_test() -> Result<()> {
 	.await?;
 	nonce += 1;
 	tracing::info!(
-		"Data stored at block {}; authorization pinned to bytes_allowance = 2 × {}",
-		store_block,
+		"Data stored at best-chain block {}; authorization pinned to bytes_allowance = 2 × {}",
+		best_store_block,
 		data.len()
 	);
 
 	let content_hash = blake2_256(&data);
 	enable_auto_renew(client, &content_hash, nonce).await?;
 	tracing::info!("Auto-renewal enabled for {}", hash_hex);
+
+	// Re-anchor against the finalized chain so cycle math + `assert_proof_checked_at` reads
+	// the right canonical blocks even if a reorg moved the store between best-inclusion and
+	// finality.
+	wait_for_finalized_height(collator1, best_store_block + 2, BLOCK_PRODUCTION_TIMEOUT_SECS)
+		.await?;
+	let store_block =
+		resolve_canonical_store_block(client, &content_hash, best_store_block.saturating_sub(3))
+			.await?;
+	if store_block != best_store_block {
+		tracing::info!(
+			"Canonical store block on finalized chain is {} (best-chain reported {})",
+			store_block,
+			best_store_block
+		);
+	}
 
 	let cadence = RETENTION_PERIOD as u64 + 1;
 	let r1 = store_block + cadence;
@@ -3259,19 +3306,25 @@ async fn parachain_auto_renew_authorization_expires_mid_cycle_test() -> Result<(
 	tracing::info!("Test data: {} bytes, hash={}", data.len(), hash_hex);
 
 	let nonce = get_alice_nonce(collator1).await?;
-	let (store_block, mut nonce) = authorize_and_store_data(collator1, &data, nonce).await?;
-	tracing::info!("Data stored at block {}", store_block);
+	let (best_store_block, mut nonce) = authorize_and_store_data(collator1, &data, nonce).await?;
+	tracing::info!("Data stored at best-chain block {}", best_store_block);
 
 	let cadence = RETENTION_PERIOD as u64 + 1;
-	let r1 = store_block + cadence;
-	let r2 = store_block + 2 * cadence;
+	// Best-chain estimates for the override and the cycle-1 wait. After finality covers the
+	// store we re-resolve to the canonical block (`resolve_canonical_store_block`) so the
+	// downstream assertions land on the right finalized blocks even after a reorg between
+	// best-inclusion and finality.
+	let est_r1 = best_store_block + cadence;
+	let est_r2 = best_store_block + 2 * cadence;
 
-	// `expired()` is `now >= expiration`; midpoint of (r1, r2] gives slack.
-	let override_expiration: u32 = ((r1 + r2) / 2) as u32;
+	// `expired()` is `now >= expiration`; midpoint of (r1, r2] gives slack — generous enough
+	// that an off-by-one between best and canonical doesn't flip cycle 1 from "renews" to
+	// "fails", or cycle 2 from "fails" to "renews".
+	let override_expiration: u32 = ((est_r1 + est_r2) / 2) as u32;
 	tracing::info!(
-		"Overriding Alice's authorization expiration: r1={}, r2={}, expiration={}",
-		r1,
-		r2,
+		"Overriding Alice's authorization expiration: est_r1={}, est_r2={}, expiration={}",
+		est_r1,
+		est_r2,
 		override_expiration
 	);
 
@@ -3297,7 +3350,25 @@ async fn parachain_auto_renew_authorization_expires_mid_cycle_test() -> Result<(
 	nonce += 1;
 	tracing::info!("Auto-renewal enabled");
 
-	wait_for_finalized_height(collator1, r1 + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	wait_for_finalized_height(collator1, est_r1 + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	// Re-anchor against the finalized chain so the cycle math + assertions don't read the
+	// wrong canonical block if a reorg moved the store.
+	let store_block =
+		resolve_canonical_store_block(client, &content_hash, best_store_block.saturating_sub(3))
+			.await?;
+	if store_block != best_store_block {
+		tracing::info!(
+			"Canonical store block on finalized chain is {} (best-chain reported {})",
+			store_block,
+			best_store_block
+		);
+	}
+	let r1 = store_block + cadence;
+	let r2 = store_block + 2 * cadence;
+	// est_r1's finality wait above may not cover canonical r1 if canonical > best — wait again.
+	if r1 + 1 > est_r1 + 1 {
+		wait_for_finalized_height(collator1, r1 + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	}
 	// Proof for the original store fires at `r1 - 1 = store_block + RP`.
 	assert_proof_checked_at(client, r1 - 1, "auth_expires cycle 1").await?;
 	dump_renewal_window(client, r1, "auth_expires cycle 1").await?;
@@ -3372,16 +3443,35 @@ async fn parachain_auto_renew_authorization_expires_mid_cycle_test() -> Result<(
 	};
 	let (hash2_hex, _) = content_hash_and_cid(&data2);
 
-	let store2_block = submit_store_signed(client, &data2, nonce).await?;
+	let best_store2_block = submit_store_signed(client, &data2, nonce).await?;
 	nonce += 1;
-	tracing::info!("Stored second item at block {} (hash={})", store2_block, hash2_hex);
+	tracing::info!(
+		"Stored second item at best-chain block {} (hash={})",
+		best_store2_block,
+		hash2_hex
+	);
 
 	let content_hash2 = blake2_256(&data2);
 	enable_auto_renew(client, &content_hash2, nonce).await?;
 	tracing::info!("Auto-renewal enabled for second item");
 
+	let est_r1_after = best_store2_block + cadence;
+	wait_for_finalized_height(collator1, est_r1_after + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	// Re-anchor on the finalized chain for the same reorg reasons as above.
+	let store2_block =
+		resolve_canonical_store_block(client, &content_hash2, best_store2_block.saturating_sub(3))
+			.await?;
+	if store2_block != best_store2_block {
+		tracing::info!(
+			"Canonical store2 block on finalized chain is {} (best-chain reported {})",
+			store2_block,
+			best_store2_block
+		);
+	}
 	let r1_after = store2_block + cadence;
-	wait_for_finalized_height(collator1, r1_after + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	if r1_after + 1 > est_r1_after + 1 {
+		wait_for_finalized_height(collator1, r1_after + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
+	}
 	// Proof for the second store fires at `r1_after - 1 = store2_block + RP`.
 	assert_proof_checked_at(client, r1_after - 1, "post-reauth cycle 1").await?;
 	let r1_after_hash = finalized_block_hash_at(client, r1_after).await?;

--- a/zombienet-sdk-tests/tests/parachain_sync_storage.rs
+++ b/zombienet-sdk-tests/tests/parachain_sync_storage.rs
@@ -110,7 +110,6 @@ use crate::{
 	test_log,
 	utils::{
 		authorize_and_store_data, authorize_and_store_data_finalized, authorize_and_store_items,
-		build_parachain_network_config_single_collator,
 		build_parachain_network_config_three_relay_validators, content_hash_and_cid,
 		expect_all_items_bitswap_dont_have, generate_test_data, get_alice_nonce, get_db_path,
 		get_para_id, get_parachain_binary_path, get_parachain_chain_id, initialize_network,
@@ -169,7 +168,7 @@ async fn parachain_fast_sync_test() -> Result<()> {
 	verify_parachain_binaries()?;
 
 	let para_args = get_para_node_args();
-	let config = build_parachain_network_config_single_collator(para_args)?;
+	let config = build_parachain_network_config_three_relay_validators(para_args)?;
 	let mut network = initialize_network(config).await?;
 	network.wait_until_is_up(NETWORK_READY_TIMEOUT_SECS).await?;
 
@@ -263,7 +262,7 @@ async fn parachain_fast_sync_with_pruning_test() -> Result<()> {
 	verify_parachain_binaries()?;
 
 	let para_args = get_para_node_args_with_pruning(PRUNING_BLOCKS);
-	let config = build_parachain_network_config_single_collator(para_args)?;
+	let config = build_parachain_network_config_three_relay_validators(para_args)?;
 	let mut network = initialize_network(config).await?;
 	network.wait_until_is_up(NETWORK_READY_TIMEOUT_SECS).await?;
 
@@ -570,7 +569,7 @@ async fn parachain_full_sync_test() -> Result<()> {
 	verify_parachain_binaries()?;
 
 	let para_args = get_para_node_args();
-	let config = build_parachain_network_config_single_collator(para_args)?;
+	let config = build_parachain_network_config_three_relay_validators(para_args)?;
 	let mut network = initialize_network(config).await?;
 	network.wait_until_is_up(NETWORK_READY_TIMEOUT_SECS).await?;
 
@@ -656,7 +655,7 @@ async fn parachain_full_sync_with_pruning_test() -> Result<()> {
 	verify_parachain_binaries()?;
 
 	let para_args = get_para_node_args_with_pruning(PRUNING_BLOCKS);
-	let config = build_parachain_network_config_single_collator(para_args)?;
+	let config = build_parachain_network_config_three_relay_validators(para_args)?;
 	let mut network = initialize_network(config).await?;
 	network.wait_until_is_up(NETWORK_READY_TIMEOUT_SECS).await?;
 
@@ -876,7 +875,7 @@ async fn parachain_rpc_node_bitswap_test() -> Result<()> {
 	verify_parachain_binaries()?;
 
 	let para_args = get_para_node_args();
-	let config = build_parachain_network_config_single_collator(para_args)?;
+	let config = build_parachain_network_config_three_relay_validators(para_args)?;
 	let mut network = initialize_network(config).await?;
 	network.wait_until_is_up(NETWORK_READY_TIMEOUT_SECS).await?;
 
@@ -1007,7 +1006,7 @@ async fn parachain_ldb_storage_verification_test() -> Result<()> {
 		"--".into(),
 		"--network-backend=libp2p".into(),
 	];
-	let config = build_parachain_network_config_single_collator(para_args)?;
+	let config = build_parachain_network_config_three_relay_validators(para_args)?;
 	let network = initialize_network(config).await?;
 	network.wait_until_is_up(NETWORK_READY_TIMEOUT_SECS).await?;
 

--- a/zombienet-sdk-tests/tests/parachain_sync_storage.rs
+++ b/zombienet-sdk-tests/tests/parachain_sync_storage.rs
@@ -109,7 +109,7 @@
 use crate::{
 	test_log,
 	utils::{
-		authorize_and_store_data, authorize_and_store_data_finalized, authorize_and_store_items,
+		authorize_and_store_data, authorize_and_store_items,
 		build_parachain_network_config_three_relay_validators, content_hash_and_cid,
 		expect_all_items_bitswap_dont_have, generate_test_data, get_alice_nonce, get_db_path,
 		get_para_id, get_parachain_binary_path, get_parachain_chain_id, initialize_network,
@@ -1067,7 +1067,7 @@ async fn parachain_ldb_storage_verification_test() -> Result<()> {
 	// === Step 2: First store - verify refcount = 1 and content hash matches ===
 	test_log!(TEST, "=== Step 2: First store - expecting refcount = 1 ===");
 	let (first_store_block, next_nonce) =
-		authorize_and_store_data_finalized(collator1, &test_data, nonce).await?;
+		authorize_and_store_data(collator1, &test_data, nonce).await?;
 	nonce = next_nonce;
 	tracing::info!("First store completed at block {}", first_store_block);
 
@@ -1101,8 +1101,7 @@ async fn parachain_ldb_storage_verification_test() -> Result<()> {
 
 	// === Step 3: Second store (same data) - verify refcount = 2, still 2 keys ===
 	test_log!(TEST, "=== Step 3: Second store - expecting refcount = 2, still 2 keys ===");
-	let (second_store_block, _) =
-		authorize_and_store_data_finalized(collator1, &test_data, nonce).await?;
+	let (second_store_block, _) = authorize_and_store_data(collator1, &test_data, nonce).await?;
 	tracing::info!("Second store completed at block {}", second_store_block);
 
 	let dump = verify_col11(&collator_db_path, "col11 AFTER second store")?;

--- a/zombienet-sdk-tests/tests/parachain_sync_storage.rs
+++ b/zombienet-sdk-tests/tests/parachain_sync_storage.rs
@@ -109,7 +109,7 @@
 use crate::{
 	test_log,
 	utils::{
-		authorize_and_store_data, authorize_and_store_items,
+		authorize_and_store_data, authorize_and_store_data_finalized, authorize_and_store_items,
 		build_parachain_network_config_three_relay_validators, content_hash_and_cid,
 		expect_all_items_bitswap_dont_have, generate_test_data, get_alice_nonce, get_db_path,
 		get_para_id, get_parachain_binary_path, get_parachain_chain_id, initialize_network,
@@ -1067,7 +1067,7 @@ async fn parachain_ldb_storage_verification_test() -> Result<()> {
 	// === Step 2: First store - verify refcount = 1 and content hash matches ===
 	test_log!(TEST, "=== Step 2: First store - expecting refcount = 1 ===");
 	let (first_store_block, next_nonce) =
-		authorize_and_store_data(collator1, &test_data, nonce).await?;
+		authorize_and_store_data_finalized(collator1, &test_data, nonce).await?;
 	nonce = next_nonce;
 	tracing::info!("First store completed at block {}", first_store_block);
 
@@ -1101,7 +1101,8 @@ async fn parachain_ldb_storage_verification_test() -> Result<()> {
 
 	// === Step 3: Second store (same data) - verify refcount = 2, still 2 keys ===
 	test_log!(TEST, "=== Step 3: Second store - expecting refcount = 2, still 2 keys ===");
-	let (second_store_block, _) = authorize_and_store_data(collator1, &test_data, nonce).await?;
+	let (second_store_block, _) =
+		authorize_and_store_data_finalized(collator1, &test_data, nonce).await?;
 	tracing::info!("Second store completed at block {}", second_store_block);
 
 	let dump = verify_col11(&collator_db_path, "col11 AFTER second store")?;

--- a/zombienet-sdk-tests/tests/utils/bitswap.rs
+++ b/zombienet-sdk-tests/tests/utils/bitswap.rs
@@ -528,3 +528,260 @@ pub async fn expect_bitswap_dont_have(
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Persistent bitswap client (port of `bulletin-stress-test/src/bitswap.rs`).
+//
+// `fetch_via_bitswap` spawns a fresh litep2p per call. After ~300 calls in a single test
+// (e.g. bulk 512-item verification) litep2p's transport service exhausts with "Dial failure"
+// / "transport service closed", causing the tail of items to fail. The persistent client
+// keeps one litep2p alive across many fetches and opens a new substream per call.
+// ---------------------------------------------------------------------------
+
+/// Persistent bitswap client. Owns a litep2p instance running in a background task with a
+/// long-lived connection to one peer; each `fetch_block` call opens a new substream rather
+/// than dialing fresh.
+pub struct BitswapClient {
+	cmd_tx: mpsc::Sender<BitswapClientCommand>,
+	peer_id: PeerId,
+	_event_task: tokio::task::JoinHandle<()>,
+}
+
+impl BitswapClient {
+	/// Fetch one item by content hash. Sequential per client — for parallelism, create
+	/// multiple clients.
+	pub async fn fetch_block(&self, data_hash: &[u8; 32], timeout: Duration) -> Result<Vec<u8>> {
+		let cid_bytes = hash_to_cid_bytes(data_hash);
+		let (response_tx, response_rx) = oneshot::channel();
+		self.cmd_tx
+			.send(BitswapClientCommand::Fetch { peer: self.peer_id, cid_bytes, response_tx })
+			.await
+			.map_err(|_| anyhow!("BitswapClient protocol task closed"))?;
+		tokio::time::timeout(timeout, response_rx)
+			.await
+			.map_err(|_| anyhow!("Bitswap fetch timed out"))?
+			.map_err(|_| anyhow!("Response channel closed"))?
+	}
+}
+
+/// Dial `multiaddr_str`, wait for the connection to establish, then return a ready-to-use
+/// `BitswapClient`. The litep2p instance is moved into a background tokio task that pumps
+/// its event loop until the client is dropped.
+pub async fn create_connected_bitswap_client(multiaddr_str: &str) -> Result<BitswapClient> {
+	let multiaddr: Multiaddr = multiaddr_str.parse().context("parse multiaddr")?;
+	let peer_id_multihash = multiaddr
+		.iter()
+		.find_map(|p| {
+			if let litep2p::types::multiaddr::Protocol::P2p(peer_id) = p {
+				Some(peer_id)
+			} else {
+				None
+			}
+		})
+		.ok_or_else(|| anyhow!("multiaddr does not contain peer ID"))?;
+	let peer_id = PeerId::from_multihash(peer_id_multihash)
+		.map_err(|_| anyhow!("invalid peer ID in multiaddr"))?;
+
+	let (cmd_tx, cmd_rx) = mpsc::channel(32);
+	let protocol = BitswapClientProtocol::new(cmd_rx);
+
+	let config = Litep2pConfigBuilder::new()
+		.with_keypair(Keypair::generate())
+		.with_user_protocol(Box::new(protocol))
+		.with_websocket(WebSocketConfig {
+			listen_addresses: vec!["/ip4/127.0.0.1/tcp/0/ws".parse().unwrap()],
+			..Default::default()
+		})
+		.with_keep_alive_timeout(Duration::from_secs(60))
+		.build();
+
+	let mut litep2p =
+		Litep2p::new(config).map_err(|e| anyhow!("failed to create litep2p: {:?}", e))?;
+
+	litep2p
+		.dial_address(multiaddr.clone())
+		.await
+		.map_err(|e| anyhow!("failed to dial {multiaddr}: {:?}", e))?;
+
+	let connected =
+		tokio::time::timeout(Duration::from_secs(30), wait_for_connection(&mut litep2p, peer_id))
+			.await
+			.map_err(|_| anyhow!("timeout waiting for bitswap connection to {multiaddr}"))?;
+	if !connected {
+		anyhow::bail!("failed to establish bitswap connection to {multiaddr}");
+	}
+
+	let event_task = tokio::spawn(async move {
+		loop {
+			match litep2p.next_event().await {
+				Some(event) => tracing::trace!("litep2p event: {:?}", event),
+				None => break,
+			}
+		}
+	});
+
+	Ok(BitswapClient { cmd_tx, peer_id, _event_task: event_task })
+}
+
+/// Fetch + verify all `items` against `node` via bitswap using `concurrency` persistent
+/// connections in parallel (each handles `items.len() / concurrency` items sequentially).
+/// Caches every item's blake2_256 hash in advance to avoid re-hashing per fetch.
+pub async fn verify_all_items_bitswap_concurrent(
+	node: &zombienet_sdk::NetworkNode,
+	items: &[Vec<u8>],
+	concurrency: usize,
+	per_item_timeout_secs: u64,
+	label: &str,
+) -> Result<()> {
+	use std::sync::Arc;
+	let multiaddr = node.multiaddr();
+	tracing::info!(
+		"=== Verifying bitswap fetch of {} items via {} persistent connections (label={}) ===",
+		items.len(),
+		concurrency,
+		label
+	);
+
+	let mut clients = Vec::with_capacity(concurrency);
+	for i in 0..concurrency {
+		let c = create_connected_bitswap_client(multiaddr).await.with_context(|| {
+			format!("{label}: failed to create bitswap client {i}/{concurrency}")
+		})?;
+		clients.push(Arc::new(c));
+	}
+
+	let timeout = Duration::from_secs(per_item_timeout_secs);
+	let chunk_size = items.len().div_ceil(concurrency);
+	let mut handles = Vec::new();
+	for (client_idx, chunk_start) in (0..items.len()).step_by(chunk_size).enumerate() {
+		let chunk_end = (chunk_start + chunk_size).min(items.len());
+		let client = Arc::clone(&clients[client_idx]);
+		let chunk: Vec<(usize, Vec<u8>)> = items[chunk_start..chunk_end]
+			.iter()
+			.enumerate()
+			.map(|(i, d)| (chunk_start + i, d.clone()))
+			.collect();
+		let label = label.to_string();
+		let total = items.len();
+		handles.push(tokio::spawn(async move {
+			for (item_idx, data) in chunk {
+				let hash = blake2_256(&data);
+				let fetched = client.fetch_block(&hash, timeout).await.with_context(|| {
+					format!("{label}: item {} ({}/{}) fetch failed", item_idx, item_idx + 1, total)
+				})?;
+				if fetched != data {
+					anyhow::bail!(
+						"{label}: item {} ({}/{}) data mismatch (got {} bytes, expected {})",
+						item_idx,
+						item_idx + 1,
+						total,
+						fetched.len(),
+						data.len()
+					);
+				}
+			}
+			Ok::<_, anyhow::Error>(())
+		}));
+	}
+
+	for handle in handles {
+		handle.await.map_err(|e| anyhow!("bitswap worker task panicked: {e}"))??;
+	}
+
+	tracing::info!("✓ All {} items bitswap-fetchable from {}", items.len(), label);
+	Ok(())
+}
+
+/// Concurrent variant of [`expect_bitswap_dont_have`]. Polls all `items` against `node`
+/// across `concurrency` persistent connections until every probe returns DONT_HAVE or the
+/// per-item timeout elapses on any worker.
+pub async fn expect_all_items_bitswap_dont_have_concurrent(
+	node: &zombienet_sdk::NetworkNode,
+	items: &[Vec<u8>],
+	concurrency: usize,
+	per_item_timeout_secs: u64,
+	label: &str,
+) -> Result<()> {
+	use std::sync::Arc;
+	let multiaddr = node.multiaddr();
+	tracing::info!(
+		"=== Expecting bitswap DONT_HAVE for {} items via {} persistent connections (label={}) ===",
+		items.len(),
+		concurrency,
+		label
+	);
+
+	let mut clients = Vec::with_capacity(concurrency);
+	for i in 0..concurrency {
+		let c = create_connected_bitswap_client(multiaddr).await.with_context(|| {
+			format!("{label}: failed to create bitswap client {i}/{concurrency}")
+		})?;
+		clients.push(Arc::new(c));
+	}
+
+	let timeout = Duration::from_secs(per_item_timeout_secs);
+	let chunk_size = items.len().div_ceil(concurrency);
+	let mut handles = Vec::new();
+	for (client_idx, chunk_start) in (0..items.len()).step_by(chunk_size).enumerate() {
+		let chunk_end = (chunk_start + chunk_size).min(items.len());
+		let client = Arc::clone(&clients[client_idx]);
+		let chunk: Vec<(usize, Vec<u8>)> = items[chunk_start..chunk_end]
+			.iter()
+			.enumerate()
+			.map(|(i, d)| (chunk_start + i, d.clone()))
+			.collect();
+		let label = label.to_string();
+		let total = items.len();
+		handles.push(tokio::spawn(async move {
+			for (item_idx, data) in chunk {
+				let hash = blake2_256(&data);
+				let deadline = std::time::Instant::now() + timeout;
+				loop {
+					match client.fetch_block(&hash, Duration::from_secs(3)).await {
+						Ok(_) => {
+							if std::time::Instant::now() >= deadline {
+								anyhow::bail!(
+									"{label}: item {} ({}/{}) still served after {}s — col11 \
+									 entry not evicted as expected",
+									item_idx,
+									item_idx + 1,
+									total,
+									per_item_timeout_secs
+								);
+							}
+							tokio::time::sleep(Duration::from_secs(1)).await;
+						},
+						Err(e) => {
+							let msg = e.to_string();
+							if msg.contains("Peer does not have the block") ||
+								msg.contains("DONT_HAVE")
+							{
+								break;
+							}
+							if std::time::Instant::now() >= deadline {
+								return Err(e).with_context(|| {
+									format!(
+										"{label}: item {} ({}/{}) probe kept failing for {}s",
+										item_idx,
+										item_idx + 1,
+										total,
+										per_item_timeout_secs
+									)
+								});
+							}
+							tokio::time::sleep(Duration::from_secs(1)).await;
+						},
+					}
+				}
+			}
+			Ok::<_, anyhow::Error>(())
+		}));
+	}
+
+	for handle in handles {
+		handle.await.map_err(|e| anyhow!("bitswap worker task panicked: {e}"))??;
+	}
+
+	tracing::info!("✓ All {} items returned DONT_HAVE from {}", items.len(), label);
+	Ok(())
+}

--- a/zombienet-sdk-tests/tests/utils/bitswap.rs
+++ b/zombienet-sdk-tests/tests/utils/bitswap.rs
@@ -612,11 +612,8 @@ pub async fn create_connected_bitswap_client(multiaddr_str: &str) -> Result<Bits
 	}
 
 	let event_task = tokio::spawn(async move {
-		loop {
-			match litep2p.next_event().await {
-				Some(event) => tracing::trace!("litep2p event: {:?}", event),
-				None => break,
-			}
+		while let Some(event) = litep2p.next_event().await {
+			tracing::trace!("litep2p event: {:?}", event);
 		}
 	});
 

--- a/zombienet-sdk-tests/tests/utils/network.rs
+++ b/zombienet-sdk-tests/tests/utils/network.rs
@@ -112,59 +112,6 @@ pub fn verify_parachain_binaries() -> Result<()> {
 	Ok(())
 }
 
-/// Parachain network: 2 relay validators (alice, bob) + 1 collator.
-pub fn build_parachain_network_config_single_collator(
-	para_node_args: Vec<String>,
-) -> Result<NetworkConfig> {
-	let relay_binary = get_relay_binary_path();
-	let para_binary = get_parachain_binary_path();
-	let para_chain_spec = get_parachain_chain_spec();
-
-	tracing::info!("Relay binary: {}", relay_binary);
-	tracing::info!("Parachain binary: {}", para_binary);
-	tracing::info!("Parachain chain spec: {}", para_chain_spec);
-
-	let relay_args: Vec<_> = vec!["-lruntime=debug"].into_iter().map(|s| s.into()).collect();
-	let relay_args2 = relay_args.clone();
-
-	let para_args: Vec<_> = para_node_args.iter().map(|s| s.as_str().into()).collect();
-
-	let relay_chain = get_relay_chain();
-	let para_id = get_para_id();
-	tracing::info!("Relay chain: {}", relay_chain);
-	tracing::info!("Parachain ID: {}", para_id);
-
-	NetworkConfigBuilder::new()
-		.with_relaychain(|relaychain| {
-			relaychain
-				.with_chain(relay_chain.as_str())
-				.with_default_command(relay_binary.as_str())
-				.with_node(|node| node.with_name("alice").validator(true).with_args(relay_args))
-				.with_node(|node| node.with_name("bob").validator(true).with_args(relay_args2))
-		})
-		.with_parachain(|parachain| {
-			parachain
-				.with_id(para_id)
-				.with_chain_spec_path(para_chain_spec.as_str())
-				.cumulus_based(true)
-				.with_collator(|c| {
-					c.with_name("collator-1")
-						.validator(true)
-						.with_command(para_binary.as_str())
-						.with_args(para_args)
-				})
-		})
-		.with_global_settings(|gs| match std::env::var("ZOMBIENET_SDK_BASE_DIR") {
-			Ok(val) => gs.with_base_dir(val),
-			_ => gs,
-		})
-		.build()
-		.map_err(|errs| {
-			let message = errs.into_iter().map(|e| e.to_string()).collect::<Vec<_>>().join(", ");
-			anyhow!("config errs: {message}")
-		})
-}
-
 /// Parachain network: 3 relay validators (for stable GRANDPA finality) + 1 collator.
 pub fn build_parachain_network_config_three_relay_validators(
 	para_node_args: Vec<String>,

--- a/zombienet-sdk-tests/tests/utils/tx.rs
+++ b/zombienet-sdk-tests/tests/utils/tx.rs
@@ -472,6 +472,52 @@ pub async fn submit_store_signed(
 	Ok(block_number)
 }
 
+/// Resolve the canonical store block by walking the **finalized** chain backward from the
+/// latest finalized block until a `TransactionStorage::Stored` event whose payload contains
+/// `content_hash` is found. Robust against best-vs-finalized reorgs: subxt's
+/// `wait_for_in_best_block` can name an inclusion block that gets orphaned, so the eager
+/// `canonical_store_block` reading at that hash returns a number not on the new canonical
+/// chain. This walk re-anchors against finality.
+///
+/// Caller must already have waited for finality to cover the expected store block (e.g. via
+/// `wait_for_finalized_height`). `search_from_inclusive` bounds how far back the walk
+/// descends — pass the best-reported store block minus a small reorg-depth buffer.
+pub async fn resolve_canonical_store_block(
+	client: &OnlineClient<SubstrateConfig>,
+	content_hash: &[u8; 32],
+	search_from_inclusive: u64,
+) -> Result<u64> {
+	// 32-byte sliding-window match against the event's scale-encoded field bytes —
+	// `Stored { index: u32, content_hash: [u8; 32], cid: Option<Cid> }`. Random collisions
+	// at 32 bytes are astronomically unlikely.
+	let mut current = client.blocks().at_latest().await?;
+	loop {
+		let block_n = current.number() as u64;
+		if block_n < search_from_inclusive {
+			break;
+		}
+		let events = current.events().await?;
+		for ev in events.iter().filter_map(|e| e.ok()) {
+			if ev.pallet_name() == "TransactionStorage" &&
+				ev.variant_name() == "Stored" &&
+				ev.field_bytes().windows(32).any(|w| w == content_hash)
+			{
+				return Ok(block_n);
+			}
+		}
+		if block_n == 0 {
+			break;
+		}
+		let parent_hash = current.header().parent_hash;
+		current = client.blocks().at(parent_hash).await?;
+	}
+	anyhow::bail!(
+		"Stored event for content_hash 0x{} not found on finalized chain at/above block {}",
+		hex::encode(content_hash),
+		search_from_inclusive,
+	)
+}
+
 /// Canonical store/renew block number, read from `TransactionByContentHash` at the
 /// inclusion-block hash. subxt's `tx_in_block.block_hash()` can name a block whose
 /// `block.number()` is one ahead of the canonical `Transactions[N]` key the pallet uses to

--- a/zombienet-sdk-tests/tests/utils/tx.rs
+++ b/zombienet-sdk-tests/tests/utils/tx.rs
@@ -233,8 +233,9 @@ pub async fn authorize_and_store_items(
 /// Best-only inclusion for both the authorize and store extrinsics — caller gets fast
 /// turnaround (~1 block) so any follow-up like `enable_auto_renew` can land before
 /// `store_block + RP`. Returns the canonical inclusion block number read at the
-/// inclusion-block hash. Callers that later assert against finalized state must resolve
-/// canonicality with [`finalized_store_block_for_hash`] to survive reorgs.
+/// inclusion-block hash. Callers that later assert against finalized state accept that a
+/// rare reorg between best-inclusion and finality can leave the captured block number
+/// pointing at an orphaned chain.
 pub async fn authorize_and_store_data(
 	node: &zombienet_sdk::NetworkNode,
 	data: &[u8],
@@ -295,22 +296,8 @@ pub async fn authorize_and_store_data(
 	Ok((block_number, nonce))
 }
 
-/// Read the canonical store block number for `content_hash` from the **finalized** chain.
-/// Use this *after* finality has caught up past the store, so callers that later assert
-/// against finalized state survive reorgs that moved the store extrinsic to a different
-/// block on the new canonical chain.
-pub async fn finalized_store_block_for_hash(
-	client: &OnlineClient<SubstrateConfig>,
-	content_hash: &[u8; 32],
-) -> Result<u64> {
-	let finalized_hash = client.blocks().at_latest().await?.hash();
-	canonical_store_block(client, finalized_hash, content_hash).await
-}
-
 /// Returns (block_number, next_nonce). Waits for finalization (for LDB / sync tests where
 /// the captured block number must be on the canonical chain *before* the test proceeds).
-/// Auto-renew flows should keep using [`authorize_and_store_data`] + a late
-/// [`finalized_store_block_for_hash`] so they don't burn the RP window on finality.
 pub async fn authorize_and_store_data_finalized(
 	node: &zombienet_sdk::NetworkNode,
 	data: &[u8],
@@ -458,8 +445,7 @@ pub async fn top_up_alice_authorization(
 
 /// Signed `store(data)` from Alice; caller ensures Alice is authorized. Returns the
 /// canonical inclusion block number (see [`canonical_store_block`]). Waits for best-only
-/// inclusion — callers that later read finalized state must resolve canonicality with
-/// [`finalized_store_block_for_hash`] to survive reorgs.
+/// inclusion; callers accept the rare-reorg risk on later finalized-state reads.
 pub async fn submit_store_signed(
 	client: &OnlineClient<SubstrateConfig>,
 	data: &[u8],

--- a/zombienet-sdk-tests/tests/utils/tx.rs
+++ b/zombienet-sdk-tests/tests/utils/tx.rs
@@ -230,10 +230,88 @@ pub async fn authorize_and_store_items(
 }
 
 /// Returns (block_number, next_nonce). Waits for best block.
-/// Waits for finality of both the authorize and store extrinsics before returning. See
-/// [`submit_store_signed`] for why best-only inclusion is unsafe for callers that later
-/// read finalized state.
+/// Best-only inclusion for both the authorize and store extrinsics — caller gets fast
+/// turnaround (~1 block) so any follow-up like `enable_auto_renew` can land before
+/// `store_block + RP`. Returns the canonical inclusion block number read at the
+/// inclusion-block hash. Callers that later assert against finalized state must resolve
+/// canonicality with [`finalized_store_block_for_hash`] to survive reorgs.
 pub async fn authorize_and_store_data(
+	node: &zombienet_sdk::NetworkNode,
+	data: &[u8],
+	mut nonce: u64,
+) -> Result<(u64, u64)> {
+	let client: OnlineClient<SubstrateConfig> = node.wait_client().await?;
+	let signer = dev::alice();
+	let bytes_to_authorize = (data.len() as u64) * 2;
+
+	let authorize_call = subxt::tx::dynamic(
+		"Sudo",
+		"sudo",
+		vec![value! {
+			TransactionStorage(authorize_account {
+				who: Value::from_bytes(signer.public_key().0),
+				transactions: 10u32,
+				bytes: bytes_to_authorize
+			})
+		}],
+	);
+
+	tracing::info!("Submitting authorization transaction (nonce={})...", nonce);
+	let params = SubstrateExtrinsicParamsBuilder::new().nonce(nonce).build();
+	nonce += 1;
+
+	tokio::time::timeout(Duration::from_secs(TRANSACTION_TIMEOUT_SECS), async {
+		let progress =
+			client.tx().sign_and_submit_then_watch(&authorize_call, &signer, params).await?;
+		wait_for_in_best_block(progress).await?;
+		Ok::<_, anyhow::Error>(())
+	})
+	.await
+	.map_err(|_| anyhow!("authorization transaction timed out"))??;
+
+	tracing::info!("Authorization transaction included in block");
+
+	let store_call = tx("TransactionStorage", "store", vec![Value::from_bytes(data)]);
+
+	tracing::info!("Submitting store transaction (nonce={})...", nonce);
+	let params = SubstrateExtrinsicParamsBuilder::new().nonce(nonce).build();
+	nonce += 1;
+
+	let (block_hash, _events) =
+		tokio::time::timeout(Duration::from_secs(TRANSACTION_TIMEOUT_SECS), async {
+			let progress =
+				client.tx().sign_and_submit_then_watch(&store_call, &signer, params).await?;
+			wait_for_in_best_block(progress).await
+		})
+		.await
+		.map_err(|_| anyhow!("store transaction timed out"))??;
+
+	// subxt's `tx_in_block.block_hash()` can name a block whose number is one ahead of the
+	// canonical `Transactions[N]` key — see `canonical_store_block`.
+	let content_hash = blake2_256(data);
+	let block_number = canonical_store_block(&client, block_hash, &content_hash).await?;
+
+	tracing::info!("Store transaction included at canonical block {}", block_number);
+	Ok((block_number, nonce))
+}
+
+/// Read the canonical store block number for `content_hash` from the **finalized** chain.
+/// Use this *after* finality has caught up past the store, so callers that later assert
+/// against finalized state survive reorgs that moved the store extrinsic to a different
+/// block on the new canonical chain.
+pub async fn finalized_store_block_for_hash(
+	client: &OnlineClient<SubstrateConfig>,
+	content_hash: &[u8; 32],
+) -> Result<u64> {
+	let finalized_hash = client.blocks().at_latest().await?.hash();
+	canonical_store_block(client, finalized_hash, content_hash).await
+}
+
+/// Returns (block_number, next_nonce). Waits for finalization (for LDB / sync tests where
+/// the captured block number must be on the canonical chain *before* the test proceeds).
+/// Auto-renew flows should keep using [`authorize_and_store_data`] + a late
+/// [`finalized_store_block_for_hash`] so they don't burn the RP window on finality.
+pub async fn authorize_and_store_data_finalized(
 	node: &zombienet_sdk::NetworkNode,
 	data: &[u8],
 	mut nonce: u64,
@@ -284,12 +362,10 @@ pub async fn authorize_and_store_data(
 		.await
 		.map_err(|_| anyhow!("store transaction timed out"))??;
 
-	// subxt's `tx_in_block.block_hash()` can name a block whose number is one ahead of the
-	// canonical `Transactions[N]` key — see `canonical_store_block`.
-	let content_hash = blake2_256(data);
-	let block_number = canonical_store_block(&client, block_hash, &content_hash).await?;
+	let block = client.blocks().at(block_hash).await?;
+	let block_number = block.number() as u64;
 
-	tracing::info!("Store transaction finalized at canonical block {}", block_number);
+	tracing::info!("Store transaction finalized at block {}", block_number);
 	Ok((block_number, nonce))
 }
 
@@ -381,11 +457,9 @@ pub async fn top_up_alice_authorization(
 }
 
 /// Signed `store(data)` from Alice; caller ensures Alice is authorized. Returns the
-/// canonical inclusion block number (see [`canonical_store_block`]), waiting for finality
-/// before reading. Best-only inclusion is unsafe here: a reorg between inclusion and the
-/// caller's later assertion would leave the captured block number pointing at an orphaned
-/// chain while `finalized_block_hash_at` reads the new canonical chain, producing flakes
-/// like "expected 1 ProofChecked at block X, saw 0".
+/// canonical inclusion block number (see [`canonical_store_block`]). Waits for best-only
+/// inclusion — callers that later read finalized state must resolve canonicality with
+/// [`finalized_store_block_for_hash`] to survive reorgs.
 pub async fn submit_store_signed(
 	client: &OnlineClient<SubstrateConfig>,
 	data: &[u8],
@@ -395,20 +469,20 @@ pub async fn submit_store_signed(
 	let store_call = tx("TransactionStorage", "store", vec![Value::from_bytes(data)]);
 	let params = SubstrateExtrinsicParamsBuilder::new().nonce(nonce).build();
 
-	tracing::info!("Submitting store (finalized, nonce={}, {} bytes)...", nonce, data.len());
+	tracing::info!("Submitting store (nonce={}, {} bytes)...", nonce, data.len());
 
 	let (block_hash, _events) =
-		tokio::time::timeout(Duration::from_secs(FINALIZED_TRANSACTION_TIMEOUT_SECS), async {
+		tokio::time::timeout(Duration::from_secs(TRANSACTION_TIMEOUT_SECS), async {
 			let progress =
 				client.tx().sign_and_submit_then_watch(&store_call, &signer, params).await?;
-			wait_for_finalized(progress).await
+			wait_for_in_best_block(progress).await
 		})
 		.await
 		.map_err(|_| anyhow!("store transaction timed out"))??;
 
 	let content_hash = blake2_256(data);
 	let block_number = canonical_store_block(client, block_hash, &content_hash).await?;
-	tracing::info!("Store transaction finalized at canonical block {}", block_number);
+	tracing::info!("Store transaction included at canonical block {}", block_number);
 	Ok(block_number)
 }
 

--- a/zombienet-sdk-tests/tests/utils/tx.rs
+++ b/zombienet-sdk-tests/tests/utils/tx.rs
@@ -230,68 +230,10 @@ pub async fn authorize_and_store_items(
 }
 
 /// Returns (block_number, next_nonce). Waits for best block.
+/// Waits for finality of both the authorize and store extrinsics before returning. See
+/// [`submit_store_signed`] for why best-only inclusion is unsafe for callers that later
+/// read finalized state.
 pub async fn authorize_and_store_data(
-	node: &zombienet_sdk::NetworkNode,
-	data: &[u8],
-	mut nonce: u64,
-) -> Result<(u64, u64)> {
-	let client: OnlineClient<SubstrateConfig> = node.wait_client().await?;
-	let signer = dev::alice();
-	let bytes_to_authorize = (data.len() as u64) * 2;
-
-	let authorize_call = subxt::tx::dynamic(
-		"Sudo",
-		"sudo",
-		vec![value! {
-			TransactionStorage(authorize_account {
-				who: Value::from_bytes(signer.public_key().0),
-				transactions: 10u32,
-				bytes: bytes_to_authorize
-			})
-		}],
-	);
-
-	tracing::info!("Submitting authorization transaction (nonce={})...", nonce);
-	let params = SubstrateExtrinsicParamsBuilder::new().nonce(nonce).build();
-	nonce += 1;
-
-	tokio::time::timeout(Duration::from_secs(TRANSACTION_TIMEOUT_SECS), async {
-		let progress =
-			client.tx().sign_and_submit_then_watch(&authorize_call, &signer, params).await?;
-		wait_for_in_best_block(progress).await?;
-		Ok::<_, anyhow::Error>(())
-	})
-	.await
-	.map_err(|_| anyhow!("authorization transaction timed out"))??;
-
-	tracing::info!("Authorization transaction included in block");
-
-	let store_call = tx("TransactionStorage", "store", vec![Value::from_bytes(data)]);
-
-	tracing::info!("Submitting store transaction (nonce={})...", nonce);
-	let params = SubstrateExtrinsicParamsBuilder::new().nonce(nonce).build();
-	nonce += 1;
-
-	let (block_hash, _events) =
-		tokio::time::timeout(Duration::from_secs(TRANSACTION_TIMEOUT_SECS), async {
-			let progress =
-				client.tx().sign_and_submit_then_watch(&store_call, &signer, params).await?;
-			wait_for_in_best_block(progress).await
-		})
-		.await
-		.map_err(|_| anyhow!("store transaction timed out"))??;
-
-	// subxt's `tx_in_block.block_hash()` can name a block whose number is one ahead of the
-	// canonical `Transactions[N]` key — see `canonical_store_block`.
-	let content_hash = blake2_256(data);
-	let block_number = canonical_store_block(&client, block_hash, &content_hash).await?;
-
-	tracing::info!("Store transaction included at canonical block {}", block_number);
-	Ok((block_number, nonce))
-}
-
-/// Returns (block_number, next_nonce). Waits for finalization (for LDB tests).
-pub async fn authorize_and_store_data_finalized(
 	node: &zombienet_sdk::NetworkNode,
 	data: &[u8],
 	mut nonce: u64,
@@ -342,10 +284,12 @@ pub async fn authorize_and_store_data_finalized(
 		.await
 		.map_err(|_| anyhow!("store transaction timed out"))??;
 
-	let block = client.blocks().at(block_hash).await?;
-	let block_number = block.number() as u64;
+	// subxt's `tx_in_block.block_hash()` can name a block whose number is one ahead of the
+	// canonical `Transactions[N]` key — see `canonical_store_block`.
+	let content_hash = blake2_256(data);
+	let block_number = canonical_store_block(&client, block_hash, &content_hash).await?;
 
-	tracing::info!("Store transaction finalized at block {}", block_number);
+	tracing::info!("Store transaction finalized at canonical block {}", block_number);
 	Ok((block_number, nonce))
 }
 
@@ -437,7 +381,11 @@ pub async fn top_up_alice_authorization(
 }
 
 /// Signed `store(data)` from Alice; caller ensures Alice is authorized. Returns the
-/// canonical inclusion block number (see [`canonical_store_block`]).
+/// canonical inclusion block number (see [`canonical_store_block`]), waiting for finality
+/// before reading. Best-only inclusion is unsafe here: a reorg between inclusion and the
+/// caller's later assertion would leave the captured block number pointing at an orphaned
+/// chain while `finalized_block_hash_at` reads the new canonical chain, producing flakes
+/// like "expected 1 ProofChecked at block X, saw 0".
 pub async fn submit_store_signed(
 	client: &OnlineClient<SubstrateConfig>,
 	data: &[u8],
@@ -447,20 +395,20 @@ pub async fn submit_store_signed(
 	let store_call = tx("TransactionStorage", "store", vec![Value::from_bytes(data)]);
 	let params = SubstrateExtrinsicParamsBuilder::new().nonce(nonce).build();
 
-	tracing::info!("Submitting store (nonce={}, {} bytes)...", nonce, data.len());
+	tracing::info!("Submitting store (finalized, nonce={}, {} bytes)...", nonce, data.len());
 
 	let (block_hash, _events) =
-		tokio::time::timeout(Duration::from_secs(TRANSACTION_TIMEOUT_SECS), async {
+		tokio::time::timeout(Duration::from_secs(FINALIZED_TRANSACTION_TIMEOUT_SECS), async {
 			let progress =
 				client.tx().sign_and_submit_then_watch(&store_call, &signer, params).await?;
-			wait_for_in_best_block(progress).await
+			wait_for_finalized(progress).await
 		})
 		.await
 		.map_err(|_| anyhow!("store transaction timed out"))??;
 
 	let content_hash = blake2_256(data);
 	let block_number = canonical_store_block(client, block_hash, &content_hash).await?;
-	tracing::info!("Store transaction included at canonical block {}", block_number);
+	tracing::info!("Store transaction finalized at canonical block {}", block_number);
 	Ok(block_number)
 }
 

--- a/zombienet/bulletin-paseo-local.toml
+++ b/zombienet/bulletin-paseo-local.toml
@@ -26,6 +26,13 @@ p2p_port = 30433
 rpc_port = 9943
 balance = 2000000000000
 
+[[relaychain.nodes]]
+name = "charlie"
+validator = true
+p2p_port = 30533
+rpc_port = 9944
+balance = 2000000000000
+
 [[parachains]]
 id = 1501
 chain_spec_path = "./zombienet/bulletin-paseo-spec.json"

--- a/zombienet/bulletin-westend-local.toml
+++ b/zombienet/bulletin-westend-local.toml
@@ -26,6 +26,13 @@ p2p_port = 30433
 rpc_port = 9943
 balance = 2000000000000
 
+[[relaychain.nodes]]
+name = "charlie"
+validator = true
+p2p_port = 30533
+rpc_port = 9944
+balance = 2000000000000
+
 [[parachains]]
 id = 1010
 chain_spec_path = "./zombienet/bulletin-westend-spec.json"


### PR DESCRIPTION
Stabilize zombienet-SDK CI: align event/block reads to the finalized chain, add a third relay validator for finality robustness, and  give bulk-`enable_auto_renew` tests enough RP headroom to survive finality lag.

  ### Changes

  - **Relay topology.** Added `charlie` validator to `zombienet/bulletin-{westend,paseo}-local.toml`. All sync tests switch to `build_parachain_network_config_three_relay_validators`; the single-collator helper in `utils/network.rs` is removed. Three validators give GRANDPA a fault-tolerant quorum, preventing brief stalls that widen the best-vs-finalized window.

  - **Finalized-state reads** in `auto_renew_storage.rs`: event scans, block-hash lookups, and walk-backs switch from best to finalized (`current_finalized_block`, `finalized_block_hash_at`, finalized parent-hash traversal). Removes the class of flakes where  a best-block read followed a non-canonical fork.

  - **`BULK_ENABLE_RETENTION_PERIOD = 30`** for the two standalone tests that bulk-submit `enable_auto_renew` after a finality wait (`parachain_on_initialize_cleanup_test`, `parachain_auto_renew_many_items_worst_case_test`). With RP=10 and ~6–10-block finality
  lag, the chain advances past `store_block + RP` while waiting, so every enable hits `RenewedNotFound`. RP=30 gives ~15 blocks of margin. The cleanup test's diagnostic also counts `frame_system::ExtrinsicFailed` to distinguish "enables landed but rejected" from "enables never landed".

  - **`parachain_auto_renew_many_items_test`** stays at RP=10 (shared `archive_harness` — mid-chain RP bump halts finality via the proof inherent). Its pre-enable wait uses **best** (`wait_for_block_height`) so `pre_enable_block ≈ store_block + 1` and bulk enables land inside the RP window. Walk-back stays on best — only used for earliest/latest store-block as cycle anchors, not for finalized assertions.

  - **`tx.rs` docstrings** clarify: `submit_store_signed` / `authorize_and_store_data` wait for best (fast, so callers can follow up before `store_block + RP`); `authorize_and_store_data_finalized` retained for LDB/sync tests where the captured block must be canonical.