### PR TITLE
ci: shared `use-polkadot-binaries` action

### DIFF
--- a/.github/actions/use-polkadot-binaries/action.yml
+++ b/.github/actions/use-polkadot-binaries/action.yml
@@ -1,0 +1,234 @@
+name: Set up Polkadot binaries
+description: |
+  Restore or populate the cached polkadot-sdk binaries and add them to PATH.
+
+  Modes:
+    prepare  — populate-on-miss + save-on-end. Must run in a non-matrix job so the
+               cache is built exactly once and shared with downstream consumers.
+    consume  — restore-only with fail-on-cache-miss. Use in matrix legs / consumers.
+
+  Versions are read from .github/env (POLKADOT_NODE_VERSION, CHAIN_SPEC_BUILDER_VERSION,
+  ZOMBIENET_VERSION, TRY_RUNTIME_VERSION, FRAME_OMNI_BENCHER_VERSION). The action loads
+  that file into $GITHUB_ENV and installs `just` for you — callers only need to checkout
+  the repo first.
+
+inputs:
+  groups:
+    description: Space-separated binary groups. Supported - polkadot-node, chain-spec-builder, zombienet, try-runtime, frame-omni-bencher.
+    required: true
+  mode:
+    description: prepare (populate + save, non-matrix job) or consume (restore-only).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Validate use-polkadot-binaries inputs
+      shell: bash
+      env:
+        INPUT_GROUPS: ${{ inputs.groups }}
+        INPUT_MODE: ${{ inputs.mode }}
+      run: |
+        set -euo pipefail
+        case "$INPUT_MODE" in
+          prepare|consume) ;;
+          *) echo "::error::use-polkadot-binaries: mode must be 'prepare' or 'consume', got '$INPUT_MODE'"; exit 1 ;;
+        esac
+        if [ -z "${INPUT_GROUPS// }" ]; then
+          echo "::error::use-polkadot-binaries: groups must be a non-empty space-separated list"
+          exit 1
+        fi
+        VALID="polkadot-node chain-spec-builder zombienet try-runtime frame-omni-bencher"
+        for g in $INPUT_GROUPS; do
+          case " $VALID " in
+            *" $g "*) ;;
+            *) echo "::error::use-polkadot-binaries: unknown group '$g'. Valid - $VALID"; exit 1 ;;
+          esac
+        done
+
+    - name: Refuse prepare in matrix job
+      if: inputs.mode == 'prepare' && toJSON(matrix) != 'null'
+      shell: bash
+      run: |
+        echo "::error::use-polkadot-binaries: mode=prepare must run in a non-matrix job."
+        echo "::error::Add a dedicated prepare-* job upstream and have matrix legs use mode=consume."
+        exit 1
+
+    - name: Load .github/env
+      shell: bash
+      run: cat .github/env >> "$GITHUB_ENV"
+
+    - name: Install just
+      uses: ./.github/actions/install-just
+
+    # ============================================================
+    # polkadot-node
+    # ============================================================
+    - name: Cache polkadot-node binaries
+      id: cache-polkadot-node
+      if: inputs.mode == 'prepare' && contains(format(' {0} ', inputs.groups), ' polkadot-node ')
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ${{ env.POLKADOT_BINARIES_DIR }}/polkadot-node
+        key: polkadot-binaries-${{ runner.os }}-polkadot-node-${{ env.POLKADOT_NODE_VERSION }}
+
+    - name: Populate polkadot-node binaries
+      if: inputs.mode == 'prepare' && contains(format(' {0} ', inputs.groups), ' polkadot-node ') && steps.cache-polkadot-node.outputs.cache-hit != 'true'
+      shell: bash
+      run: just binaries-polkadot > /dev/null
+
+    - name: Restore polkadot-node binaries
+      if: inputs.mode == 'consume' && contains(format(' {0} ', inputs.groups), ' polkadot-node ')
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ${{ env.POLKADOT_BINARIES_DIR }}/polkadot-node
+        key: polkadot-binaries-${{ runner.os }}-polkadot-node-${{ env.POLKADOT_NODE_VERSION }}
+        fail-on-cache-miss: true
+
+    - name: Add polkadot-node to PATH
+      if: contains(format(' {0} ', inputs.groups), ' polkadot-node ')
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Cache extraction can drop the +x bit; restore it before `just` validates
+        # the binaries (its presence check uses [ -x ]).
+        if [ -d "${POLKADOT_BINARIES_DIR}/polkadot-node" ]; then
+          chmod -R +x "${POLKADOT_BINARIES_DIR}/polkadot-node"
+        fi
+        just binaries-polkadot >> "$GITHUB_PATH"
+
+    # ============================================================
+    # chain-spec-builder
+    # ============================================================
+    - name: Cache chain-spec-builder binaries
+      id: cache-chain-spec-builder
+      if: inputs.mode == 'prepare' && contains(format(' {0} ', inputs.groups), ' chain-spec-builder ')
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ${{ env.POLKADOT_BINARIES_DIR }}/chain-spec-builder
+        key: polkadot-binaries-${{ runner.os }}-chain-spec-builder-${{ env.CHAIN_SPEC_BUILDER_VERSION }}
+
+    - name: Populate chain-spec-builder binaries
+      if: inputs.mode == 'prepare' && contains(format(' {0} ', inputs.groups), ' chain-spec-builder ') && steps.cache-chain-spec-builder.outputs.cache-hit != 'true'
+      shell: bash
+      run: just binaries-chain-spec-builder > /dev/null
+
+    - name: Restore chain-spec-builder binaries
+      if: inputs.mode == 'consume' && contains(format(' {0} ', inputs.groups), ' chain-spec-builder ')
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ${{ env.POLKADOT_BINARIES_DIR }}/chain-spec-builder
+        key: polkadot-binaries-${{ runner.os }}-chain-spec-builder-${{ env.CHAIN_SPEC_BUILDER_VERSION }}
+        fail-on-cache-miss: true
+
+    - name: Add chain-spec-builder to PATH
+      if: contains(format(' {0} ', inputs.groups), ' chain-spec-builder ')
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -d "${POLKADOT_BINARIES_DIR}/chain-spec-builder" ]; then
+          chmod -R +x "${POLKADOT_BINARIES_DIR}/chain-spec-builder"
+        fi
+        just binaries-chain-spec-builder >> "$GITHUB_PATH"
+
+    # ============================================================
+    # zombienet
+    # ============================================================
+    - name: Cache zombienet binaries
+      id: cache-zombienet
+      if: inputs.mode == 'prepare' && contains(format(' {0} ', inputs.groups), ' zombienet ')
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ${{ env.POLKADOT_BINARIES_DIR }}/zombienet
+        key: polkadot-binaries-${{ runner.os }}-zombienet-${{ env.ZOMBIENET_VERSION }}
+
+    - name: Populate zombienet binaries
+      if: inputs.mode == 'prepare' && contains(format(' {0} ', inputs.groups), ' zombienet ') && steps.cache-zombienet.outputs.cache-hit != 'true'
+      shell: bash
+      run: just binaries-zombienet > /dev/null
+
+    - name: Restore zombienet binaries
+      if: inputs.mode == 'consume' && contains(format(' {0} ', inputs.groups), ' zombienet ')
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ${{ env.POLKADOT_BINARIES_DIR }}/zombienet
+        key: polkadot-binaries-${{ runner.os }}-zombienet-${{ env.ZOMBIENET_VERSION }}
+        fail-on-cache-miss: true
+
+    - name: Add zombienet to PATH
+      if: contains(format(' {0} ', inputs.groups), ' zombienet ')
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -d "${POLKADOT_BINARIES_DIR}/zombienet" ]; then
+          chmod -R +x "${POLKADOT_BINARIES_DIR}/zombienet"
+        fi
+        just binaries-zombienet >> "$GITHUB_PATH"
+
+    # ============================================================
+    # try-runtime
+    # ============================================================
+    - name: Cache try-runtime binaries
+      id: cache-try-runtime
+      if: inputs.mode == 'prepare' && contains(format(' {0} ', inputs.groups), ' try-runtime ')
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ${{ env.POLKADOT_BINARIES_DIR }}/try-runtime
+        key: polkadot-binaries-${{ runner.os }}-try-runtime-${{ env.TRY_RUNTIME_VERSION }}
+
+    - name: Populate try-runtime binaries
+      if: inputs.mode == 'prepare' && contains(format(' {0} ', inputs.groups), ' try-runtime ') && steps.cache-try-runtime.outputs.cache-hit != 'true'
+      shell: bash
+      run: just binaries-try-runtime > /dev/null
+
+    - name: Restore try-runtime binaries
+      if: inputs.mode == 'consume' && contains(format(' {0} ', inputs.groups), ' try-runtime ')
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ${{ env.POLKADOT_BINARIES_DIR }}/try-runtime
+        key: polkadot-binaries-${{ runner.os }}-try-runtime-${{ env.TRY_RUNTIME_VERSION }}
+        fail-on-cache-miss: true
+
+    - name: Add try-runtime to PATH
+      if: contains(format(' {0} ', inputs.groups), ' try-runtime ')
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -d "${POLKADOT_BINARIES_DIR}/try-runtime" ]; then
+          chmod -R +x "${POLKADOT_BINARIES_DIR}/try-runtime"
+        fi
+        just binaries-try-runtime >> "$GITHUB_PATH"
+
+    # ============================================================
+    # frame-omni-bencher
+    # ============================================================
+    - name: Cache frame-omni-bencher binaries
+      id: cache-frame-omni-bencher
+      if: inputs.mode == 'prepare' && contains(format(' {0} ', inputs.groups), ' frame-omni-bencher ')
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ${{ env.POLKADOT_BINARIES_DIR }}/frame-omni-bencher
+        key: polkadot-binaries-${{ runner.os }}-frame-omni-bencher-${{ env.FRAME_OMNI_BENCHER_VERSION }}
+
+    - name: Populate frame-omni-bencher binaries
+      if: inputs.mode == 'prepare' && contains(format(' {0} ', inputs.groups), ' frame-omni-bencher ') && steps.cache-frame-omni-bencher.outputs.cache-hit != 'true'
+      shell: bash
+      run: just binaries-bencher > /dev/null
+
+    - name: Restore frame-omni-bencher binaries
+      if: inputs.mode == 'consume' && contains(format(' {0} ', inputs.groups), ' frame-omni-bencher ')
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ${{ env.POLKADOT_BINARIES_DIR }}/frame-omni-bencher
+        key: polkadot-binaries-${{ runner.os }}-frame-omni-bencher-${{ env.FRAME_OMNI_BENCHER_VERSION }}
+        fail-on-cache-miss: true
+
+    - name: Add frame-omni-bencher to PATH
+      if: contains(format(' {0} ', inputs.groups), ' frame-omni-bencher ')
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -d "${POLKADOT_BINARIES_DIR}/frame-omni-bencher" ]; then
+          chmod -R +x "${POLKADOT_BINARIES_DIR}/frame-omni-bencher"
+        fi
+        just binaries-bencher >> "$GITHUB_PATH"

--- a/.github/workflows/chainspec-sync-check.yml
+++ b/.github/workflows/chainspec-sync-check.yml
@@ -34,21 +34,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Load common environment variables via env file
-        run: cat .github/env >> $GITHUB_ENV
-
-      - uses: ./.github/actions/install-just
-
-      - name: Cache polkadot-node binaries
-        id: cache-binaries
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - name: Set up Polkadot binaries
+        uses: ./.github/actions/use-polkadot-binaries
         with:
-          path: ${{ env.POLKADOT_BINARIES_DIR }}/polkadot-node
-          key: polkadot-node-${{ runner.os }}-${{ env.POLKADOT_NODE_VERSION }}
-
-      - name: Populate cache
-        if: steps.cache-binaries.outputs.cache-hit != 'true'
-        run: just binaries-polkadot
+          groups: polkadot-node
+          mode: prepare
 
   sync-check:
     needs: [set-image, setup]
@@ -77,25 +67,17 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Load common environment variables via env file
-        run: cat .github/env >> $GITHUB_ENV
-
-      - uses: ./.github/actions/install-just
-
-      - name: Restore binary cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - name: Set up Polkadot binaries
+        uses: ./.github/actions/use-polkadot-binaries
         with:
-          path: ${{ env.POLKADOT_BINARIES_DIR }}/polkadot-node
-          key: polkadot-node-${{ runner.os }}-${{ env.POLKADOT_NODE_VERSION }}
-          fail-on-cache-miss: true
-
-      - name: Resolve binary directory
-        run: |
-          POLKADOT_DIR="$(just binaries-polkadot)"
-          echo "$POLKADOT_DIR" >> "$GITHUB_PATH"
+          groups: polkadot-node
+          mode: consume
 
       - name: Sync a few blocks
-        run: ./scripts/chainspec_sync_check.sh "${{ matrix.chainspec }}" "${{ matrix.relay_rpc }}"
+        env:
+          CHAINSPEC: ${{ matrix.chainspec }}
+          RELAY_RPC: ${{ matrix.relay_rpc }}
+        run: ./scripts/chainspec_sync_check.sh "$CHAINSPEC" "$RELAY_RPC"
 
       - name: Upload omni-node log on failure
         if: failure()
@@ -107,7 +89,7 @@ jobs:
 
   sync-check-complete:
     name: All chainspec sync checks passed
-    needs: [sync-check]
+    needs: [setup, sync-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -48,8 +48,23 @@ jobs:
           TASKS=$(echo $TASKS | jq -c .)
           echo "runtime=$TASKS" >> $GITHUB_OUTPUT
 
+  prepare-try-runtime:
+    name: Prepare try-runtime
+    needs: [changes]
+    if: needs.changes.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Polkadot binaries
+        uses: ./.github/actions/use-polkadot-binaries
+        with:
+          groups: try-runtime
+          mode: prepare
+
   prepare-snapshots:
-    needs: [runtime-matrix]
+    needs: [runtime-matrix, prepare-try-runtime]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -59,6 +74,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # Snapshot lookup uses a deliberately-non-matching primary `key:` so
+      # `restore-keys` always falls through to the most recent dated entry.
+      # With `lookup-only` the snapshot isn't restored — we just decide
+      # whether to regenerate. `cache-matched-key` is empty iff nothing was
+      # found, which is also the case on the daily `schedule` (lookup
+      # skipped) so the snapshot is force-refreshed nightly.
       - name: Check if snapshot exists in cache
         id: cache-restore
         if: github.event_name != 'schedule'
@@ -71,22 +92,12 @@ jobs:
             try-runtime-snapshot-${{ matrix.runtime.name }}-
           fail-on-cache-miss: false
 
-      - name: Load common environment variables via env file
-        run: cat .github/env >> $GITHUB_ENV
-
-      - uses: ./.github/actions/install-just
+      - name: Set up Polkadot binaries
         if: steps.cache-restore.outputs.cache-matched-key == ''
-
-      - name: Cache try-runtime CLI
-        if: steps.cache-restore.outputs.cache-matched-key == ''
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/use-polkadot-binaries
         with:
-          path: ${{ env.POLKADOT_BINARIES_DIR }}/try-runtime
-          key: polkadot-binaries-${{ runner.os }}-${{ env.TRY_RUNTIME_VERSION }}
-
-      - name: Resolve try-runtime + add to PATH
-        if: steps.cache-restore.outputs.cache-matched-key == ''
-        run: echo "$(just binaries-try-runtime)" >> "$GITHUB_PATH"
+          groups: try-runtime
+          mode: consume
 
       - name: Generate snapshot for ${{ matrix.runtime.name }}
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -134,7 +145,7 @@ jobs:
 
 
   check-migrations:
-    needs: [runtime-matrix, prepare-snapshots]
+    needs: [runtime-matrix, prepare-try-runtime, prepare-snapshots]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
@@ -154,8 +165,11 @@ jobs:
           git remote add upstream "https://github.com/${BASE_REPO}.git"
           git fetch upstream --tags
 
-      - name: Load common environment variables via env file
-        run: cat .github/env >> $GITHUB_ENV
+      - name: Set up Polkadot binaries
+        uses: ./.github/actions/use-polkadot-binaries
+        with:
+          groups: try-runtime
+          mode: consume
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
@@ -163,17 +177,6 @@ jobs:
           targets: "wasm32v1-none"
           components: "rust-src"
           toolchain: "${{ env.RUST_STABLE_VERSION }}"
-
-      - uses: ./.github/actions/install-just
-
-      - name: Cache try-runtime CLI
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ${{ env.POLKADOT_BINARIES_DIR }}/try-runtime
-          key: polkadot-binaries-${{ runner.os }}-${{ env.TRY_RUNTIME_VERSION }}
-
-      - name: Resolve try-runtime + add to PATH
-        run: echo "$(just binaries-try-runtime)" >> "$GITHUB_PATH"
 
       - name: Restore snapshot from cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -213,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     name: All migrations passed
     if: always() && github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    needs: [changes, check-migrations]
+    needs: [changes, prepare-try-runtime, prepare-snapshots, check-migrations]
     steps:
       - name: Decide outcome
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -142,11 +142,27 @@ jobs:
       - name: Run tests
         run: ${{ matrix.target.cmd }}
 
+  prepare-bencher:
+    name: Prepare frame-omni-bencher
+    needs: [set-image, check-fmt]
+    runs-on: parity-large
+    container:
+      image: ${{ needs.set-image.outputs.CI_IMAGE }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Polkadot binaries
+        uses: ./.github/actions/use-polkadot-binaries
+        with:
+          groups: frame-omni-bencher
+          mode: prepare
+
   benchmarks:
     name: Check Benchmarks (${{ matrix.runtime.name }})
     runs-on: parity-large
     timeout-minutes: 60
-    needs: [set-image, check-fmt]
+    needs: [set-image, check-fmt, prepare-bencher]
     container:
       image: ${{ needs.set-image.outputs.CI_IMAGE }}
     strategy:
@@ -167,19 +183,11 @@ jobs:
           shared-key: "bulletin-cache-benchmarks-${{ matrix.runtime.name }}"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Load common environment variables via env file
-        run: cat .github/env >> $GITHUB_ENV
-
-      - uses: ./.github/actions/install-just
-
-      - name: Cache frame-omni-bencher
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - name: Set up Polkadot binaries
+        uses: ./.github/actions/use-polkadot-binaries
         with:
-          path: ${{ env.POLKADOT_BINARIES_DIR }}/frame-omni-bencher
-          key: polkadot-binaries-${{ runner.os }}-${{ env.FRAME_OMNI_BENCHER_VERSION }}
-
-      - name: Resolve frame-omni-bencher + add to PATH
-        run: echo "$(just binaries-bencher)" >> "$GITHUB_PATH"
+          groups: frame-omni-bencher
+          mode: consume
 
       - name: Run benchmarks (${{ matrix.runtime.name }})
         run: |
@@ -192,7 +200,7 @@ jobs:
   all-tests-passed:
     name: All tests passed
     if: always()
-    needs: [changes, check-fmt, clippy, test, benchmarks]
+    needs: [changes, check-fmt, clippy, test, prepare-bencher, benchmarks]
     runs-on: ubuntu-latest
     steps:
       - name: Decide outcome

--- a/.github/workflows/cmd-run.yml
+++ b/.github/workflows/cmd-run.yml
@@ -172,23 +172,12 @@ jobs:
           repository: ${{ env.REPO }}
           ref: ${{ env.PR_BRANCH }}
 
-      - name: Load .github/env
+      - name: Set up Polkadot binaries
         if: startsWith(github.event.inputs.cmd, 'bench')
-        run: grep -v '^#' .github/env | grep '=' >> $GITHUB_ENV
-
-      - uses: ./.github/actions/install-just
-        if: startsWith(github.event.inputs.cmd, 'bench')
-
-      - name: Cache frame-omni-bencher
-        if: startsWith(github.event.inputs.cmd, 'bench')
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: ./.github/actions/use-polkadot-binaries
         with:
-          path: ${{ env.POLKADOT_BINARIES_DIR }}/frame-omni-bencher
-          key: polkadot-binaries-${{ runner.os }}-${{ env.FRAME_OMNI_BENCHER_VERSION }}
-
-      - name: Resolve frame-omni-bencher + add to PATH
-        if: startsWith(github.event.inputs.cmd, 'bench')
-        run: echo "$(just binaries-bencher)" >> "$GITHUB_PATH"
+          groups: frame-omni-bencher
+          mode: prepare
 
       - name: Run cmd
         id: cmd

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -39,27 +39,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Load common environment variables via env file
-        run: cat .github/env >> $GITHUB_ENV
-
-      - uses: ./.github/actions/install-just
-
-      - name: Cache polkadot-sdk + zombienet binaries
-        id: cache-binaries
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - name: Set up Polkadot binaries
+        uses: ./.github/actions/use-polkadot-binaries
         with:
-          path: |
-            ${{ env.POLKADOT_BINARIES_DIR }}/polkadot-node
-            ${{ env.POLKADOT_BINARIES_DIR }}/chain-spec-builder
-            ${{ env.POLKADOT_BINARIES_DIR }}/zombienet
-          key: polkadot-binaries-${{ runner.os }}-${{ env.POLKADOT_NODE_VERSION }}-${{ env.CHAIN_SPEC_BUILDER_VERSION }}-${{ env.ZOMBIENET_VERSION }}
-
-      - name: Populate cache
-        if: steps.cache-binaries.outputs.cache-hit != 'true'
-        run: |
-          just binaries-polkadot
-          just binaries-chain-spec-builder
-          just binaries-zombienet
+          groups: polkadot-node chain-spec-builder zombienet
+          mode: prepare
 
   runtime-matrix:
     if: needs.changes.outputs.should-run == 'true'
@@ -97,8 +81,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Load common environment variables via env file
-        run: cat .github/env >> $GITHUB_ENV
+      - name: Set up Polkadot binaries
+        uses: ./.github/actions/use-polkadot-binaries
+        with:
+          groups: polkadot-node chain-spec-builder zombienet
+          mode: consume
 
       - name: Rust cache (Bulletin)
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -116,8 +103,6 @@ jobs:
             examples/package.json
             console-ui/package-lock.json
 
-      - uses: ./.github/actions/install-just
-
       - name: Install subxt-cli
         run: |
           if ! command -v subxt &> /dev/null; then
@@ -125,25 +110,6 @@ jobs:
           else
             echo "subxt-cli already installed"
           fi
-
-      - name: Restore binary cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: |
-            ${{ env.POLKADOT_BINARIES_DIR }}/polkadot-node
-            ${{ env.POLKADOT_BINARIES_DIR }}/chain-spec-builder
-            ${{ env.POLKADOT_BINARIES_DIR }}/zombienet
-          key: polkadot-binaries-${{ runner.os }}-${{ env.POLKADOT_NODE_VERSION }}-${{ env.CHAIN_SPEC_BUILDER_VERSION }}-${{ env.ZOMBIENET_VERSION }}
-          fail-on-cache-miss: true
-
-      - name: Resolve binary directories + add to PATH
-        run: |
-          POLKADOT_DIR="$(just binaries-polkadot)"
-          CSB_DIR="$(just binaries-chain-spec-builder)"
-          ZN_DIR="$(just binaries-zombienet)"
-          echo "$POLKADOT_DIR" >> "$GITHUB_PATH"
-          echo "$CSB_DIR" >> "$GITHUB_PATH"
-          echo "$ZN_DIR" >> "$GITHUB_PATH"
 
       - name: Start services
         working-directory: examples

--- a/.github/workflows/zombienet-tests.yml
+++ b/.github/workflows/zombienet-tests.yml
@@ -40,27 +40,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Load common environment variables via env file
-        run: cat .github/env >> $GITHUB_ENV
-
-      - uses: ./.github/actions/install-just
-
-      - name: Cache polkadot-sdk binaries
-        id: cache-binaries
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - name: Set up Polkadot binaries
+        uses: ./.github/actions/use-polkadot-binaries
         with:
-          # Cache only the resolved binaries (~333 MB); skip `.polkadot-binaries/_src/`
-          # which holds the polkadot-sdk clone + cargo target (~11 GB) from cold builds.
-          path: |
-            ${{ env.POLKADOT_BINARIES_DIR }}/polkadot-node
-            ${{ env.POLKADOT_BINARIES_DIR }}/chain-spec-builder
-          key: polkadot-binaries-${{ runner.os }}-${{ env.POLKADOT_NODE_VERSION }}-${{ env.CHAIN_SPEC_BUILDER_VERSION }}
-
-      - name: Fetch / build polkadot binaries
-        if: steps.cache-binaries.outputs.cache-hit != 'true'
-        run: |
-          just binaries-polkadot
-          just binaries-chain-spec-builder
+          groups: polkadot-node chain-spec-builder
+          mode: prepare
 
       # Keyed by commit SHA: the spec embeds the bulletin runtime WASM.
       - name: Cache bulletin chain specs
@@ -102,10 +86,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Load common environment variables via env file
-        run: cat .github/env >> $GITHUB_ENV
-
-      - uses: ./.github/actions/install-just
+      - name: Set up Polkadot binaries
+        uses: ./.github/actions/use-polkadot-binaries
+        with:
+          groups: polkadot-node chain-spec-builder
+          mode: consume
 
       - name: Rust cache
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
@@ -113,15 +98,6 @@ jobs:
           workspaces: .
           shared-key: "bulletin-cache-zombienet-auto-renew-tests-${{ matrix.runtime.name }}"
           save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Restore polkadot binaries cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: |
-            ${{ env.POLKADOT_BINARIES_DIR }}/polkadot-node
-            ${{ env.POLKADOT_BINARIES_DIR }}/chain-spec-builder
-          key: polkadot-binaries-${{ runner.os }}-${{ env.POLKADOT_NODE_VERSION }}-${{ env.CHAIN_SPEC_BUILDER_VERSION }}
-          fail-on-cache-miss: true
 
       - name: Restore bulletin chain specs cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -131,9 +107,6 @@ jobs:
             zombienet/bulletin-paseo-spec.json
           key: bulletin-specs-${{ runner.os }}-${{ github.sha }}
           fail-on-cache-miss: true
-
-      - name: Mark binaries executable
-        run: chmod -R +x "$POLKADOT_BINARIES_DIR"
 
       - name: Run zombienet auto-renew tests
         env:
@@ -171,10 +144,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Load common environment variables via env file
-        run: cat .github/env >> $GITHUB_ENV
-
-      - uses: ./.github/actions/install-just
+      - name: Set up Polkadot binaries
+        uses: ./.github/actions/use-polkadot-binaries
+        with:
+          groups: polkadot-node chain-spec-builder
+          mode: consume
 
       - name: Rust cache
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
@@ -182,15 +156,6 @@ jobs:
           workspaces: .
           shared-key: "bulletin-cache-zombienet-sync-tests-${{ matrix.runtime.name }}"
           save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Restore polkadot binaries cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: |
-            ${{ env.POLKADOT_BINARIES_DIR }}/polkadot-node
-            ${{ env.POLKADOT_BINARIES_DIR }}/chain-spec-builder
-          key: polkadot-binaries-${{ runner.os }}-${{ env.POLKADOT_NODE_VERSION }}-${{ env.CHAIN_SPEC_BUILDER_VERSION }}
-          fail-on-cache-miss: true
 
       - name: Restore bulletin chain specs cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -200,9 +165,6 @@ jobs:
             zombienet/bulletin-paseo-spec.json
           key: bulletin-specs-${{ runner.os }}-${{ github.sha }}
           fail-on-cache-miss: true
-
-      - name: Mark binaries executable
-        run: chmod -R +x "$POLKADOT_BINARIES_DIR"
 
       - name: Run zombienet sync tests
         env:


### PR DESCRIPTION
## Summary

  - Add `.github/actions/use-polkadot-binaries` composite action that owns the cache + setup dance for polkadot-sdk binaries  (polkadot-node, chain-spec-builder, zombienet, try-runtime, frame-omni-bencher).
  - Standardize one cache entry per binary group, keyed by `polkadot-binaries-${runner.os}-<group>-<VERSION_VAR>`. All workflows now  share the same entries instead of writing near-duplicates under different keys.
  - Migrate `integration-test`, `zombienet-tests`, `check`, `cmd-run`, and `check-runtime-migration` to call the action.
  - 
  ## Why

  Five workflows were each rolling their own version of "load `.github/env` → install `just` → `actions/cache` → `just binaries-*` →  add to PATH". Three of them wrote slightly different cache keys for the byte-identical `polkadot-node` directory — ~600 MB of  redundant entries against the 10 GB repo cache quota, and a workflow churning its cache could cold-bust the others. Two of them (`check.yml` benchmarks, `check-runtime-migration.yml`) had matrix legs each preparing their own cache instead of pre-warming once  and consuming downstream.

  ## How

  ```
                ┌──────────────────────────────────┐
                │  use-polkadot-binaries (action)  │
                │  mode: prepare | consume         │
                │  groups: <space-separated list>  │
                └─────────────┬────────────────────┘
                              │ on call:
                              ▼
       ┌──────────────────────────────────────────────────┐
       │ 1. Validate inputs (mode + group names)          │
       │ 2. Refuse mode=prepare in matrix jobs (guard)    │
       │ 3. cat .github/env >> $GITHUB_ENV                │
       │ 4. Install just                                  │
       │ 5. Per group:                                    │
       │      prepare → cache@v5  + populate-on-miss      │
       │      consume → cache/restore (fail-on-miss)      │
       │ 6. chmod +x + append dir to $GITHUB_PATH         │
       └──────────────────────────────────────────────────┘

  Job topology (enforced by the matrix-guard):

    prepare-* job (non-matrix)           matrix legs (any number)
    ┌─────────────────────────┐          ┌─────────────────────────┐
    │ use-polkadot-binaries   │ ───┐     │ use-polkadot-binaries   │
    │   mode: prepare         │    │     │   mode: consume         │
    │   → writes cache@v5     │    └────►│   → restores from cache │
    └─────────────────────────┘  needs:  │     fail-on-cache-miss  │
                                         └─────────────────────────┘
  ```

  Caches are content-addressed by their version var from `.github/env`; bumping `POLKADOT_NODE_VERSION` invalidates only the
  `polkadot-node` entry. Per-workflow paths are narrow (`${POLKADOT_BINARIES_DIR}/<group>`), so the `_src/` source-build tree (~11 GB)
   never enters the cache.

  ## What changed per workflow

  | Workflow | Migration |
  |---|---|
  | `integration-test.yml` | `setup` → `prepare`; `integration-tests` matrix → `consume`. |
  | `zombienet-tests.yml` | `prepare-binaries` → `prepare`; auto-renew + sync matrix → `consume`. |
  | `check.yml` | Extracted new `prepare-bencher` job (was per-matrix-leg cache); `benchmarks` matrix → `consume`. |
  | `cmd-run.yml` | `cmd` job (single, non-matrix) → `prepare`. |
  | `check-runtime-migration.yml` | Extracted new `prepare-try-runtime` job (was duplicated across two matrix jobs);
  `prepare-snapshots` + `check-migrations` matrices → `consume`. |

  Aggregator jobs (`all-tests-passed`, `confirmMigrationsPassed`) get the new `prepare-*` jobs added to their `needs:` so an upstream failure can't silently propagate as `skipped`.

  ## Notes

  - **The matrix-guard is enforcement, not just guidance.** Any future workflow that tries `mode: prepare` inside a matrix job will  fail with a clear error pointing to the right pattern.
  - Cross-workflow cache sharing: the canonical key shape means a `polkadot-node` cache populated by `integration-test.yml` on main is  restored by `zombienet-tests.yml` and any future consumer —  eliminating cold source-builds.
