### PR TITLE
Auto renew paid flag

### DIFF
--- a/docs/001_authorizations.md
+++ b/docs/001_authorizations.md
@@ -37,8 +37,8 @@ The renew-family extrinsics:
 
 - `force_renew(entry: TransactionRef)` — synchronous renewal. `TransactionRef::Position { block, index }` or `TransactionRef::ContentHash(_)`.
 - `renew(entry: TransactionRef)` — one-shot scheduler. Pre-pays the renewal at registration (same charge as `force_renew`); cycle delivers without re-charging.
-- `enable_auto_renew(content_hash)` — recurring scheduler. Snapshot check + one tx slot at registration; bytes are charged per cycle.
-- `disable_auto_renew(content_hash)` — cancels the registration. Pre-paid one-shots are forfeit on cancel.
+- `enable_auto_renew(content_hash)` — recurring scheduler. Pre-pays the first cycle at registration (same charge as `force_renew`); cycle 1 delivers without re-charging, cycle 2 onward charges per cycle.
+- `disable_auto_renew(content_hash)` — cancels the registration. Signed callers are rejected with `CannotDisablePrepaidAutoRenewal` while the registration is in its prepaid window (`paid: true`); they must wait for the first cycle to consume the prepayment. Root can disable regardless (governance/cleanup), but the prepayment is forfeit.
 
 `store`, `store_with_cid_config`, `force_renew`, `renew`, `enable_auto_renew`, and `disable_auto_renew` are unconditionally feeless. Authorization is the sole economic gate. Wrapper calls (e.g. `utility::batch`) are rejected by `ValidateStorageCalls`.
 
@@ -55,7 +55,7 @@ PoP grants two numbers per account: `bytes_allowance` (size budget) and `transac
 
 - One `AuthorizationExtent` per scope is kept in `Authorizations`, keyed by `AuthorizationScope::{Account, Preimage}`.
 - `AuthorizationExtent { transactions, transactions_allowance, bytes, bytes_permanent, bytes_allowance }` holds the soft-side counters (`bytes`, `transactions`), the per-window renew quota (`bytes_permanent`), and the caps.
-- `bytes` and `transactions` bump on `store` / `store_with_cid_config`. `bytes_permanent` bumps on `force_renew`, on the `renew` one-shot scheduler at registration, and on each recurring auto-renewal cycle in `do_process_auto_renewals`. The `transactions` axis bumps on all of those plus `enable_auto_renew`'s registration (one tx slot only — bytes are charged per cycle).
+- `bytes` and `transactions` bump on `store` / `store_with_cid_config`. `bytes_permanent` bumps on `force_renew`, on the `renew` one-shot scheduler at registration, on `enable_auto_renew`'s registration (prepayment for the first cycle), and on each cycle-2-onward recurring cycle in `do_process_auto_renewals`. The `transactions` axis bumps on all of those.
 
 ### `authorize_account` semantics
 
@@ -90,9 +90,10 @@ In-budget `store` txs sort strictly above over-budget ones. Pool nonce / arrival
 The hard cap is enforced at two levels, and a renewal that would breach **either** is rejected.
 
 "Renew" here means any path that consumes the per-window renew quota: `force_renew`,
-`enable_auto_renew`'s force-renew step, and each auto-renewal cycle in
-`do_process_auto_renewals`. The one-shot `renew` scheduler does **not** consume this
-quota at registration time — only at cycle time (via `do_process_auto_renewals`).
+the `renew` one-shot scheduler at registration, `enable_auto_renew`'s registration
+(prepaying the first cycle), and each per-cycle charge in `do_process_auto_renewals`
+(cycle 2 onward for recurring registrations; the prepaid first cycle does not
+re-consume).
 
 ### Per-account quota
 
@@ -199,7 +200,7 @@ A user across many accounts (Sybil-like) is bounded by the chain-wide cap (Examp
 
 ## Migration
 
-`STORAGE_VERSION = 4`. Migrations are only relevant for the Paseo/Westend testnets carrying pre-existing on-chain state forward; see the `pallet_bulletin_transaction_storage::migrations::{v1, v2, v3, v4}` modules for the wiring. The v4 step re-encodes each `AutoRenewals` entry from `{ account }` to `{ account, recurring }` (all pre-existing entries were written by the old `enable_auto_renew`, so they migrate as `recurring: true`).
+`STORAGE_VERSION = 4`. Migrations are only relevant for the Paseo/Westend testnets carrying pre-existing on-chain state forward; see the `pallet_bulletin_transaction_storage::migrations::{v1, v2, v3, v4}` modules for the wiring. The v4 step re-encodes each `AutoRenewals` entry from `{ account }` to `{ account, recurring, paid }`. All pre-existing entries were written by the old non-prepaying `enable_auto_renew`, so they migrate as `{ recurring: true, paid: false }` — their next `do_process_auto_renewals` cycle charges per-cycle, preserving their on-chain behaviour across the upgrade.
 
 ## Capacity planning operational steps
 
@@ -214,11 +215,10 @@ Auto-renewal reuses the manual renew code path so the [Hard limit on renewed sto
 
 Behaviour on auto-renewal failure (per-account quota or chain-wide cap rejected at cycle time, or `MaxBlockTransactions` reached): the registration is dropped from `AutoRenewals`, `Event::AutoRenewalFailed` is emitted, and the data expires normally.
 
-The latest-entry guard in `on_initialize` skips an obsolete entry when `TransactionByContentHash[hash]` points to a later block — a manual `force_renew` or the force-renew inside `enable_auto_renew` may have moved the latest reference forward; the renewal cycle then fires from the new entry's expiry, not the original.
+The latest-entry guard in `on_initialize` skips an obsolete entry when `TransactionByContentHash[hash]` points to a later block — a manual `force_renew` may have moved the latest reference forward; the renewal cycle then fires from the new entry's expiry, not the original.
 
 ## TODO
 
 - **Reserve block-transaction slots for user txs.** `do_process_auto_renewals` is mandatory and pushes into the same `BlockTransactions` slot as user `store` / `force_renew`. Cap auto-renewals to a fraction of `MaxBlockTransactions` or partition the slot budget.
 - **Per-content dedup of re-renewals (nice-to-have).** On a renew of `X`, look up the previous `(block, idx)` for `X` via `TransactionByContentHash` and cancel its pending decrement — drops the per-content double-count when the same content is renewed in multiple consecutive windows.
-- **Promote the `enable_auto_renew` snapshot to a real reservation (nice-to-have).** The recurring scheduler's snapshot check is non-consuming, so a caller can over-schedule past `bytes_allowance / size` and have later cycles fail with `AutoRenewalFailed`. `renew` (one-shot) already pre-pays.
 

--- a/pallets/transaction-storage/src/benchmarking.rs
+++ b/pallets/transaction-storage/src/benchmarking.rs
@@ -510,6 +510,15 @@ mod benchmarks {
 			.into();
 		TransactionStorage::<T>::enable_auto_renew(authorized_origin.clone(), content_hash)
 			.map_err(|_| BenchmarkError::Stop("unable to enable auto-renew"))?;
+		// `enable_auto_renew` leaves the entry with `paid: true`, which blocks
+		// signed `disable_auto_renew`. Flip to the post-first-cycle state so this
+		// benchmark measures the path real owners actually hit (a Root-disable
+		// would exercise a different branch with different weight).
+		AutoRenewals::<T>::mutate(content_hash, |entry| {
+			if let Some(data) = entry {
+				data.paid = false;
+			}
+		});
 
 		#[extrinsic_call]
 		_(authorized_origin, content_hash);
@@ -605,7 +614,9 @@ mod benchmarks {
 					block_chunks: 0,
 					kind: TransactionKind::Store,
 				};
-				let renewal_data = RenewalData { account: caller, recurring: true };
+				// `paid: false` exercises the per-cycle `check_authorization` charge
+				// path, which is the heavier branch we want to measure.
+				let renewal_data = RenewalData { account: caller, recurring: true, paid: false };
 				pending
 					.try_push((content_hash, tx_info, renewal_data))
 					.map_err(|_| BenchmarkError::Stop("unable to push pending renewal"))?;
@@ -682,7 +693,7 @@ mod benchmarks {
 			// populated by the real `store()` call above).
 			AutoRenewals::<T>::insert(
 				template.content_hash,
-				RenewalData { account: caller.clone(), recurring: true },
+				RenewalData { account: caller.clone(), recurring: true, paid: false },
 			);
 
 			// Distinct `content_hash` per entry so the on_initialize loop's
@@ -707,7 +718,7 @@ mod benchmarks {
 					TransactionByContentHash::<T>::insert(unique_hash, (obsolete_block, i));
 					AutoRenewals::<T>::insert(
 						unique_hash,
-						RenewalData { account: caller.clone(), recurring: true },
+						RenewalData { account: caller.clone(), recurring: true, paid: false },
 					);
 				}
 				Ok(())

--- a/pallets/transaction-storage/src/lib.rs
+++ b/pallets/transaction-storage/src/lib.rs
@@ -1373,14 +1373,15 @@ pub mod pallet {
 						// Recurring: consume the prepayment so subsequent cycles
 						// charge per-cycle, and unblock `disable_auto_renew` for the
 						// owner now that the prepaid renewal has been delivered.
-						AutoRenewals::<T>::insert(
-							content_hash,
-							RenewalData {
-								account: renewal_data.account.clone(),
-								recurring: true,
-								paid: false,
-							},
-						);
+						// `mutate` (not `insert`) so a Root `disable_auto_renew`
+						// executed earlier in the same block — between the
+						// `on_initialize` queue and this inherent — is not silently
+						// re-armed by a fresh insert.
+						AutoRenewals::<T>::mutate(content_hash, |entry| {
+							if let Some(data) = entry {
+								data.paid = false;
+							}
+						});
 					}
 					Self::deposit_event(Event::DataAutoRenewed {
 						index: new_index,

--- a/pallets/transaction-storage/src/lib.rs
+++ b/pallets/transaction-storage/src/lib.rs
@@ -105,6 +105,10 @@ pub const AUTO_RENEWAL_NOT_ENABLED: InvalidTransaction = InvalidTransaction::Cus
 pub const NOT_AUTO_RENEWAL_OWNER: InvalidTransaction = InvalidTransaction::Custom(10);
 /// `enable_auto_renew`: an auto-renewal is already registered for this content hash.
 pub const AUTO_RENEWAL_ALREADY_ENABLED: InvalidTransaction = InvalidTransaction::Custom(11);
+/// `disable_auto_renew`: the registration has been prepaid for its next cycle and
+/// cannot be disabled by the owner until the cycle fires and consumes the prepayment.
+/// Root can still disable for governance cleanup.
+pub const CANNOT_DISABLE_PREPAID_AUTO_RENEWAL: InvalidTransaction = InvalidTransaction::Custom(12);
 
 /// Percent of `MaxPermanentStorageSize` at which the pallet emits
 /// [`Event::PermanentStorageNearCap`] (rising-edge only). Off-chain governance consumers
@@ -231,6 +235,10 @@ pub mod pallet {
 		AutoRenewalNotEnabled,
 		/// Caller is not the owner of the auto-renewal registration.
 		NotAutoRenewalOwner,
+		/// `disable_auto_renew` rejected: the registration has been prepaid for its next
+		/// cycle. The owner must wait until that cycle consumes the prepayment before
+		/// disabling. Root can disable regardless.
+		CannotDisablePrepaidAutoRenewal,
 		/// Authorizer's `authorization_period` override is zero or `>= T::AuthorizationPeriod`.
 		/// The override is intended to shorten an authorizer's window; to grant the default
 		/// length, pass `None` instead.
@@ -252,10 +260,27 @@ pub mod pallet {
 
 	/// Data associated with a renewal registration in [`AutoRenewals`].
 	///
-	/// Holds the owner account whose authorization is charged each cycle, plus a
-	/// `recurring` flag that decides whether the registration is consumed after a
-	/// single successful renewal (`false`, set by [`Pallet::renew`]) or persists
-	/// forever (`true`, set by [`Pallet::enable_auto_renew`]).
+	/// Holds the owner account, a `recurring` flag that decides whether the
+	/// registration is consumed after a single successful renewal (`false`, set by
+	/// [`Pallet::renew`]) or persists forever (`true`, set by
+	/// [`Pallet::enable_auto_renew`]), and a `paid` flag indicating that the next
+	/// cycle has already been charged against the owner's authorization at
+	/// registration time.
+	///
+	/// Both [`Pallet::renew`] and [`Pallet::enable_auto_renew`] insert with
+	/// `paid: true`: the extension's `check_signed` charges `bytes_permanent`,
+	/// `PermanentStorageUsed`, and one tx slot up front (same as `force_renew`).
+	/// [`Pallet::do_process_auto_renewals`] keys its charge-skip off `paid`: when
+	/// `paid` is true the cycle renews without re-charging and then flips `paid`
+	/// to false (for recurring entries) so subsequent cycles pay per-cycle, as
+	/// before. One-shot entries (`recurring: false`) are removed after the single
+	/// renewal so the flag is inert after that point.
+	///
+	/// While `paid` is true, [`Pallet::disable_auto_renew`] rejects signed callers
+	/// — the owner must wait for the first cycle to consume the prepayment. This
+	/// is what makes `enable_auto_renew` honestly cost a renewal even if the
+	/// owner immediately disables (bytes already left the per-account quota at
+	/// registration). Root can still disable for governance cleanup.
 	#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, scale_info::TypeInfo, MaxEncodedLen)]
 	pub struct RenewalData<AccountId> {
 		/// Account whose authorization will be consumed each time data is auto-renewed.
@@ -264,6 +289,11 @@ pub mod pallet {
 		/// `false` — one-shot: removed from `AutoRenewals` after the first successful
 		/// renewal cycle (set by `renew`).
 		pub recurring: bool,
+		/// `true` — the next renewal cycle has already been charged at registration
+		/// time and will fire free. After the cycle delivers, the flag is flipped to
+		/// `false` for recurring entries; for one-shot entries the registration is
+		/// removed outright.
+		pub paid: bool,
 	}
 
 	/// Custom origin for authorized signed transaction storage operations.
@@ -530,7 +560,7 @@ pub mod pallet {
 
 			AutoRenewals::<T>::insert(
 				content_hash,
-				RenewalData { account: who.clone(), recurring: false },
+				RenewalData { account: who.clone(), recurring: false, paid: true },
 			);
 			Self::deposit_event(Event::RenewalEnabled { content_hash, who, recurring: false });
 			Ok(())
@@ -750,22 +780,28 @@ pub mod pallet {
 
 		/// Enable automatic renewal for a previously stored piece of data.
 		///
-		/// Force-renew + schedule. This call combines a regular renewal (paid up
-		/// front against the caller's account authorization) with a registration in
-		/// [`AutoRenewals`]. Bytes and one tx slot are charged here via the
-		/// extension's `check_signed`, the renewal entry is added to
-		/// [`BlockTransactions`] by [`Self::do_renew`], and future renewal cycles
-		/// fire from [`Self::do_process_auto_renewals`] when the renewed entry
-		/// expires. Bounding the registration against the renew hard cap (rather
-		/// than a free snapshot check) means a caller cannot register more
-		/// auto-renewals than `bytes_allowance` supports.
+		/// **Recurring scheduler with pre-paid first cycle.** The extension's
+		/// `check_signed` charges `bytes_permanent`, `PermanentStorageUsed`, and
+		/// one tx slot at registration (same hard-cap accounting as `force_renew`
+		/// / one-shot `renew`). The registration is inserted as
+		/// [`RenewalData`] `{ recurring: true, paid: true }`. The first renewal
+		/// cycle fires at the next `RetentionPeriod` boundary **without**
+		/// re-charging — the slot is already paid for; the cycle then flips
+		/// `paid` to `false`. From that point on, every subsequent cycle charges
+		/// the owner's authorization in [`Self::do_process_auto_renewals`],
+		/// dropping the registration with [`Event::AutoRenewalFailed`] if the
+		/// quota is exhausted at cycle time.
 		///
-		/// Feeless: no token fee. Spam is bounded by the per-account renew quota
-		/// (`bytes_permanent + size <= bytes_allowance`) and the chain-wide cap
-		/// (`PermanentStorageUsed + size <= MaxPermanentStorageSize`).
+		/// Feeless: no token fee. Spam is bounded structurally by the up-front
+		/// hard-cap charge — the caller cannot over-schedule past their
+		/// `bytes_allowance` or the chain-wide `MaxPermanentStorageSize`.
+		/// [`Self::disable_auto_renew`] additionally rejects the owner while
+		/// `paid` is `true`, so the prepayment cannot be reclaimed before the
+		/// first cycle fires.
 		///
-		/// Emits [`Renewed`](Event::Renewed) for the immediate renewal and
-		/// [`RenewalEnabled`](Event::RenewalEnabled) `{ recurring: true }` for the registration.
+		/// Emits [`RenewalEnabled`](Event::RenewalEnabled) `{ recurring: true }`
+		/// for the registration; the first actual renewal is emitted as
+		/// [`DataAutoRenewed`](Event::DataAutoRenewed) at cycle time.
 		#[pallet::call_index(12)]
 		#[pallet::weight(T::WeightInfo::enable_auto_renew())]
 		#[pallet::feeless_if(|_origin: &OriginFor<T>, _content_hash: &ContentHash| -> bool { true })]
@@ -783,19 +819,19 @@ pub mod pallet {
 				Error::<T>::AutoRenewalAlreadyEnabled
 			);
 
-			// Defensive content-hash existence check. The snapshot precondition
-			// (auth exists, unexpired, has room for `info.size`) and the one-tx-slot
-			// charge run in the extension's `check_signed` for this call. The
-			// renewal itself fires later via `do_process_auto_renewals` — registering
-			// here must not call `do_renew`, otherwise `bytes_permanent` would be
-			// double-charged (once by the cycle, once by the synchronous renew).
+			// Defensive content-hash existence check. The hard-cap accounting
+			// (`bytes_permanent`, `PermanentStorageUsed`, one tx slot) is performed by
+			// the extension's `check_signed` for this call with `is_renew = true`,
+			// matching the one-shot `renew`. Registering here must not call
+			// `do_renew`, otherwise `bytes_permanent` would be double-charged (once
+			// by registration, once by `do_process_auto_renewals`'s prepaid cycle).
 			let (block, index) = TransactionByContentHash::<T>::get(content_hash)
 				.ok_or(Error::<T>::RenewedNotFound)?;
 			Self::transaction_info(block, index).ok_or(Error::<T>::RenewedNotFound)?;
 
 			AutoRenewals::<T>::insert(
 				content_hash,
-				RenewalData { account: who.clone(), recurring: true },
+				RenewalData { account: who.clone(), recurring: true, paid: true },
 			);
 			Self::deposit_event(Event::RenewalEnabled { content_hash, who, recurring: true });
 			Ok(())
@@ -803,12 +839,20 @@ pub mod pallet {
 
 		/// Disable automatic renewal for a piece of data.
 		///
-		/// Signed: the caller must be the account that originally enabled the renewal.
-		/// Root: bypasses the owner check (governance/cleanup).
+		/// Signed: the caller must be the account that originally enabled the renewal,
+		/// and the registration must not be in its prepaid window — see
+		/// [`Error::CannotDisablePrepaidAutoRenewal`]. Both registrations from
+		/// [`Pallet::renew`] and [`Pallet::enable_auto_renew`] start with `paid: true`;
+		/// the owner has to wait for the first cycle to consume the prepayment before
+		/// they can disable.
+		///
+		/// Root: bypasses the owner check and the prepaid-window check
+		/// (governance/cleanup).
 		///
 		/// Feeless: no token fee and no authorization is consumed. Signed admission is
-		/// gated in [`check_signed`](Self::check_signed) on ownership, so a caller can
-		/// issue at most one successful `disable_auto_renew` per registration it owns.
+		/// gated in [`check_signed`](Self::check_signed) on ownership and the prepaid
+		/// flag, so a caller can issue at most one successful `disable_auto_renew` per
+		/// registration it owns — and only after the first cycle has fired.
 		///
 		/// Emits [`AutoRenewalDisabled`](Event::AutoRenewalDisabled) when successful.
 		#[pallet::call_index(13)]
@@ -824,6 +868,7 @@ pub mod pallet {
 			match caller {
 				AuthorizedCaller::Signed { who, .. } => {
 					ensure!(renewal_data.account == who, Error::<T>::NotAutoRenewalOwner);
+					ensure!(!renewal_data.paid, Error::<T>::CannotDisablePrepaidAutoRenewal);
 				},
 				AuthorizedCaller::Root => {},
 				AuthorizedCaller::Unsigned => return Err(DispatchError::BadOrigin),
@@ -1305,23 +1350,37 @@ pub mod pallet {
 			let mut transactions = <BlockTransactions<T>>::get();
 
 			for (content_hash, tx_info, renewal_data) in pending.into_iter() {
-				// One-shot was pre-paid at registration; recurring pays per cycle.
-				let new_index = if renewal_data.recurring {
+				// `paid = true` means the cycle was already charged at registration
+				// (the one-shot `renew` path and the first cycle after
+				// `enable_auto_renew`). All other recurring cycles charge here.
+				let was_paid = renewal_data.paid;
+				let new_index = if was_paid {
+					Self::do_renew_in_memory(&mut transactions, &tx_info, extrinsic_index)
+				} else {
 					let scope = AuthorizationScope::Account(renewal_data.account.clone());
 					if Self::check_authorization(&scope, tx_info.size, true, true).is_ok() {
 						Self::do_renew_in_memory(&mut transactions, &tx_info, extrinsic_index)
 					} else {
 						None
 					}
-				} else {
-					Self::do_renew_in_memory(&mut transactions, &tx_info, extrinsic_index)
 				};
 
 				if let Some(new_index) = new_index {
-					// One-shot registrations: remove now that the single renewal has fired.
-					// Recurring registrations stay in place to fire again next cycle.
 					if !renewal_data.recurring {
+						// One-shot: registration is consumed.
 						AutoRenewals::<T>::remove(content_hash);
+					} else if was_paid {
+						// Recurring: consume the prepayment so subsequent cycles
+						// charge per-cycle, and unblock `disable_auto_renew` for the
+						// owner now that the prepaid renewal has been delivered.
+						AutoRenewals::<T>::insert(
+							content_hash,
+							RenewalData {
+								account: renewal_data.account.clone(),
+								recurring: true,
+								paid: false,
+							},
+						);
 					}
 					Self::deposit_event(Event::DataAutoRenewed {
 						index: new_index,
@@ -2128,13 +2187,12 @@ pub mod pallet {
 					));
 				},
 				Call::<T>::enable_auto_renew { content_hash } => {
-					// Feeless recurring registration. Mirrors `renew`'s snapshot model:
-					// auth must exist, be unexpired, and have headroom for one more
-					// renewal of `info.size` (`bytes_permanent + size ≤ bytes_allowance`).
-					// Only one tx slot is consumed; `bytes_permanent`, the chain-wide
-					// `PermanentStorageUsed` counter, and the actual Renew entry are
-					// produced later by `do_process_auto_renewals` at the retention
-					// boundary.
+					// Pre-paid recurring registration. Mirrors one-shot `renew`'s
+					// hard-cap charge: `bytes_permanent`, the chain-wide
+					// `PermanentStorageUsed` counter, and one tx slot are all consumed
+					// here. The first cycle then fires free in
+					// `do_process_auto_renewals` (`paid = true` on the inserted
+					// `RenewalData`); subsequent cycles charge per-cycle.
 					if AutoRenewals::<T>::contains_key(*content_hash) {
 						return Err(AUTO_RENEWAL_ALREADY_ENABLED.into());
 					}
@@ -2142,20 +2200,11 @@ pub mod pallet {
 						.ok_or(RENEWED_NOT_FOUND)?;
 					let info = Self::transaction_info(block, index).ok_or(RENEWED_NOT_FOUND)?;
 
-					let auth = Authorizations::<T>::get(AuthorizationScope::Account(who.clone()))
-						.ok_or(AUTHORIZATION_NOT_FOUND)?;
-					if auth.expired(Self::now()) {
-						return Err(AUTHORIZATION_NOT_FOUND.into());
-					}
-					if !auth.extent.has_permanent_capacity(info.size as u64) {
-						return Err(PERMANENT_ALLOWANCE_EXCEEDED.into());
-					}
-					// `size = 0, is_renew = false`: only the tx counter is charged.
 					Self::check_authorization(
 						&AuthorizationScope::Account(who.clone()),
-						0,
+						info.size,
 						context.consume_authorization(),
-						false,
+						true,
 					)?;
 
 					let scope = AuthorizationScope::Account(who.clone());
@@ -2171,14 +2220,19 @@ pub mod pallet {
 					));
 				},
 				Call::<T>::disable_auto_renew { content_hash } => {
-					// Feeless. Pool admission is gated on ownership so spam is bounded even
-					// without a token fee: the registration must exist and `who` must be
-					// its owner. `Some(scope)` triggers the origin rewrite to
+					// Feeless. Pool admission is gated on ownership AND on the prepaid
+					// window — the registration must exist, `who` must be its owner,
+					// and the next cycle must not be pre-paid (otherwise the owner
+					// would be reclaiming a slot they've already charged against their
+					// quota). `Some(scope)` triggers the origin rewrite to
 					// `Origin::Authorized` expected by the dispatch's `ensure_authorized`.
 					let renewal_data =
 						AutoRenewals::<T>::get(content_hash).ok_or(AUTO_RENEWAL_NOT_ENABLED)?;
 					if &renewal_data.account != who {
 						return Err(NOT_AUTO_RENEWAL_OWNER.into());
+					}
+					if renewal_data.paid {
+						return Err(CANNOT_DISABLE_PREPAID_AUTO_RENEWAL.into());
 					}
 					let scope = AuthorizationScope::Account(who.clone());
 					return Ok((

--- a/pallets/transaction-storage/src/migrations.rs
+++ b/pallets/transaction-storage/src/migrations.rs
@@ -692,13 +692,20 @@ pub mod v3 {
 }
 
 /// V3 → V4 migration: re-encode each [`AutoRenewals`] entry from
-/// `{ account }` (v3) to `{ account, recurring: true }` (v4).
+/// `{ account }` (v3) to `{ account, recurring: true, paid: false }` (v4).
 ///
-/// All existing entries were written by `enable_auto_renew`, which is the
-/// forever-renewal path — so they map to `recurring: true` to preserve their
-/// behaviour across the upgrade. The new one-shot path (`recurring: false`) is
-/// only reachable via the new `renew` extrinsic, which can't have written any
-/// entries before this migration runs.
+/// All existing entries were written by the old fee-paying `enable_auto_renew`,
+/// which:
+///
+/// - is the forever-renewal path, so the entries map to `recurring: true`;
+/// - did **not** pre-pay the next cycle against the owner's authorization, so they map to `paid:
+///   false` — `do_process_auto_renewals` will charge them per-cycle, preserving their on-chain
+///   behaviour across the upgrade.
+///
+/// The new one-shot path (`recurring: false`) and the new prepaid path
+/// (`paid: true`, set by both `renew` and the new `enable_auto_renew`) are only
+/// reachable through the v4 extrinsics, which can't have written any entries
+/// before this migration runs.
 pub mod v4 {
 	use super::*;
 	use crate::{
@@ -779,7 +786,7 @@ pub mod v4 {
 
 				AutoRenewals::<T>::insert(
 					content_hash,
-					RenewalData { account: v3.account, recurring: true },
+					RenewalData { account: v3.account, recurring: true, paid: false },
 				);
 				cursor = Some(content_hash);
 			}
@@ -826,6 +833,10 @@ pub mod v4 {
 				polkadot_sdk_frame::prelude::ensure!(
 					decoded.recurring,
 					"v3->v4 post_upgrade: migrated entry must have recurring=true",
+				);
+				polkadot_sdk_frame::prelude::ensure!(
+					!decoded.paid,
+					"v3->v4 post_upgrade: migrated entry must have paid=false",
 				);
 				new_count += 1;
 			}

--- a/pallets/transaction-storage/src/tests.rs
+++ b/pallets/transaction-storage/src/tests.rs
@@ -2059,9 +2059,9 @@ fn enable_auto_renew_rejects_invalid() {
 			Err(crate::RENEWED_NOT_FOUND.into()),
 		);
 
-		// Enabling without account authorization fails. The snapshot check in
-		// `check_signed` reads `Authorizations[Account(who)]` directly and folds a
-		// missing entry into `AUTHORIZATION_NOT_FOUND`.
+		// Enabling without account authorization fails. `check_authorization`
+		// (with `is_renew = true`) folds both missing and expired authorizations
+		// into `InvalidTransaction::Payment`, matching the one-shot `renew` path.
 		let data = vec![0u8; 2000];
 		let content_hash = blake2_256(&data);
 		assert_ok!(TransactionStorage::store(RuntimeOrigin::none(), data));
@@ -2071,7 +2071,7 @@ fn enable_auto_renew_rejects_invalid() {
 		let call = Call::enable_auto_renew { content_hash };
 		assert_eq!(
 			TransactionStorage::validate_signed(&unauthorized_user, &call).map(|_| ()),
-			Err(crate::AUTHORIZATION_NOT_FOUND.into()),
+			Err(InvalidTransaction::Payment.into()),
 		);
 	});
 }
@@ -2095,13 +2095,33 @@ fn disable_auto_renew_works() {
 		run_to_block(2, || None);
 		assert_ok!(enable_auto_renew_via_extension(owner, content_hash));
 
-		// Another user cannot disable (dispatch-level owner check).
+		// Even the owner cannot disable while the registration is in its prepaid
+		// window: `enable_auto_renew` charges the next cycle up front, and we
+		// don't let that prepayment be reclaimed.
+		assert_noop!(
+			disable_auto_renew_via_extension(owner, content_hash),
+			Error::CannotDisablePrepaidAutoRenewal,
+		);
+
+		// Fire the first cycle to consume the prepayment, after which the
+		// registration sits at `paid = false` and the owner can disable.
+		init_block(12);
+		assert_ok!(TransactionStorage::authorize_account(
+			RuntimeOrigin::root(),
+			owner,
+			10,
+			100_000,
+		));
+		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
+		assert!(!AutoRenewals::get(content_hash).unwrap().paid, "cycle should consume prepayment");
+
+		// Non-owner is still rejected after the prepayment is consumed.
 		assert_noop!(
 			disable_auto_renew_via_extension(other, content_hash),
 			Error::NotAutoRenewalOwner,
 		);
 
-		// Owner can disable.
+		// Owner can now disable.
 		assert_ok!(disable_auto_renew_via_extension(owner, content_hash));
 
 		assert!(AutoRenewals::get(content_hash).is_none());
@@ -2112,7 +2132,8 @@ fn disable_auto_renew_works() {
 	});
 }
 
-/// Root bypasses the owner check (governance/cleanup path).
+/// Root bypasses the owner check AND the prepaid-window check (governance/cleanup
+/// path) — even a fresh registration with `paid: true` can be torn down by Root.
 #[test]
 fn disable_auto_renew_root_override() {
 	new_test_ext().execute_with(|| {
@@ -2130,6 +2151,8 @@ fn disable_auto_renew_root_override() {
 		assert_ok!(TransactionStorage::store(RuntimeOrigin::none(), data));
 		run_to_block(2, || None);
 		assert_ok!(enable_auto_renew_via_extension(owner, content_hash));
+		// Registration is still in its prepaid window — Root must override anyway.
+		assert!(AutoRenewals::get(content_hash).unwrap().paid);
 
 		assert_ok!(TransactionStorage::disable_auto_renew(RuntimeOrigin::root(), content_hash));
 		assert!(AutoRenewals::get(content_hash).is_none());
@@ -2157,7 +2180,9 @@ fn disable_auto_renew_fails_if_not_enabled() {
 /// `disable_auto_renew` is feeless: admission is gated in `check_signed` so spam is
 /// bounded even without a token fee. Verify pool-level rejection mirrors the dispatch
 /// errors — unknown content hash returns `AUTO_RENEWAL_NOT_ENABLED`, non-owner returns
-/// `NOT_AUTO_RENEWAL_OWNER`, and the registered owner is admitted.
+/// `NOT_AUTO_RENEWAL_OWNER`, owner during prepaid window returns
+/// `CANNOT_DISABLE_PREPAID_AUTO_RENEWAL`, and the owner is admitted only after the
+/// first cycle has consumed the prepayment.
 #[test]
 fn disable_auto_renew_validate_signed_gates_on_ownership() {
 	new_test_ext().execute_with(|| {
@@ -2192,7 +2217,24 @@ fn disable_auto_renew_validate_signed_gates_on_ownership() {
 			Err(crate::NOT_AUTO_RENEWAL_OWNER.into()),
 		);
 
-		// Owner: pool admits.
+		// Owner during the prepaid window: rejected with CANNOT_DISABLE_PREPAID_AUTO_RENEWAL.
+		assert_eq!(
+			TransactionStorage::validate_signed(&owner, &call).map(|_| ()),
+			Err(crate::CANNOT_DISABLE_PREPAID_AUTO_RENEWAL.into()),
+		);
+
+		// Fire the first cycle to consume the prepayment, then re-check pool admission.
+		init_block(12);
+		assert_ok!(TransactionStorage::authorize_account(
+			RuntimeOrigin::root(),
+			owner,
+			10,
+			100_000,
+		));
+		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
+		assert!(!AutoRenewals::get(content_hash).unwrap().paid);
+
+		// Owner post-cycle: pool admits.
 		assert_ok!(TransactionStorage::validate_signed(&owner, &call));
 	});
 }
@@ -2282,20 +2324,21 @@ fn auto_renewal_consumes_authorization() {
 		let content_hash = blake2_256(&data);
 
 		// `store` is unsigned, so it does not consume authorization.
-		// `enable_auto_renew` is feeless: consumes only one tx slot at registration
-		// time; `bytes_permanent` is charged at the eventual auto-renewal cycle.
+		// `enable_auto_renew` is feeless but pre-pays the first cycle, mirroring
+		// one-shot `renew`: `bytes_permanent`, the chain-wide
+		// `PermanentStorageUsed`, and one tx slot are all charged at registration.
 		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 3, 6000));
 		assert_ok!(TransactionStorage::store(RuntimeOrigin::none(), data));
 		run_to_block(2, || None);
 		assert_ok!(enable_auto_renew_via_extension(who, content_hash));
 
-		// Registration cost is one tx slot only — no bytes consumed yet.
-		let initial_extent = TransactionStorage::account_authorization_extent(who);
+		// Registration prepaid the first cycle: `bytes_permanent = size` and one
+		// tx slot consumed.
 		assert_eq!(
-			initial_extent,
+			TransactionStorage::account_authorization_extent(who),
 			AuthorizationExtent {
 				bytes: 0,
-				bytes_permanent: 0,
+				bytes_permanent: 2000,
 				bytes_allowance: 6000,
 				transactions: 1,
 				transactions_allowance: 3,
@@ -2303,17 +2346,42 @@ fn auto_renewal_consumes_authorization() {
 		);
 
 		// First auto-renewal cycle fires when `Transactions[1]` ages out at
-		// block 12. Refresh the authorization first since the block-1 grant
-		// expired at block 11; the re-grant resets the consumed counters.
+		// block 12. The block-1 grant expired at block 11, so the re-grant below
+		// replaces it with fresh counters; the cycle then fires free against the
+		// fresh auth thanks to `paid: true`.
 		init_block(12);
 		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 3, 6000));
 		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
 
-		// Auto-renewal charged `size` bytes_permanent + 1 tx slot against the
-		// refreshed authorization (which started fresh at 0/0).
-		let after_extent = TransactionStorage::account_authorization_extent(who);
+		// Cycle 1 (prepaid) leaves the fresh authorization untouched.
 		assert_eq!(
-			after_extent,
+			TransactionStorage::account_authorization_extent(who),
+			AuthorizationExtent {
+				bytes: 0,
+				bytes_permanent: 0,
+				bytes_allowance: 6000,
+				transactions: 0,
+				transactions_allowance: 3,
+			},
+		);
+		// Prepayment is consumed; subsequent cycles charge per-cycle.
+		assert!(!AutoRenewals::get(content_hash).unwrap().paid);
+
+		// Cycle 2: carry `BlockTransactions[12]` → `Transactions[12]` so the
+		// block-12 renew can age out at block 23.
+		let block_txs = BlockTransactions::take();
+		if !block_txs.is_empty() {
+			Transactions::insert(12u64, &block_txs);
+		}
+		init_block(23);
+		// The block-12 grant expired at block 22; re-grant fresh counters so the
+		// cycle can charge against a known baseline.
+		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 3, 6000));
+		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
+
+		// Cycle 2 (paid = false) charged `size` bytes_permanent + 1 tx slot.
+		assert_eq!(
+			TransactionStorage::account_authorization_extent(who),
 			AuthorizationExtent {
 				bytes: 0,
 				bytes_permanent: 2000,
@@ -2333,49 +2401,35 @@ fn auto_renewal_fails_when_authorization_exhausted() {
 		let data = vec![0u8; 2000];
 		let content_hash = blake2_256(&data);
 
-		// Authorize generously initially; the second cycle will run against a
-		// refreshed authorization with only 1 op of headroom — enough for one
-		// renewal but not two.
+		// Authorize generously initially so the prepaid registration fits.
 		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 5, 100_000));
 		assert_ok!(TransactionStorage::store(RuntimeOrigin::none(), data));
 		run_to_block(2, || None);
 		assert_ok!(enable_auto_renew_via_extension(who, content_hash));
 
-		// First auto-renewal cycle fires at block 12 (block-1 entry ages out).
+		// Cycle 1 (prepaid) fires free at block 12. Re-authorize first because
+		// the block-1 grant expired at block 11.
 		init_block(12);
-		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 1, 2000));
+		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 5, 100_000));
 		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
+		assert!(!AutoRenewals::get(content_hash).unwrap().paid, "cycle should consume prepayment");
 
-		// Authorization is now fully consumed on the permanent axis.
-		let extent = TransactionStorage::account_authorization_extent(who);
-		assert_eq!(
-			extent,
-			AuthorizationExtent {
-				bytes: 0,
-				bytes_permanent: 2000,
-				bytes_allowance: 2000,
-				transactions: 1,
-				transactions_allowance: 1,
-			},
-		);
-
-		// Data was renewed into block 12.
-		assert_eq!(TransactionByContentHash::get(content_hash), Some((12, 0)));
-
-		// Simulate on_finalize: move BlockTransactions → Transactions(12)
+		// Carry block-12 renew into Transactions[12] for the next age-out.
 		let block_txs = BlockTransactions::take();
 		if !block_txs.is_empty() {
 			Transactions::insert(12u64, &block_txs);
 		}
 
-		// Next renewal at block 23 (12 + 10 + 1) — should fail.
+		// Cycle 2 at block 23 runs against a refreshed authorization with no
+		// headroom — `bytes_permanent + size > bytes_allowance` fires.
 		init_block(23);
+		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 1, 1000));
 		let pending = PendingAutoRenewals::get();
 		assert_eq!(pending.len(), 1, "Should have pending renewal");
 
 		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
 
-		// Should have failed — event emitted and auto-renewal removed
+		// Should have failed — event emitted and auto-renewal removed.
 		System::assert_has_event(RuntimeEvent::TransactionStorage(Event::AutoRenewalFailed {
 			content_hash,
 			account: who,
@@ -2435,8 +2489,10 @@ fn pending_auto_renewals_populated_only_for_registered_items() {
 
 #[test]
 fn auto_renew_permissionless_transfer() {
-	// Alice stores and enables auto-renew, then disables. Bob enables instead.
-	// Anyone can choose to keep data alive on Bulletin, permissionlessly.
+	// Alice stores and enables auto-renew, waits out the prepaid window so the
+	// first cycle consumes her prepayment, then disables. Bob enables instead.
+	// Anyone can take over keeping data alive on Bulletin, permissionlessly —
+	// but only after the original registrant's pre-paid cycle has fired.
 	new_test_ext().execute_with(|| {
 		run_to_block(1, || None);
 		let alice = 1;
@@ -2451,25 +2507,52 @@ fn auto_renew_permissionless_transfer() {
 			10,
 			100_000
 		));
-		assert_ok!(TransactionStorage::store(RuntimeOrigin::none(), data));
+		assert_ok!(TransactionStorage::store(RuntimeOrigin::none(), data.clone()));
 		run_to_block(2, || None);
 
-		// Alice enables auto-renew (feeless registration — no `BlockTransactions`
-		// write).
+		// Alice enables auto-renew (prepays the first cycle).
 		assert_ok!(enable_auto_renew_via_extension(alice, content_hash));
 		let renewal = AutoRenewals::get(content_hash).unwrap();
 		assert_eq!(renewal.account, alice);
+		assert!(renewal.paid);
 
-		// Alice disables auto-renew.
+		// Alice cannot disable during the prepaid window.
+		assert_noop!(
+			disable_auto_renew_via_extension(alice, content_hash),
+			Error::CannotDisablePrepaidAutoRenewal,
+		);
+
+		// Fire the first cycle to consume Alice's prepayment.
+		init_block(12);
+		assert_ok!(TransactionStorage::authorize_account(
+			RuntimeOrigin::root(),
+			alice,
+			10,
+			100_000,
+		));
+		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
+		assert!(!AutoRenewals::get(content_hash).unwrap().paid);
+		// Carry the cycle-12 renew out of `BlockTransactions` so the next
+		// `enable_auto_renew` can resolve the `(12, 0)` index against
+		// `Transactions[12]` (mirrors what `on_finalize` does in a live chain).
+		let block_txs = BlockTransactions::take();
+		if !block_txs.is_empty() {
+			Transactions::insert(12u64, &block_txs);
+		}
+
+		// Alice can now disable.
 		assert_ok!(disable_auto_renew_via_extension(alice, content_hash));
 		assert!(AutoRenewals::get(content_hash).is_none());
 
-		// Bob authorizes and enables auto-renew for the same content.
+		// Bob authorizes and enables auto-renew for the same content. The renew
+		// at block 12 made `(12, 0)` the latest `TransactionByContentHash` entry,
+		// so `enable_auto_renew` resolves cleanly.
 		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), bob, 10, 100_000));
 		assert_ok!(enable_auto_renew_via_extension(bob, content_hash));
 
 		let renewal = AutoRenewals::get(content_hash).unwrap();
 		assert_eq!(renewal.account, bob, "Bob should now own the auto-renewal");
+		assert!(renewal.paid, "Bob's registration prepays his first cycle");
 
 		System::assert_has_event(RuntimeEvent::TransactionStorage(Event::RenewalEnabled {
 			content_hash,
@@ -4209,8 +4292,9 @@ fn enable_auto_renew_rejects_already_enabled() {
 	});
 }
 
-/// Expired authorization rejects at the extension's snapshot check with
-/// `AUTHORIZATION_NOT_FOUND` (`expired()` is `now >= expiration`).
+/// Expired authorization rejects through `check_authorization` with
+/// `InvalidTransaction::Payment` — same path one-shot `renew` and `force_renew`
+/// take when `expired()` is `now >= expiration`.
 #[test]
 fn enable_auto_renew_rejects_expired_authorization() {
 	new_test_ext().execute_with(|| {
@@ -4229,7 +4313,7 @@ fn enable_auto_renew_rejects_expired_authorization() {
 		let call = Call::enable_auto_renew { content_hash };
 		assert_eq!(
 			TransactionStorage::validate_signed(&who, &call).map(|_| ()),
-			Err(crate::AUTHORIZATION_NOT_FOUND.into()),
+			Err(InvalidTransaction::Payment.into()),
 		);
 	});
 }
@@ -4263,6 +4347,10 @@ fn enable_auto_renew_rejects_insufficient_capacity() {
 /// in the renewal block is a no-op for the in-flight cycle — the caller still sees one
 /// final `DataAutoRenewed` event. Subsequent cycles are correctly suppressed because
 /// `AutoRenewals[hash]` is gone for the next on_initialize sweep.
+///
+/// This is only reachable once the registration has cleared its prepaid window
+/// (`disable_auto_renew` rejects the owner while `paid: true`), so we exercise it
+/// on cycle 2.
 #[test]
 fn disable_auto_renew_in_renewal_block_does_not_prevent_renewal() {
 	new_test_ext().execute_with(|| {
@@ -4276,11 +4364,21 @@ fn disable_auto_renew_in_renewal_block_does_not_prevent_renewal() {
 		run_to_block(2, || None);
 		assert_ok!(enable_auto_renew_via_extension(who, content_hash));
 
-		// Renewal block: on_initialize captures the entry into PendingAutoRenewals.
+		// Cycle 1: fire to consume the prepayment so the owner can `disable` later.
 		init_block(12);
+		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 10, 100_000));
+		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
+		assert!(!AutoRenewals::get(content_hash).unwrap().paid);
+		let block_txs = BlockTransactions::take();
+		if !block_txs.is_empty() {
+			Transactions::insert(12u64, &block_txs);
+		}
+
+		// Cycle 2 block: on_initialize captures the block-12 renewal into pending.
+		init_block(23);
 		assert_eq!(PendingAutoRenewals::get().len(), 1);
 
-		// Refresh authorization (original expired at block 11).
+		// Refresh authorization for cycle 2 (block-12 grant expired at block 22).
 		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 10, 100_000));
 
 		// Disable in the normal section — after on_initialize, before the inherent.
@@ -4302,7 +4400,8 @@ fn disable_auto_renew_in_renewal_block_does_not_prevent_renewal() {
 /// `do_process_auto_renewals` emits `AutoRenewalFailed` when `check_authorization`
 /// returns `CHAIN_PERMANENT_CAP_REACHED` — i.e. the chain-wide `PermanentStorageUsed`
 /// counter would exceed `MaxPermanentStorageSize` — even if the per-account budget is
-/// fine.
+/// fine. The chain-wide gate only applies on cycles that actually charge, so this
+/// scenario is reachable on cycle 2 (the first cycle is prepaid at registration).
 #[test]
 fn auto_renewal_fails_on_chain_wide_permanent_cap() {
 	new_test_ext().execute_with(|| {
@@ -4312,6 +4411,7 @@ fn auto_renewal_fails_on_chain_wide_permanent_cap() {
 		let content_hash = blake2_256(&data);
 
 		// Per-account budget comfortably large — chain-wide cap is the only gate.
+		// Pick a cap that fits the registration's prepayment but not a second cycle.
 		MaxPermanentStorageSize::set(&3000);
 		assert_ok!(TransactionStorage::authorize_account(
 			RuntimeOrigin::root(),
@@ -4322,7 +4422,9 @@ fn auto_renewal_fails_on_chain_wide_permanent_cap() {
 		assert_ok!(TransactionStorage::store(RuntimeOrigin::none(), data));
 		run_to_block(2, || None);
 		assert_ok!(enable_auto_renew_via_extension(who, content_hash));
+		assert_eq!(PermanentStorageUsed::get(), 2000);
 
+		// Cycle 1 (prepaid) fires free at block 12 — chain-wide counter is not bumped.
 		init_block(12);
 		assert_ok!(TransactionStorage::authorize_account(
 			RuntimeOrigin::root(),
@@ -4330,8 +4432,21 @@ fn auto_renewal_fails_on_chain_wide_permanent_cap() {
 			10,
 			1_000_000,
 		));
-		// Push the chain-wide counter just under cap so the 2000-byte renewal overshoots
-		// (2000 + 2000 > 3000).
+		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
+		assert!(!AutoRenewals::get(content_hash).unwrap().paid);
+		let block_txs = BlockTransactions::take();
+		if !block_txs.is_empty() {
+			Transactions::insert(12u64, &block_txs);
+		}
+
+		// Cycle 2 at block 23 would charge another `size` chain-wide; overshoot the cap.
+		init_block(23);
+		assert_ok!(TransactionStorage::authorize_account(
+			RuntimeOrigin::root(),
+			who,
+			10,
+			1_000_000,
+		));
 		PermanentStorageUsed::put(2000);
 
 		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
@@ -4389,9 +4504,10 @@ fn auto_renew_obeys_updated_retention_period() {
 }
 
 /// `enable_auto_renew` is signed by the *registrant*, who may not be the storer.
-/// `do_process_auto_renewals` consumes the registrant's authorization for each cycle,
-/// not the storer's. Verifies: Bob registers auto-renew on data Alice stored, and Bob's
-/// `bytes_permanent` is consumed.
+/// The prepayment at registration (and every subsequent cycle's charge) consume
+/// the registrant's authorization, not the storer's. Verifies: Bob registers
+/// auto-renew on data Alice stored, and Bob's `bytes_permanent` is the one that
+/// moves — both at registration time and on cycle 2.
 #[test]
 fn auto_renew_consumes_registrant_authorization_not_storer() {
 	new_test_ext().execute_with(|| {
@@ -4411,10 +4527,14 @@ fn auto_renew_consumes_registrant_authorization_not_storer() {
 		assert_ok!(TransactionStorage::store(RuntimeOrigin::none(), data));
 		run_to_block(2, || None);
 
-		// Bob — not Alice — enables auto-renew.
+		// Bob — not Alice — enables auto-renew. The prepayment lands on Bob.
 		assert_ok!(enable_auto_renew_via_extension(bob, content_hash));
 		assert_eq!(AutoRenewals::get(content_hash).unwrap().account, bob);
+		assert_eq!(TransactionStorage::account_authorization_extent(alice).bytes_permanent, 0);
+		assert_eq!(TransactionStorage::account_authorization_extent(bob).bytes_permanent, 2000);
 
+		// Cycle 1 (prepaid) fires free at block 12 — re-authorize both so the
+		// chain state is clean, but the cycle won't charge anyone.
 		init_block(12);
 		assert_ok!(TransactionStorage::authorize_account(
 			RuntimeOrigin::root(),
@@ -4424,8 +4544,23 @@ fn auto_renew_consumes_registrant_authorization_not_storer() {
 		));
 		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), bob, 10, 100_000,));
 		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
+		assert!(!AutoRenewals::get(content_hash).unwrap().paid);
+		let block_txs = BlockTransactions::take();
+		if !block_txs.is_empty() {
+			Transactions::insert(12u64, &block_txs);
+		}
 
-		// Alice's `bytes_permanent` is untouched; Bob's was consumed.
+		// Cycle 2 at block 23 charges per-cycle: again the registrant (Bob) pays.
+		init_block(23);
+		assert_ok!(TransactionStorage::authorize_account(
+			RuntimeOrigin::root(),
+			alice,
+			10,
+			100_000,
+		));
+		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), bob, 10, 100_000,));
+		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
+
 		assert_eq!(TransactionStorage::account_authorization_extent(alice).bytes_permanent, 0);
 		assert_eq!(TransactionStorage::account_authorization_extent(bob).bytes_permanent, 2000);
 		System::assert_has_event(RuntimeEvent::TransactionStorage(Event::DataAutoRenewed {
@@ -4439,6 +4574,13 @@ fn auto_renew_consumes_registrant_authorization_not_storer() {
 /// `refresh_account_authorization` only extends `expiration`. If `bytes_permanent` is
 /// already at or near the per-account cap, refreshing does NOT reset counters, so the
 /// next auto-renew cycle still fails on the per-account axis (not on expiration).
+///
+/// To exercise this, we need to drive `bytes_permanent` close to the cap before
+/// the cycle under test. `enable_auto_renew` pre-pays one cycle's worth at
+/// registration — that registration charge already moves `bytes_permanent` to
+/// `size`. The first cycle fires free (prepaid). The second cycle then has to
+/// charge against an authorization whose `bytes_permanent` was preserved by
+/// `refresh`, not reset.
 #[test]
 fn refresh_authorization_does_not_reset_counters_for_auto_renew() {
 	new_test_ext().execute_with(|| {
@@ -4453,33 +4595,45 @@ fn refresh_authorization_does_not_reset_counters_for_auto_renew() {
 		run_to_block(2, || None);
 		assert_ok!(enable_auto_renew_via_extension(who, content_hash));
 
-		// Cycle 1: succeeds, `bytes_permanent → 2000`. Re-auth resets the fresh expired
-		// entry (this overwrites the original since AuthorizationPeriod = 10 expired at
-		// block 11), but new bytes_allowance is still 3000.
-		init_block(12);
-		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 10, 3000));
-		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
-		let after_cycle_1 = TransactionStorage::account_authorization_extent(who);
-		assert_eq!(after_cycle_1.bytes_permanent, 2000);
-		assert!(AutoRenewals::get(content_hash).is_some());
+		// Registration prepaid the first cycle: `bytes_permanent → 2000`.
+		let after_register = TransactionStorage::account_authorization_extent(who);
+		assert_eq!(after_register.bytes_permanent, 2000);
 
-		// Carry BlockTransactions[12] → Transactions[12].
+		// Refresh at block 11 (the original auth's expiration boundary), extending
+		// expiration to 21 so block 12's free cycle and the subsequent paid cycle
+		// at block 23 both see an unexpired auth — but counters must NOT reset.
+		init_block(11);
+		assert_ok!(TransactionStorage::refresh_account_authorization(RuntimeOrigin::root(), who,));
+		let after_refresh = TransactionStorage::account_authorization_extent(who);
+		assert_eq!(after_refresh, after_register, "refresh must not touch the extent");
+
+		// Cycle 1 (prepaid) fires free at block 12; carry the renew into
+		// `Transactions[12]` so it can age out for cycle 2.
+		init_block(12);
+		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
+		assert!(!AutoRenewals::get(content_hash).unwrap().paid);
+		assert_eq!(
+			TransactionStorage::account_authorization_extent(who).bytes_permanent,
+			2000,
+			"prepaid cycle does not charge again",
+		);
 		let block_txs = BlockTransactions::take();
 		if !block_txs.is_empty() {
 			Transactions::insert(12u64, &block_txs);
 		}
 
-		// Refresh at block 22 (the re-auth's expiration boundary), extending expiration
-		// to 32 so block 23's renewal sees an unexpired auth — but counters must NOT
-		// reset.
-		init_block(22);
+		// Refresh again at block 21 to keep the auth alive past block 23.
+		init_block(21);
 		assert_ok!(TransactionStorage::refresh_account_authorization(RuntimeOrigin::root(), who,));
-		let after_refresh = TransactionStorage::account_authorization_extent(who);
-		assert_eq!(after_refresh, after_cycle_1, "refresh must not touch the extent");
+		assert_eq!(
+			TransactionStorage::account_authorization_extent(who).bytes_permanent,
+			2000,
+			"second refresh must also leave the extent untouched",
+		);
 
-		// Cycle 2 at block 23: per-account cap (3000) cannot fit another 2000-byte
-		// renewal on top of the consumed 2000 → AutoRenewalFailed on the per-account
-		// axis (not on expiration — refresh kept it alive).
+		// Cycle 2 at block 23 must charge another 2000 against a per-account cap
+		// of 3000 already at 2000 → AutoRenewalFailed on the per-account axis (not
+		// on expiration — refresh kept the auth alive).
 		init_block(23);
 		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
 		System::assert_has_event(RuntimeEvent::TransactionStorage(Event::AutoRenewalFailed {

--- a/pallets/transaction-storage/src/tests.rs
+++ b/pallets/transaction-storage/src/tests.rs
@@ -691,7 +691,8 @@ fn renew_by_content_hash_schedules_one_shot() {
 
 		let entry = AutoRenewals::get(content_hash).unwrap();
 		assert_eq!(entry.account, who);
-		assert!(!entry.recurring);
+		assert!(!entry.recurring, "renew should register a one-shot entry");
+		assert!(entry.paid, "one-shot is prepaid at registration");
 
 		System::assert_has_event(RuntimeEvent::TransactionStorage(Event::RenewalEnabled {
 			content_hash,
@@ -2673,6 +2674,7 @@ fn renew_schedules_one_shot() {
 		let entry = AutoRenewals::get(content_hash).unwrap();
 		assert_eq!(entry.account, who);
 		assert!(!entry.recurring, "renew should register a one-shot entry");
+		assert!(entry.paid, "one-shot is prepaid at registration");
 
 		System::assert_has_event(RuntimeEvent::TransactionStorage(Event::RenewalEnabled {
 			content_hash,
@@ -4394,6 +4396,49 @@ fn disable_auto_renew_in_renewal_block_does_not_prevent_renewal() {
 		}));
 		// AutoRenewals stays gone after the block — no further cycles.
 		assert!(AutoRenewals::get(content_hash).is_none());
+	});
+}
+
+/// Root `disable_auto_renew` executed in the same block as a prepaid cycle (between
+/// `on_initialize` and the mandatory inherent) must not be silently undone by the
+/// cycle's `paid: true → false` flip. The flip is implemented as a `mutate`, so a
+/// Root disable that already removed the entry leaves nothing for the cycle to
+/// flip — and no further cycles fire.
+#[test]
+fn root_disable_in_prepaid_renewal_block_is_not_undone_by_cycle() {
+	new_test_ext().execute_with(|| {
+		run_to_block(1, || None);
+		let who = 1;
+		let data = vec![0u8; 2000];
+		let content_hash = blake2_256(&data);
+
+		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 10, 100_000));
+		assert_ok!(TransactionStorage::store(RuntimeOrigin::none(), data));
+		run_to_block(2, || None);
+		assert_ok!(enable_auto_renew_via_extension(who, content_hash));
+		assert!(AutoRenewals::get(content_hash).unwrap().paid, "registration starts prepaid");
+
+		// Cycle 1 block: on_initialize captures the prepaid entry into pending.
+		init_block(12);
+		assert_eq!(PendingAutoRenewals::get().len(), 1);
+
+		// Root disables in the normal section — bypasses both the owner check and the
+		// prepaid-window check.
+		assert_ok!(TransactionStorage::disable_auto_renew(RuntimeOrigin::root(), content_hash));
+		assert!(AutoRenewals::get(content_hash).is_none(), "Root disable cleared the entry");
+
+		// Mandatory inherent: the captured pending renewal still fires (the prepayment
+		// honestly delivers one cycle), but the post-cycle flip must not reinsert.
+		assert_ok!(TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), None));
+		System::assert_has_event(RuntimeEvent::TransactionStorage(Event::DataAutoRenewed {
+			index: 0,
+			content_hash,
+			account: who,
+		}));
+		assert!(
+			AutoRenewals::get(content_hash).is_none(),
+			"Root's disable must survive the cycle — no silent re-arming via the paid-flip path",
+		);
 	});
 }
 

--- a/runtimes/bulletin-paseo/tests/tests.rs
+++ b/runtimes/bulletin-paseo/tests/tests.rs
@@ -359,7 +359,9 @@ fn authorized_storage_transactions_are_for_free() {
 
 			advance_block();
 
-			// `enable_auto_renew` should also be feeless and consume one tx unit instead.
+			// `enable_auto_renew` is feeless but pre-pays one cycle at registration
+			// — same hard-cap accounting as `force_renew`. The next cycle fires
+			// free thanks to `paid: true`; subsequent cycles charge per-cycle.
 			let extent_before = TransactionStorage::account_authorization_extent(who.clone());
 			let enable_call =
 				RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::enable_auto_renew {
@@ -371,7 +373,10 @@ fn authorized_storage_transactions_are_for_free() {
 			let extent_after = TransactionStorage::account_authorization_extent(who.clone());
 			assert_eq!(extent_after.transactions, extent_before.transactions + 1);
 			assert_eq!(extent_after.bytes, extent_before.bytes);
-			assert_eq!(extent_after.bytes_permanent, extent_before.bytes_permanent);
+			assert_eq!(
+				extent_after.bytes_permanent,
+				extent_before.bytes_permanent + data.len() as u64,
+			);
 		});
 }
 

--- a/runtimes/bulletin-westend/tests/tests.rs
+++ b/runtimes/bulletin-westend/tests/tests.rs
@@ -359,7 +359,9 @@ fn authorized_storage_transactions_are_for_free() {
 
 			advance_block();
 
-			// `enable_auto_renew` should also be feeless and consume one tx unit instead.
+			// `enable_auto_renew` is feeless but pre-pays one cycle at registration
+			// — same hard-cap accounting as `force_renew`. The next cycle fires
+			// free thanks to `paid: true`; subsequent cycles charge per-cycle.
 			let extent_before = TransactionStorage::account_authorization_extent(who.clone());
 			let enable_call =
 				RuntimeCall::TransactionStorage(TxStorageCall::<Runtime>::enable_auto_renew {
@@ -371,7 +373,10 @@ fn authorized_storage_transactions_are_for_free() {
 			let extent_after = TransactionStorage::account_authorization_extent(who.clone());
 			assert_eq!(extent_after.transactions, extent_before.transactions + 1);
 			assert_eq!(extent_after.bytes, extent_before.bytes);
-			assert_eq!(extent_after.bytes_permanent, extent_before.bytes_permanent);
+			assert_eq!(
+				extent_after.bytes_permanent,
+				extent_before.bytes_permanent + data.len() as u64,
+			);
 		});
 }
 


### PR DESCRIPTION
One-shot `renew` pre-pays for the first and only cycle. I made it so `enable_auto_renew` also pre-pays for the first cycle. After that it goes back to charging every cycle. Users can't disable auto renewed when it's prepaid so people can be sure that that data will be renewed.