### PR TITLE
Set Paseo Next v2 as default faucet network

### DIFF
--- a/console-ui/src/config/networks.ts
+++ b/console-ui/src/config/networks.ts
@@ -67,6 +67,6 @@ export const WEB3_STORAGE_NETWORKS: Record<string, Network> = {
 };
 
 export const DEFAULT_NETWORKS = {
-  bulletin: "paseo",
+  bulletin: "paseo-next-v2",
   web3storage: "local",
 } as const;


### PR DESCRIPTION
## Summary
- Change the Bulletin UI default network from Bulletin Paseo Next to Bulletin Paseo Next v2.

## Verification
- npm run build (console-ui, after building local SDK and generating PAPI descriptors)