### PR TITLE
Add transactions to runtime api

### DIFF
--- a/pallets/transaction-storage/runtime-api/src/lib.rs
+++ b/pallets/transaction-storage/runtime-api/src/lib.rs
@@ -24,6 +24,12 @@ pub struct AccountAuthorization<BlockNumber> {
 	/// Bytes already consumed by `renew` calls (counts against the same
 	/// `bytes_allowance` cap).
 	pub bytes_permanent_used: u64,
+	/// Total transaction cap granted by the authorizer. Used together with
+	/// `transactions_used` to predict whether a `store` will receive the
+	/// priority boost.
+	pub transactions_allowance: u32,
+	/// Transactions already consumed by `store` and `renew` calls.
+	pub transactions_used: u32,
 }
 
 sp_api::decl_runtime_apis! {

--- a/pallets/transaction-storage/src/lib.rs
+++ b/pallets/transaction-storage/src/lib.rs
@@ -1773,6 +1773,8 @@ pub mod pallet {
 				bytes_allowance: auth.extent.bytes_allowance,
 				bytes_used: auth.extent.bytes,
 				bytes_permanent_used: auth.extent.bytes_permanent,
+				transactions_allowance: auth.extent.transactions_allowance,
+				transactions_used: auth.extent.transactions,
 			})
 		}
 

--- a/pallets/transaction-storage/src/tests/runtime_api.rs
+++ b/pallets/transaction-storage/src/tests/runtime_api.rs
@@ -34,14 +34,15 @@ fn account_authorization_returns_none_when_missing_or_expired() {
 }
 
 #[test]
-fn account_authorization_reports_raw_consumed_bytes() {
+fn account_authorization_reports_raw_consumption() {
 	new_test_ext().execute_with(|| {
 		run_to_block(1, || None);
 		let who = 1;
 		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 10, 4000));
 
 		// Drive the consumption through the signed pre_dispatch path so the
-		// account's `bytes` / `bytes_permanent` counters actually update.
+		// account's `bytes` / `bytes_permanent` / `transactions` counters
+		// actually update.
 		let data = vec![0u8; 1000];
 		let store_call = Call::store { data: data.clone() };
 		assert_ok!(TransactionStorage::pre_dispatch_signed(&who, &store_call));
@@ -55,6 +56,8 @@ fn account_authorization_reports_raw_consumed_bytes() {
 		assert_eq!(summary.bytes_allowance, 4000);
 		assert_eq!(summary.bytes_used, 1000);
 		assert_eq!(summary.bytes_permanent_used, 1000);
+		assert_eq!(summary.transactions_allowance, 10);
+		assert_eq!(summary.transactions_used, 2);
 	});
 }
 


### PR DESCRIPTION
Transaction allowance is useful to know whether the store() will be high-priority and whether renew() will actually work