### PR TITLE
Bump polkadot-sdk to 2604.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,9 +1006,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "asset-hub-westend-runtime"
-version = "0.44.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78fae0d900d4f376d2ce6bd53c84796a54f55fc2a1fdc15d35b5972ac2dc229"
+checksum = "54be4b8c647703291296e19dd7d85b90d12d01bf345a8a5b4a86da739ecd092f"
 dependencies = [
  "assets-common",
  "bp-asset-hub-rococo",
@@ -1144,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "asset-test-utils"
-version = "31.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ddce94b873a0b2b935d08ae99c74476f36da4448ed2e2d04d16adb8eb3cd4cc"
+checksum = "4609df453374413168547cb49ce7f5f4bdbbdc6992220c4030997f1ed256e875"
 dependencies = [
  "assets-common",
  "cumulus-pallet-parachain-system",
@@ -1176,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "assets-common"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8466c29d8ed20032995f698dca7333aef406ce541f397fa4fff213e9106a6238"
+checksum = "9ec653f113c0ed4d5d86db31650ce838d5fed6342690260501db0943f0864ac9"
 dependencies = [
  "cumulus-primitives-core",
  "ethereum-standards",
@@ -1748,9 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "bp-asset-hub-rococo"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc85463a7e6d8c4fb58f8964439cd4fb0293ea0c427a601769be81a29642066d"
+checksum = "d2b05ebb767a72f4d9951237ea32b5c1264081b099b489e3b26dbf6a3e52dd4f"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -1767,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "bp-asset-hub-westend"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3aeaf56aa74fd886e9719bf5195dd574d6949b3d5240057a3e7d190606b8e"
+checksum = "e793df58af006213289daf73519610f39f83fe3a25404f8e3a4a46608cb3ac18"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -1786,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "bp-bridge-hub-cumulus"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb185eb63d9e62f252758852d88d5de1754745bb5978d989df7b7352a71f440"
+checksum = "57bb7cb9581890cab93090f9ffdc71f7d89acfd8401d9ab269f19423458937d3"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -1803,9 +1803,9 @@ dependencies = [
 
 [[package]]
 name = "bp-bridge-hub-rococo"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0db212c30089ff586b3523e6986dbf8219c9fffbbb7d30f38e7062389d576f"
+checksum = "dc6fea048bb5bb03696f736b7bc2b095f93795514aed1912ce3099aa98f6b81e"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -1820,9 +1820,9 @@ dependencies = [
 
 [[package]]
 name = "bp-bridge-hub-westend"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74df71054fd88d81621f395cbaad348a68d285e5229a520992b3d98abddafb36"
+checksum = "57f92034bdf5c270aa9c1e1dcdec6cd4958e263aa61aa0e0c7b985ea6e8f2ab0"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -1908,9 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "bp-relayers"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7307bc43700f770a9e9c0c2d24f13ba487f8d8616fe3788b186b489253854bc9"
+checksum = "89f493f246a0ac741b719ce574802c35073da35d9b39889e7c584d8fb1649a15"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1927,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "bp-runtime"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b533f60ba5be417ee53b67afb755eeffd71cf9b38449f1b888c6b8feaaaf0608"
+checksum = "6d3949a24059cf7080afc6f48e6f602a704f16477ebf88db6deac763fc75ee4b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2997,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-aura-ext"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77e4e2eabcd039fa312527c106febf4ab51a7878b3b82b57dd5b51e0294eb08"
+checksum = "e6580ef26f38d4c792a36f99efd4d1f8583803bc99c54ab9953fb27c9af48f99"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3015,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7584e55f8f82926d36126168a0b94712ad6fe01e03dd83b27d7ae5ad70184fc0"
+checksum = "25f61ed90405269cd880934c06b2f43df2d0b68b7104cbedad1648749ac138c5"
 dependencies = [
  "array-bytes 6.2.3",
  "bytes",
@@ -3071,9 +3071,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc645400b6f8c249406daf573c298908f87a9eb41ed6b59b18856a97fc53a26"
+checksum = "2b92fa477e5f60add7a418c80db01d90672afcb45074f2a15aed7c5a007eb56a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3085,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35f07e0f5f3ff2448938d63f71cb9a2d587933c1f011e0a4dd9f3a1ec61b237"
+checksum = "31758512300537aaf11c713fb6121c5286a6afcb47dc771268218ce4498a0e98"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -3121,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc83b39f928db62f3d3b13337cd856da414a324072a89a404dbd05d0a663463f"
+checksum = "39282e0bb47f2b54b5f11e047fd1041cf30a09bd428ef060220559ece2e8369e"
 dependencies = [
  "approx",
  "bitflags 1.3.2",
@@ -3203,9 +3203,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad827cc26c1d34927f34d306f62a93f9104485d05cf7bd02e27d2168d5c6991"
+checksum = "476449f38b0424adae257fc659dd82b98f0e3673d69802055913f55dfa52e622"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3221,9 +3221,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a790fbfc051215754cebac5644c63e3c20d75f5c908022160a930a234e9f08b1"
+checksum = "1661a7583cb9d3e5d6cc73f2554161d4f8500b37ed5061d8bb7cec3631eeb5e9"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3851,9 +3851,9 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "emulated-integration-tests-common"
-version = "30.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1598710fc59310262898a74a1406e26023ff8b44055207da739e8e013a856386"
+checksum = "4d76d914b30e9e7a9f3793a96717e405ef08f57b8c73999a4ee0f724b7160917"
 dependencies = [
  "asset-test-utils",
  "bp-messages",
@@ -4299,9 +4299,9 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frame-benchmarking"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eefadb34832df54ce9421ddd6f182d756f188197f8e507651d012150e125ee0"
+checksum = "bac5bf601c69cb27aee945517b723c2df4ecfc0bdd7b498f04998307d7ce5c13"
 dependencies = [
  "anyhow",
  "frame-support",
@@ -4541,9 +4541,9 @@ dependencies = [
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd3b8a3cc61742a9033608420e47a2dab4ff9d9127a55a56199359637aef5c"
+checksum = "e1a4b94405b4f92766969ac9143a0740b1bc0e5af8f5c9fc4223df9b3c9d4cc5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7646,9 +7646,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-accumulate-and-forward"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b4c0c7ea6ab1ee5e8baf46d260578822e6ebf15ed14c04feb4c3edfd795183"
+checksum = "70a06a4007d81c38e6a450742f209b61252f091440328ffb7ddb8365c5871f59"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7661,9 +7661,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-ah-ops"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccaf91811e062e3a1d26d08fe5b80d61b32051c1c6e04e83cf5dd10dba10f5f"
+checksum = "fb3da67e7bf0c4f57591dab022fa05f603c6410927826110fb40d43a2ad38620"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7683,9 +7683,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-conversion"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5181c48fa3ea50bf9f3b3a19e4cf708e7e0d0ee6397961e2c176a215d9ebf3"
+checksum = "7331060ed8eb72522a1ef81ef5803de08919fd29a5517365435def45476c77a3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7702,9 +7702,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-conversion-ops"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "482a68587027c81d431a503fff70f1c88bec005638c2b6ed7f6a83185dcbf878"
+checksum = "8a68381c24f8b482a7737e36bf6be9d76e5c5af25bf86568be08806b43f600f8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7721,9 +7721,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-conversion-precompiles"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703250477bdfdd3fb91c141a68f7520dd4760693a06315a24d6d16778ef0ca9e"
+checksum = "51a23011cfbfb8c1742d0ed68d17f53899a2e84d884680dc1e01aa9d24d5f263"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7737,9 +7737,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50cfade1e1ed4f89ccce19163d4a7b9289173a9659535251721ea916aa8e0"
+checksum = "8cbc1bab2aaa9985bb32e18ba508350e1422ab18e5d3b57ed7aa7f321a717fca"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7753,9 +7753,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-rate"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db795f12bd78b65725d382e5cf85ef2d3751bdfbf2e2dd417b3acebd13590379"
+checksum = "d85da1aca868a63ebc24fe20e03fceba9932db588c87ea1a671a5f0b372bd96b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7768,9 +7768,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-rewards"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9112865de430ea943890734b5fcf4d5bb44796f1de2c18b25f3081d7b3a95f4b"
+checksum = "d1ee7b1c7479990298cafbb5b0c781f034aa1faeabdfe88b4e77439512026084"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7787,9 +7787,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dbf12ef714ba9068629f0e204677b3f113dcdabdd04c1b6d0e68e3d72b722c3"
+checksum = "017113f0b67563bdea68388389245b085b3ac034fed74cdda24cd3758297930d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7804,9 +7804,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets"
-version = "50.0.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a12ce465455024ddb679ca6425f63a6f7c40763a86f7482a8b02dd6c85e5a32"
+checksum = "5752ea378a98c5ead92025b916fad0981dfb46ac712842d69b2bbf4260acce5f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7821,9 +7821,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets-freezer"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c60f82574de1d8bf7c40e585323d503845e151801280a44a74b1420385f790"
+checksum = "15621de603c5545907267e6363a2d5f0be9fc4e3fcc1e37b4c4da0d94380659a"
 dependencies = [
  "log",
  "pallet-assets",
@@ -7834,9 +7834,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets-holder"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9149a0f06545f1ebeacdfbc54fef8bf3ad9fd7e8a3bc6161de32ff19b812b54d"
+checksum = "f5ff68417c4ef999aa1962709ae739271f1eddbc6a898e3dcf7cebc8f36af1e8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7850,9 +7850,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets-precompiles"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600be4f3db354d9e2041864fbaec3a961576f5ce9ab5d1aa6c377b2ada718df3"
+checksum = "82db74bb122110065622182608c0c17c9e8c616e42c94d9127c4966f267ca5b8"
 dependencies = [
  "const-crypto",
  "ethereum-standards",
@@ -7873,9 +7873,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-aura"
-version = "46.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d189a393438200a3f0302847e6c646376a423c290d58c629e8283e3ea9a40795"
+checksum = "40e28873a69c8343e303b4a5bf0156a5965d8eae96623dcb3afca25f99c8ca15"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7890,9 +7890,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9757ea14adec92eb42718e1801b7406a7c2bfea4a82fc77455eb2c558f3ce1d"
+checksum = "8534c65146d23e618c803bc1217b102067d0d8a4c65a612a8c8bea9edfe45bb1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7920,9 +7920,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-babe"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351943c9049b6469a94386edb96848b8b11b72b491a29c3f368eaeb3fd430e20"
+checksum = "3f50441ab81c511e8878754e0b8884f6089c1d15c94297c7fe6222844b28fd31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7944,9 +7944,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-bags-list"
-version = "46.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00bdc9f9b8506797a012ad36767aa117cae2745244fad8b87b514da31dd75d7"
+checksum = "4a7c4476b0780e60c6727ec9f13037361557d8513e8bb72421f0be08cb6bd6fe"
 dependencies = [
  "aquamarine",
  "docify",
@@ -7966,9 +7966,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "48.0.0"
+version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7eeb90835154816cffa771fa82689e94b8afe33eba30de3f8d1dcd2f2b42a3"
+checksum = "082c8405f9664430eaf30e4f62b94f50a6b831414fafb607b03a4abd148d1d47"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7983,9 +7983,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy"
-version = "48.0.0"
+version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ee9536ff175ca442714e599c3753597d7f396d351ebc2b2860144520eed0e"
+checksum = "3a9bbe39703709e7facd8465eb135066836117d284e5c62c938d2c481d19aa5e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8003,9 +8003,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "48.0.0"
+version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2255b4ac8dcc82f82ded6bb8c3e32aedc6e67f85fbc165af8ca200ecb086f34b"
+checksum = "be55642d71a77b0addd28ab9306f68b4115c81bda7c855722d4e02d26db15d44"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
@@ -8029,9 +8029,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-bridge-messages"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac7e32dbd16530d52351f9ec4904031297a3e249d31956ff93e03e5ac2e55fe3"
+checksum = "218433924fddf9d1a94d848f1d5f11dd2d51274719bcb4b468fd26ef364eb83b"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -8049,9 +8049,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-broker"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b0bbf7fa5c78b3d32aa1437ff60bd432e2f3dec69deb477fddcd192d2d2c2c"
+checksum = "c9618c786871aa77af41927d6ee6cb0829aaed0e5f4e42e26b83046bab08ce15"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8112,9 +8112,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-collator-selection"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c34bf518141c1cd2344edbe9baa28205b0c60bf5f73ff92e0ff5e565f8d94b"
+checksum = "d16087568d6d7b14d5218f81961104d364c310b5be2dc9fd44673e8bba7c7a63"
 dependencies = [
  "cumulus-pallet-session-benchmarking",
  "frame-benchmarking",
@@ -8133,9 +8133,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d510e1ffa3cacf45fff188bc327aa5f9ee0aa95b85f24d9d1c89490a1857812"
+checksum = "f077a0cb2995747d43181d3208a3a102f5e202ffb563e4f95b5c51704c9b1b36"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8150,9 +8150,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-dap"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf956b32e26abf6f133935472c2289471c4bd7111094a1af1a9b8ac04f052c3"
+checksum = "34a7105876930a81599187f29beb56790622f54255b82713a53f8e535e4f01ca"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8184,9 +8184,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-multi-block"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654b196f666c58117c903c81d0f4c068be261d807590f12fec4617bdbdd09563"
+checksum = "84769710c4ea5bd2d864932680c73728799ce1f38dfe2d7372be36a521f27f09"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8206,9 +8206,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "46.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab6a9d55d2e0045af2080d6c93c56745fb22e5dfd6e64b8e7b7106758f64ac5"
+checksum = "e1a3506794df6805450cb787db4203a442a17f0c50ccb9597a9146c675fea26a"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8228,9 +8228,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "46.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6ef314b8d355841a3048988ea49cc9a5113dd67dc97799557ffbf989c0b178"
+checksum = "a31e7819dd30f7faa2a35ef1b9a2fadba30cad5f67b123496f27028499c5b76f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8242,9 +8242,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "46.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a48ad630cd73726eabeb376698d2b32375a4e134f1e36f075490b19e724508"
+checksum = "c22b0394236a0e3faf9c90cf9dfb98b2f5319bcc23103136d9ba26c9c3e56d17"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8261,9 +8261,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f8a269e4a09f4160a0b9383a5d5c0b4fe67dbc80f8bcedceb02fce72daea37"
+checksum = "315652f265f2f3f6ecf9e5ecd589ba01d52d9f2df0ea287c5bf654038b15b304"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8284,9 +8284,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-identity"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e5cf703eccd877f4d075a7103a8a539f3685690943c6f349f76f7742f7e8a7"
+checksum = "88febdcdd4d5ce92c1c373e9de440488a94f14d076019c185fa7770c0e0e21d2"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8301,9 +8301,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-im-online"
-version = "46.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c4b8e4a80ed879b610d5f1af20d353a11dad4ff848dfd81447fb9997ad6e80"
+checksum = "7580657dc96a3ed59ea981d93612bf026356323813e530c7f12a95ebd8a60276"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8321,9 +8321,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-indices"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de59e07085583f32f41f4c70dd1ea5fe94642f4edc022f06f292f390096cda6"
+checksum = "a558bc7f51901e229488259c370e8d49d96cd9752143df0031504ce071fa4926"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8337,9 +8337,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-message-queue"
-version = "50.0.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdab19a61b19a6ff4ba65561524fe57580413414afd1ff935b2e32d0f49d13c"
+checksum = "7c6518c1ce59b1fb63b127d462a0371e52b2a014d51ee2adfe283c1d276dcf3d"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8357,9 +8357,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-meta-tx"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1ad3aa594b0eb73984c2d98cf1d336bf55eacaf6735029a819351149a4bb84"
+checksum = "1d541f24c51e96155c517b8e46ef648ece51034fa57fc0870d3fdf14e1138617"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8376,9 +8376,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-migrations"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae37dccae86cf412a24a5cb7065cda03950bd69bcf138dcf3c7e9ae658d269d"
+checksum = "90e53c0720cc71309be3da638e75591bf02d3141590f7c6e004e326ed307b4ff"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8396,9 +8396,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-mmr"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5877919fe2e2c18fa23fd4de8e8530c5f2049247aecbfa6bc5ee59372f355eb"
+checksum = "31125bba03adf8c2163ca67146ee9005fc44aee069dbff2a32a56aabf41ced9f"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8409,9 +8409,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-multi-asset-bounties"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f6ad4dc1e04ba31fb2ea64fbe3310eb51694d955211b20cb7d8979b7cecbe2"
+checksum = "89608a9d14cef8c242fbaeec570a9bcc7e372ca1ef72ca66a8a0225067d3c4a3"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8427,9 +8427,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-multisig"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d059159fb4a4decdf8df27a12c654222aad18c69535e68acf085ee7c2b007b7"
+checksum = "193636d6e536e0ed75d8963b95e556e86feb09b319bd6cfc60f2a8a328d766d6"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8439,9 +8439,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft-fractionalization"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e81c7f8049897d982caab7f1c0168ada8c4864da64c999184b694350634153e"
+checksum = "c92d4572ba890fca812a3c09680d13f4d87bd63727a39e2056c3206ace985799"
 dependencies = [
  "log",
  "pallet-assets",
@@ -8453,9 +8453,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nfts"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e344097aec19ec0ff34baa616bd52465c9b8468b050773553ff966cb8db05a"
+checksum = "8aee15c810bacb51dfd440b19e15aa55ea7ba41f3df8f8a90eac151e45cb0942"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8481,9 +8481,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "45.0.0"
+version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9dd55e0eb67a0fc1375b73b63b0385409fa6cc31f5423e0cd00716fa40d5ecc"
+checksum = "962c84efb2f0a86bf16a179693015efc834d45925270f8ff5d044b34a33a2e46"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8500,9 +8500,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "45.0.0"
+version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ccda02ee2df9e6b31b28ed7185b941de59f3622fc9ad4367b28365bc7754b5"
+checksum = "7faf7e000bccbb24aa7f58339affb32d43254540065053d1d26699725026fd05"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8521,9 +8521,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "43.0.0"
+version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1320b1e0b25fd6fa9d236dcee5dceabc56472895a6cd0888335d9ada18f29204"
+checksum = "23aebc03234dbc9b34a77b5f4f28e4e4eeb90f1cb78aeba923200dc2e04f586d"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8548,9 +8548,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05383410fe93c18a14cdd64c31751338b3f88e36930c8e484a7d84b6822efaf8"
+checksum = "2104dce460d3854c9990f8fcd308210047399cf015ac2a6dabad2503ef0fbf1b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8573,9 +8573,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-parameters"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef9c83d0be86b44ee9bb565dbeee6afe41fc1aa5def96ebe611cc9b465367c2"
+checksum = "6c366e15feb3d7b099caf0497a3522dcb1d391302c7092a2f8e0462e09e8fe16"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8591,9 +8591,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-pgas-allowance"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be31d147d62235a2b1dfa761edc645989b0ceaa326ecaa30aa8660669ea9f8f9"
+checksum = "d56b947fcadc0c46c636c9fe17a9b7522e9cd3791bc7f4f86463b1655a9c802b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8607,9 +8607,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-preimage"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f8c81df965e6b023c5008c807780616780b822d9679958072e9930f08cfe06"
+checksum = "36177a6102deab0ee1da34caf211b8326d07e123cf343dd959467bb3e9052044"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8624,9 +8624,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-proxy"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec078a884266ba3093b8955854d54890971e98c76a51ac7aabdbaf36db0f89f"
+checksum = "716d1a543341e57c454a87f793971941a9ffbfe5adbbe3db2aa6bf6d5f1b1478"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8635,9 +8635,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-psm"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df87868ea2586aff55c809a0116e6672ec57c75179325098199e5f53a24bc125"
+checksum = "41efb0f2d552eb18fb790bd20fd2cbb871d8cf0ca5f8e00e4b48517f31e7d384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8650,9 +8650,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-recovery"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb002713c4efc06a45f9d5a06320a33f5db78ef4163c065b5e6aa081f155ee68"
+checksum = "5e4112f40888eba880317e2000b0b239e1b07fc9237e74849b091af98bd24515"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8664,9 +8664,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-referenda"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e27f4e497e2bdc2e484c2559ec73c4b601aeb6766412457599c96ba8e5727a9"
+checksum = "4e9a9885c7315b309d4904cf504e03a02e7ea12c98386648e9838530b342620f"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8683,9 +8683,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-revive"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fab67b2ff0965beb519a1c68749ec1f58debc926e0b9cda06201f6dd475d686"
+checksum = "248798d428e07ed36e1fdd1bb09c2cb7cca63df3ef9930015a61def593bbfe97"
 dependencies = [
  "alloy-consensus",
  "alloy-core",
@@ -8781,9 +8781,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-root-offences"
-version = "45.0.0"
+version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7076bda1957545bfb489f2b0320f41bba9eaa7215b3c869c49d150c661897a62"
+checksum = "321efa39b4c9e18893b6a8d3e390296a26340ac30260804df321f8c8d8479ae6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8812,9 +8812,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-scheduler"
-version = "48.0.0"
+version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d673d918e8441c87fd31cfe2922bf0b3535b4d25e7a3c4758d8b1c017d567164"
+checksum = "0b2a852a3c1a4d38d2805789623531e133e1fe91c2663b7f1420852db074b273"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8830,9 +8830,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794e88d1cc5d0a569d1d60065d75abf50ff8f694d08a632a3f559dc67f3288d"
+checksum = "9652248c8ffa9edac00d7d217d96e1d0210624f4707abeac20990044472694e6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8853,9 +8853,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46cba5f49593c0bcae3843eb10df4fd02202bfea85fccba556735c96a0a1e3d"
+checksum = "967870778286031509f4a434ff8daebd0ef02cee577b5ed681d197442547bec4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8883,9 +8883,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5c539d9f19cf7854bc9cfd719ba4e9011e0787e8927b8110a913b3aaf23742"
+checksum = "e920112ca92ec9b5b1797e56fddf89e24b941ea77d6c8191d60ccc485da1b86e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8906,9 +8906,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-async"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f1343e91a16249fa860f4302940ab05026cfb2f222e4c909b359ea28119d39"
+checksum = "9aa72c124fec0ec8581a423103db67e4fbb6fb047f4bf01548734863f2051b33"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8932,9 +8932,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-async-ah-client"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5db8a0ab71eca01b13d886f79f82bbb5696751805e2eb606441aa4ee832dc42"
+checksum = "2e6b5eba70f758f082921f4f3682638cac3ac2e9694f22dec9d32d3b79b4b71d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8953,9 +8953,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-async-rc-client"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99995f064fa68758bb0edff4e522d1bb74fdbe28874572a60c8bee49c84f422"
+checksum = "72fc88bf30b41e78cbf62c1245841d6ed83ef6d2637efe0f2dcef3683c57a5ae"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8995,9 +8995,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "52.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b051e46ee13990aea932c8320c1df918d5e783210ca1f2bc3d961ba6e6ef0b2"
+checksum = "1ca8379fdbff6ce11967f0d47994de4fff57b11e1d72292c7c76bc273280e029"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9012,9 +9012,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad4e3a4cc006a45ecad59c02583b814a7f02fb504c5f9f547bbd4238690229f9"
+checksum = "737608123d713af4d7619df47f22dbcd6fd55dbe5068f9ea429818bc3993bea7"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9028,9 +9028,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "46.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd8823ea19e3b764aad58089e1078c211d93e0cfc1291cb7ed0dfa1fe1d6136"
+checksum = "eb51deebc7013789cb29d7e27a1be156fe3fdb51b02a4f8a16c76daded664adf"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9047,9 +9047,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f17aff98f52ffb1b5d488bb140e88193fbb30c82a92113217e853c84c9586f"
+checksum = "9041abf1095150239fec5bc98c9c28b50708e5633392f9ca1b3df9f0f03d2d72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9064,9 +9064,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9849f59095432e6602658eb553aec99ed665f13f9562eaf5d1adadfca3ecc9d7"
+checksum = "5e76d71c23c93bf392aa69ac40041d39461f2083abf30abe05b753951cd7eefa"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9077,9 +9077,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-treasury"
-version = "46.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a811bf3b0eafe84bf211b9ee71ebc0ea9207b5f844391ea0bf9c20789d24ec1b"
+checksum = "13738baf24d75c8d41f706e522b243d98c282b331243d075e86231acfdd2c23e"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9097,9 +9097,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-uniques"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c834b115ff9f64c7368bedcd3a74b42321ba696ea025ba440ca261d83f1168"
+checksum = "8eb59ceb18b96668033944eb77288add7ff1960b76f31af484d6d03f9068ab6f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9112,9 +9112,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-utility"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c09d089fda68a361c4c80ca80d3309e0a132a3d6200ce6819b121ca8dcb43681"
+checksum = "6f6a381375b03d44183d0140868493a87cc346eea561aa534de0a9332088227f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9128,9 +9128,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-verify-signature"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7513c3d407ef88f0e2b7aed98899f077fdb35d742ad614097e4fc86e7d4d0e64"
+checksum = "5b82b1421a0d2cf2b53daf556c7a673c72cf1534b3309bef28130ca8c944a6bc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9144,9 +9144,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-vesting"
-version = "47.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2ab878c9d72842c04db11ff0ecf7ab2901611e752809b852ee05eeb9f14085"
+checksum = "0bd960d8545bf592283bf630b9edfa88241adc0d3d98be843ae1c53bcea4fd30"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9159,9 +9159,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-vesting-precompiles"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a267a2aeeba499b2b7320d7a0a26a70e2c40ca0b1923f3fdb4407debcbc76"
+checksum = "c18538589f9ed23b5b0f3e212ceb7e868d8cc44d2b94ac2b9901443a3fc350c0"
 dependencies = [
  "alloy-core",
  "frame-benchmarking",
@@ -9180,9 +9180,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-whitelist"
-version = "46.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47358271800bb1d0a951ae82e1a192d2d30f765dfe64489b123211758517106"
+checksum = "07e582aaaeeafc15873f018a81568f6cfb76a3921d9d8719f7bb2b286dbf2833"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9191,9 +9191,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d035f6e566e48f6a0d35324ab36b7a84d8618ed8d785997af902c0f68939bee6"
+checksum = "f6bd4996a599499dc6e3b5638020cde72bca0f329279edb678f8e22522645016"
 dependencies = [
  "bounded-collections 0.3.2",
  "frame-benchmarking",
@@ -9216,9 +9216,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdae2b05f6e921c40b68cefaea45fd6ff91491e916cca95f81b3d11e8442f27a"
+checksum = "507e7010782bc98b905c7a4234586b73d576ebdd52b26cc832f29c5ddf0456e4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9234,9 +9234,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c45573d7737579a85f3f6cae813d8fcb9f92b3042fcfcef7c99e32e7b0ff1ef5"
+checksum = "61478eddb7e38f3e66c27ff525798b242202b027c661b287334ff7526b22a7ca"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -9257,9 +9257,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc8da5fffc72a732e2e2d5eba7a3c92b1c1aa3671789d2fc4d9bd63bfc6a7b"
+checksum = "26b553f05719498ff8315eb5907595254bb797bb6621b066395d3349673ae003"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -9278,9 +9278,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-precompiles"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a77da8eed45670c81bdfb8a6f7fc8fbe9395a4a54f10db09421714096b88f82"
+checksum = "7950f7a5680e195934eeb5863b0aab266b5d61c1335b3cf70aa442dc8517494d"
 dependencies = [
  "frame-support",
  "pallet-revive",
@@ -9293,9 +9293,9 @@ dependencies = [
 
 [[package]]
 name = "parachains-common"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5afa6e3e17fb738bb50374c6d1be0c3c1202b9793989bf962854f84a12769e9"
+checksum = "b42a16a3e8983b91f0c00ac2b27167e4496ab324f3091d5aeadd43096dd50501"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -9338,9 +9338,9 @@ dependencies = [
 
 [[package]]
 name = "parachains-runtimes-test-utils"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a0d1d9983d8aca4d6c080c1133d84524e27e073f64da3197caca8b7fa726287"
+checksum = "5081c0b16fab650cfc2f0825ab13bded39861042fc1c481011f6b5651345f658"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -9793,9 +9793,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3be164ceb034e3fef2bc2dc4e3849a9e93533b2f486d91a297ec47a8b9bead8"
+checksum = "0ff99b6a05b433f4611bb8c12797d168232f01f27901fe5fb1da3ac54e856f7b"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9844,9 +9844,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbac0cbb97c16815a0e0b699839de7f877d005efcbacb7a7f15adc5ffc436950"
+checksum = "397ccc07bbf236d7cc1b23abbea6fb3915e21b808023d8854416c05868d3865c"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -9857,9 +9857,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "746067899af0c001151863973c80ca6bad987c4dd52f33ede9a78034e221848d"
+checksum = "67cf7c7c41cb77746c2ce746428815bb17d7c0a9e12bac6d5fa857319eef911f"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -9907,9 +9907,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-sdk-frame"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9478bb8d5ebf45390add809a76536fc752a974711a6d0795ea1127b73d156c5a"
+checksum = "c3007df186bc582c62d7719eac0b88d35e7bd7bccaaedc3d8b2f9be802774853"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11228,9 +11228,9 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1a96be6e424dd5e90157ec386296af7e66a1dc19a2a2ade67d1927caf68cb6"
+checksum = "ca2a24aeefb723fd15d088330c740c926a17eeb68abad5ea3df741dc0faebfca"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12923,9 +12923,9 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-core"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac551b6bacfd11f8f78f789e94824f3daf2f54a524aa881fee96c9963f2eb6e7"
+checksum = "7ed321840bbea73126905d32bcc268ca7ae4ac6d949acc801770cde7dafbfc8c"
 dependencies = [
  "bp-relayers",
  "frame-support",
@@ -12963,9 +12963,9 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue-primitives"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec95ca08b0b3833cecb7d8c367d38685bacf6781dc4605c37a6a46fef43ba1be"
+checksum = "7bb79a974972bbb78508e8d44d10d38aa3ef727f6a01714b972d75980e310115"
 dependencies = [
  "alloy-core",
  "ethabi-decode",
@@ -12990,9 +12990,9 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-pallet-system-frontend"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bda270a2e495e476c5112b1b68617ac7e4b44dd785b3c65f17894d5ef0877b7"
+checksum = "522a11154d52b76f85d703b2e45c088ed9a0e8e3bd082e06e6fd75de3ee99ffc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13012,9 +13012,9 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-runtime-common"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83928c9e70fbaf1c0359ae4d0756bb61a6317c94940e1a9f4dd309bd2af23bda"
+checksum = "ff5cd6741c917e00dc6969df416ba7512bc205adafb8362ac8d4e5b4b7a15797"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -13030,9 +13030,9 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-verification-primitives"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4b0b2e9e1d6b4d3268febada099e4f0a016bce988aab102578202f6eb42d81"
+checksum = "85517244d52c68a6474318542e89e2b49f8ec3540ac4fd76e6b04e8642b38929"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14086,9 +14086,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5279820f8b83ad3fa0b1881e8a9689dc9e8886345bb4e35089926a7ef667db"
+checksum = "2b56f822ed85d21c534b84eac13db89c7d019c7357f017891f6b69b9959d5c30"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections 0.3.2",
@@ -14108,9 +14108,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3f16414bc5640b3710035ac5b835b42425b72dd0562621b3b9b2ac5aeb46a4"
+checksum = "ab142ef7d78b19eabb76b1c6492caa4305e2b357dcba3b0775de63d7a773bb4a"
 dependencies = [
  "environmental",
  "frame-support",
@@ -14134,9 +14134,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a043b67f0ae191f95f8fe7d1db3bd7a7299d88a9bacb600a7dedd2d0961f361"
+checksum = "57c9b0e1c37267245cb593be21a3c12067dd6de52edbf04b299f19f8851e0b6b"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14850,9 +14850,9 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testnet-parachains-constants"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0a4e14985346a86e20e74bc07a867e0eadf2b1edd4780a158dc4263140bc12"
+checksum = "cfaa5e56d06e4c78a7feb6cc8b2c4dbbbb1115a9d240546af28eb770f190fc70"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -16312,9 +16312,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "westend-runtime"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1aa5abb2fdb63cabd9b7bceaa8d5a7a9a200827bd08361d9d3189804876be9c"
+checksum = "06bcedbc65b28e74906ad72f72abfdbfe41d2389c24b70b952810162ba732297"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -16416,9 +16416,9 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338d9a85e15730b1618bc831a7b81ea8675c11ff3af41d39e320a28c07e814c0"
+checksum = "4048fec2309483e098cd6bcc3a00213100c7ce576ae0c4a0839864bd7749b2bd"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -17094,9 +17094,9 @@ dependencies = [
 
 [[package]]
 name = "xcm-emulator"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60f1b54f86602de2ef4a047cb4eec580922d09574c050ee9feee207cb4acc1"
+checksum = "311b3ee8adee2b1423ab30e289e1a6bbf2d36d8b9010dd3b22c717b7d579be79"
 dependencies = [
  "array-bytes 6.2.3",
  "cumulus-pallet-parachain-system",
@@ -17143,9 +17143,9 @@ dependencies = [
 
 [[package]]
 name = "xcm-runtime-apis"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1852cc835d877d4e7854c8e2b22266e2463091d31ec6c1e4811e0ae4efad0c"
+checksum = "09fa93d5c8c9eeb4f36537d1408b438226fa54d96b5e8b46b86458af85cdf58c"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -17158,9 +17158,9 @@ dependencies = [
 
 [[package]]
 name = "xcm-simulator"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77efe010ec22795756f6f0cb8555a666c236394afa6f4e7ae56b6ddda5b8970"
+checksum = "e81fef25e8cfbb1f9f06fec987e25a143d4ff8688cb1ffcff5de53cbd59026a1"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,15 @@ array-bytes = { version = "6.1" }
 cid = { version = "0.11.1", default-features = false }
 clap = { version = "4.2.5" }
 codec = { package = "parity-scale-codec", version = "3.7.5", default-features = false }
-cumulus-pallet-aura-ext = { version = "0.27.0", default-features = false }
-cumulus-pallet-parachain-system = { version = "0.27.0", default-features = false }
-cumulus-pallet-session-benchmarking = { version = "28.0.0", default-features = false }
-cumulus-pallet-weight-reclaim = { version = "0.9.0", default-features = false }
+cumulus-pallet-aura-ext = { version = "0.28.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.28.0", default-features = false }
+cumulus-pallet-session-benchmarking = { version = "29.0.0", default-features = false }
+cumulus-pallet-weight-reclaim = { version = "0.10.0", default-features = false }
 cumulus-pallet-xcm = { version = "0.26.0", default-features = false }
-cumulus-pallet-xcmp-queue = { version = "0.27.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.28.0", default-features = false }
 cumulus-primitives-aura = { version = "0.23.0", default-features = false }
 cumulus-primitives-core = { version = "0.25.0", default-features = false }
-cumulus-primitives-utility = { version = "0.27.0", default-features = false }
+cumulus-primitives-utility = { version = "0.28.0", default-features = false }
 futures = { version = "0.3.21" }
 hex = { version = "0.4" }
 jsonrpsee = { version = "0.24.3" }
@@ -28,10 +28,10 @@ scale-info = { version = "2.11.6", default-features = false }
 serde = { version = "1.0.126" }
 serde_json = { version = "1.0.132", default-features = false }
 smallvec = { version = "1.15.1", default-features = false }
-testnet-parachains-constants = { version = "20.0.0", package = "testnet-parachains-constants", default-features = false }
+testnet-parachains-constants = { version = "21.0.0", package = "testnet-parachains-constants", default-features = false }
 tracing = { version = "0.1.41", default-features = false }
 tracing-subscriber = { version = "=0.3.19" }
-westend-runtime-constants = { version = "27.0.0", package = "westend-runtime-constants", default-features = false }
+westend-runtime-constants = { version = "28.0.0", package = "westend-runtime-constants", default-features = false }
 
 # Local workspace members
 bulletin-pallets-common = { version = "0.1.0", path = "pallets/common", default-features = false }
@@ -44,14 +44,14 @@ pallet-bulletin-transaction-storage = { version = "0.1.0", path = "pallets/trans
 pallet-bulletin-transaction-storage-runtime-api = { version = "0.1.0", path = "pallets/transaction-storage/runtime-api", default-features = false }
 
 # Polkadot SDK crates (shared git revision)
-frame-benchmarking = { version = "47.0.0", default-features = false }
+frame-benchmarking = { version = "48.0.0", default-features = false }
 frame-executive = { version = "47.0.0", default-features = false }
 frame-support = { version = "47.0.0", default-features = false }
 frame-system = { version = "47.0.0", default-features = false }
-frame-system-benchmarking = { version = "47.0.0", default-features = false }
+frame-system-benchmarking = { version = "48.0.0", default-features = false }
 frame-system-rpc-runtime-api = { version = "42.0.0", default-features = false }
 frame-try-runtime = { version = "0.53.0", default-features = false }
-polkadot-sdk-frame = { version = "0.16.0", default-features = false }
+polkadot-sdk-frame = { version = "0.17.0", default-features = false }
 
 sp-api = { version = "42.0.0", default-features = false }
 sp-authority-discovery = { version = "42.0.0", default-features = false }
@@ -74,47 +74,47 @@ sp-transaction-storage-proof = { version = "42.0.1", default-features = false }
 sp-version = { version = "45.0.0", default-features = false }
 
 pallet-authorship = { version = "47.0.0", default-features = false }
-pallet-migrations = { version = "17.0.0", default-features = false }
-pallet-proxy = { version = "47.0.0", default-features = false }
-pallet-session = { version = "47.0.0", default-features = false }
+pallet-migrations = { version = "18.0.0", default-features = false }
+pallet-proxy = { version = "48.0.0", default-features = false }
+pallet-session = { version = "48.0.0", default-features = false }
 pallet-skip-feeless-payment = { version = "22.0.0", default-features = false }
-pallet-sudo = { version = "47.0.0", default-features = false }
-pallet-timestamp = { version = "46.0.0", default-features = false }
-pallet-transaction-payment = { version = "47.0.0", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { version = "47.0.0", default-features = false }
+pallet-sudo = { version = "48.0.0", default-features = false }
+pallet-timestamp = { version = "47.0.0", default-features = false }
+pallet-transaction-payment = { version = "48.0.0", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { version = "48.0.0", default-features = false }
 
-pallet-xcm = { version = "27.0.0", default-features = false }
-xcm = { version = "23.0.0", package = "staging-xcm", default-features = false }
-xcm-builder = { version = "27.0.0", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { version = "26.0.0", package = "staging-xcm-executor", default-features = false }
+pallet-xcm = { version = "28.0.0", default-features = false }
+xcm = { version = "23.0.1", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "28.0.0", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "27.0.0", package = "staging-xcm-executor", default-features = false }
 
 # Parachains common primitives (needed by runtimes)
-parachains-common = { version = "29.0.0", default-features = false }
+parachains-common = { version = "30.0.0", default-features = false }
 
 # XCM emulator framework for integration tests
-asset-hub-westend-runtime = { version = "0.44.0", default-features = true }
-emulated-integration-tests-common = { version = "30.0.0", default-features = true }
-westend-runtime = { version = "32.0.0", default-features = true }
-xcm-emulator = { version = "0.28.0", default-features = true }
+asset-hub-westend-runtime = { version = "0.47.0", default-features = true }
+emulated-integration-tests-common = { version = "32.0.0", default-features = true }
+westend-runtime = { version = "33.0.0", default-features = true }
+xcm-emulator = { version = "0.29.0", default-features = true }
 
 # Runtime metadata hash extension
 frame-metadata-hash-extension = { version = "0.15.0", default-features = false }
 
 # Polkadot runtime common utilities
-parachains-runtimes-test-utils = { version = "30.0.0", default-features = true }
+parachains-runtimes-test-utils = { version = "31.0.0", default-features = true }
 polkadot-primitives = { version = "24.0.0", default-features = false }
-polkadot-runtime-common = { version = "26.0.0", default-features = false }
+polkadot-runtime-common = { version = "27.0.0", default-features = false }
 sc-consensus-grandpa = { version = "0.42.0" }
 sp-consensus-aura = { version = "0.48.0", default-features = false }
-xcm-runtime-apis = { version = "0.14.0", default-features = false }
+xcm-runtime-apis = { version = "0.15.0", default-features = false }
 
 # Additional FRAME pallets used by westend runtime
-pallet-aura = { version = "46.0.0", default-features = false }
-pallet-balances = { version = "48.0.0", default-features = false }
-pallet-collator-selection = { version = "28.0.0", default-features = false }
-pallet-message-queue = { version = "50.0.0", default-features = false }
-pallet-utility = { version = "47.0.0", default-features = false }
-pallet-xcm-benchmarks = { version = "27.0.0", default-features = false }
+pallet-aura = { version = "47.0.0", default-features = false }
+pallet-balances = { version = "49.0.0", default-features = false }
+pallet-collator-selection = { version = "29.0.0", default-features = false }
+pallet-message-queue = { version = "51.0.0", default-features = false }
+pallet-utility = { version = "48.0.0", default-features = false }
+pallet-xcm-benchmarks = { version = "28.0.0", default-features = false }
 
 # Substrate tooling
 substrate-wasm-builder = { version = "33.0.0" }

--- a/runtimes/bulletin-paseo/src/lib.rs
+++ b/runtimes/bulletin-paseo/src/lib.rs
@@ -156,6 +156,7 @@ pub mod migrations {
 		>,
 		cumulus_pallet_aura_ext::migration::MigrateV0ToV1<Runtime>,
 		cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
+		cumulus_pallet_parachain_system::migration::Migration<Runtime>,
 		pallet_bulletin_transaction_storage::migrations::v1::MigrateV0ToV1<Runtime>,
 		pallet_bulletin_transaction_storage::migrations::v2::MigrateV1ToV2<Runtime>,
 	);

--- a/runtimes/bulletin-paseo/src/lib.rs
+++ b/runtimes/bulletin-paseo/src/lib.rs
@@ -202,7 +202,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("bulletin-paseo"),
 	impl_name: alloc::borrow::Cow::Borrowed("bulletin-paseo"),
 	authoring_version: 1,
-	spec_version: 1_000_014,
+	spec_version: 1_000_015,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtimes/bulletin-westend/src/lib.rs
+++ b/runtimes/bulletin-westend/src/lib.rs
@@ -147,6 +147,7 @@ pub mod migrations {
 		>,
 		cumulus_pallet_aura_ext::migration::MigrateV0ToV1<Runtime>,
 		cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
+		cumulus_pallet_parachain_system::migration::Migration<Runtime>,
 		pallet_bulletin_transaction_storage::migrations::v1::MigrateV0ToV1<Runtime>,
 		pallet_bulletin_transaction_storage::migrations::v2::MigrateV1ToV2<Runtime>,
 	);

--- a/runtimes/bulletin-westend/src/lib.rs
+++ b/runtimes/bulletin-westend/src/lib.rs
@@ -193,7 +193,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("bulletin-westend"),
 	impl_name: alloc::borrow::Cow::Borrowed("bulletin-westend"),
 	authoring_version: 1,
-	spec_version: 1_000_014,
+	spec_version: 1_000_015,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/scripts/runtimes-matrix.json
+++ b/scripts/runtimes-matrix.json
@@ -22,6 +22,23 @@
     "uris": [
       "wss://paseo-bulletin-rpc.polkadot.io"
     ],
+    "integration_tests": false,
+    "try_runtime": {
+        "spec_name_check": "--disable-spec-name-check",
+        "extra_flags": "--blocktime 24000 --disable-spec-version-check"
+    },
+    "benchmarks_templates": {
+      "pallet_xcm_benchmarks::generic": "templates/xcm-bench-template.hbs",
+      "pallet_xcm_benchmarks::fungible": "templates/xcm-bench-template.hbs"
+    }
+  },
+  {
+    "name": "bulletin-paseo-next-v2",
+    "package": "bulletin-paseo-runtime",
+    "path": "runtimes/bulletin-paseo",
+    "uris": [
+      "wss://paseo-bulletin-next-rpc.polkadot.io"
+    ],
     "integration_tests": true,
     "try_runtime": {
         "spec_name_check": "--disable-spec-name-check",


### PR DESCRIPTION
## Summary
- Bump workspace dependencies from `polkadot-sdk` 2604.0.0 to 2604.1.0 (released 2026-05-21 on crates.io)
- 24 crates bumped (cumulus-*, pallet-*, parachains-common, polkadot-runtime-common, xcm-*, westend-runtime*, testnet-parachains-constants, polkadot-sdk-frame, frame-benchmarking, etc.)
- `cargo check --workspace --all-features` passes against existing code (no API breakage observed)