### PR TITLE
Pallet utility bulletin wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8111,6 +8111,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-bulletin-utility"
+version = "0.1.0"
+dependencies = [
+ "pallet-utility",
+ "parity-scale-codec",
+ "polkadot-sdk-frame",
+ "scale-info",
+]
+
+[[package]]
 name = "pallet-collator-selection"
 version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ bulletin-westend-runtime = { path = "runtimes/bulletin-westend" }
 pallet-bulletin-hop-promotion = { version = "0.1.0", path = "pallets/hop-promotion", default-features = false }
 pallet-bulletin-transaction-storage = { version = "0.1.0", path = "pallets/transaction-storage", default-features = false }
 pallet-bulletin-transaction-storage-runtime-api = { version = "0.1.0", path = "pallets/transaction-storage/runtime-api", default-features = false }
+pallet-bulletin-utility = { version = "0.1.0", path = "pallets/bulletin-utility", default-features = false }
 
 # Polkadot SDK crates (shared git revision)
 frame-benchmarking = { version = "48.0.0", default-features = false }
@@ -122,6 +123,7 @@ substrate-wasm-builder = { version = "33.0.0" }
 [workspace]
 resolver = "2"
 members = [
+	"pallets/bulletin-utility",
 	"pallets/common",
 	"pallets/hop-promotion",
 	"pallets/transaction-storage",

--- a/pallets/bulletin-utility/Cargo.toml
+++ b/pallets/bulletin-utility/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "pallet-bulletin-utility"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition.workspace = true
+license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+description = "Utility wrapper that makes batches feeless when every inner call is feeless"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { workspace = true }
+scale-info = { features = ["derive"], workspace = true }
+pallet-utility = { workspace = true }
+
+polkadot-sdk-frame = { workspace = true, default-features = false, features = [
+	"runtime",
+] }
+
+[features]
+default = ["std"]
+runtime-benchmarks = [
+	"pallet-utility/runtime-benchmarks",
+	"polkadot-sdk-frame/runtime-benchmarks",
+]
+std = [
+	"codec/std",
+	"pallet-utility/std",
+	"polkadot-sdk-frame/std",
+	"scale-info/std",
+]
+try-runtime = [
+	"pallet-utility/try-runtime",
+	"polkadot-sdk-frame/try-runtime",
+]

--- a/pallets/bulletin-utility/README.md
+++ b/pallets/bulletin-utility/README.md
@@ -1,0 +1,7 @@
+# pallet-bulletin-utility
+
+A thin wrapper around `pallet-utility`. It re-exposes `batch`, `batch_all` and `force_batch`,
+delegating execution to `pallet-utility`, and adds a `feeless_if` to each: a batch is feeless when it
+is non-empty and every inner call is itself feeless. This lets a batch of otherwise-feeless calls
+(e.g. transaction-storage `store`/`renew`) avoid being charged a fee, which the plain
+`pallet-utility` batch would incur.

--- a/pallets/bulletin-utility/src/lib.rs
+++ b/pallets/bulletin-utility/src/lib.rs
@@ -1,0 +1,134 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utility wrapper pallet.
+//!
+//! Re-exposes `pallet-utility`'s `batch`, `batch_all` and `force_batch` and delegates execution to
+//! it. The only addition is a `feeless_if` on each call that holds when the batch is non-empty and
+//! every inner call is itself feeless, so a batch of feeless calls is not charged a fee.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+use alloc::vec::Vec;
+use pallet_utility::WeightInfo;
+use polkadot_sdk_frame::{
+	deps::frame_support::{
+		dispatch::CheckIfFeeless,
+		traits::{IsSubType, OriginTrait},
+	},
+	prelude::*,
+};
+
+pub use pallet::*;
+
+type UtilityCallOf<T> = <T as pallet_utility::Config>::RuntimeCall;
+
+/// Accumulated call weight and dispatch class of `calls`, mirroring `pallet_utility`'s own
+/// `weight_and_dispatch_class` (which is private).
+fn aggregate_dispatch<T: Config>(calls: &[UtilityCallOf<T>]) -> (Weight, DispatchClass) {
+	calls.iter().map(|call| call.get_dispatch_info()).fold(
+		(Weight::zero(), DispatchClass::Operational),
+		|(total_weight, dispatch_class), di| {
+			(
+				total_weight.saturating_add(di.call_weight),
+				if di.class == DispatchClass::Normal { di.class } else { dispatch_class },
+			)
+		},
+	)
+}
+
+#[polkadot_sdk_frame::pallet]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config:
+		frame_system::Config
+		+ pallet_utility::Config<
+			RuntimeCall: CheckIfFeeless<Origin = OriginFor<Self>> + IsSubType<Call<Self>>,
+		>
+	{
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Feeless-aware [`pallet_utility::Pallet::batch`].
+		#[pallet::call_index(0)]
+		#[pallet::weight({
+			let (weight, class) = aggregate_dispatch::<T>(calls);
+			(weight.saturating_add(<T as pallet_utility::Config>::WeightInfo::batch(calls.len() as u32)), class)
+		})]
+		#[pallet::feeless_if(|origin: &OriginFor<T>, calls: &Vec<UtilityCallOf<T>>| -> bool {
+			!calls.is_empty() && calls.iter().all(|call| call.is_feeless(origin))
+		})]
+		pub fn batch(
+			origin: OriginFor<T>,
+			calls: Vec<UtilityCallOf<T>>,
+		) -> DispatchResultWithPostInfo {
+			pallet_utility::Pallet::<T>::batch(origin, calls)
+		}
+
+		/// Feeless-aware [`pallet_utility::Pallet::batch_all`].
+		#[pallet::call_index(1)]
+		#[pallet::weight({
+			let (weight, class) = aggregate_dispatch::<T>(calls);
+			(weight.saturating_add(<T as pallet_utility::Config>::WeightInfo::batch_all(calls.len() as u32)), class)
+		})]
+		#[pallet::feeless_if(|origin: &OriginFor<T>, calls: &Vec<UtilityCallOf<T>>| -> bool {
+			!calls.is_empty() && calls.iter().all(|call| call.is_feeless(origin))
+		})]
+		pub fn batch_all(
+			mut origin: OriginFor<T>,
+			calls: Vec<UtilityCallOf<T>>,
+		) -> DispatchResultWithPostInfo {
+			// `pallet_utility::batch_all` blocks nested `batch_all`, but its filter only matches
+			// `pallet_utility::Call::batch_all`. Block this pallet's variant too, so the
+			// no-nested-atomic-batch guarantee holds through the wrapper.
+			origin.add_filter(|call: &<T as frame_system::Config>::RuntimeCall| {
+				!matches!(
+					UtilityCallOf::<T>::from_ref(call).is_sub_type(),
+					Some(Call::batch_all { .. })
+				)
+			});
+			pallet_utility::Pallet::<T>::batch_all(origin, calls)
+		}
+
+		/// Feeless-aware [`pallet_utility::Pallet::force_batch`].
+		#[pallet::call_index(2)]
+		#[pallet::weight({
+			let (weight, class) = aggregate_dispatch::<T>(calls);
+			(weight.saturating_add(<T as pallet_utility::Config>::WeightInfo::force_batch(calls.len() as u32)), class)
+		})]
+		#[pallet::feeless_if(|origin: &OriginFor<T>, calls: &Vec<UtilityCallOf<T>>| -> bool {
+			!calls.is_empty() && calls.iter().all(|call| call.is_feeless(origin))
+		})]
+		pub fn force_batch(
+			origin: OriginFor<T>,
+			calls: Vec<UtilityCallOf<T>>,
+		) -> DispatchResultWithPostInfo {
+			pallet_utility::Pallet::<T>::force_batch(origin, calls)
+		}
+	}
+}

--- a/pallets/bulletin-utility/src/mock.rs
+++ b/pallets/bulletin-utility/src/mock.rs
@@ -1,0 +1,107 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test environment for the bulletin-utility pallet.
+
+use crate as pallet_bulletin_utility;
+use polkadot_sdk_frame::{
+	deps::{frame_support, frame_system},
+	prelude::*,
+	runtime::prelude::*,
+	testing_prelude::*,
+};
+
+type Block = MockBlock<Test>;
+
+/// Minimal pallet providing one feeless call and one fee-charging call, so tests can build
+/// batches whose feeless status varies.
+#[frame_support::pallet]
+pub mod dummy {
+	use super::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
+		#[pallet::weight(Weight::zero())]
+		#[pallet::feeless_if(|_origin: &OriginFor<T>| -> bool { true })]
+		pub fn feeless_noop(origin: OriginFor<T>) -> DispatchResult {
+			ensure_signed(origin)?;
+			Ok(())
+		}
+
+		#[pallet::call_index(1)]
+		#[pallet::weight(Weight::zero())]
+		pub fn paid_noop(origin: OriginFor<T>) -> DispatchResult {
+			ensure_signed(origin)?;
+			Ok(())
+		}
+	}
+}
+
+#[frame_support::runtime]
+mod runtime {
+	#[runtime::runtime]
+	#[runtime::derive(
+		RuntimeCall,
+		RuntimeEvent,
+		RuntimeError,
+		RuntimeOrigin,
+		RuntimeTask,
+		RuntimeFreezeReason,
+		RuntimeHoldReason,
+		RuntimeSlashReason,
+		RuntimeLockId,
+		RuntimeViewFunction
+	)]
+	pub struct Test;
+
+	#[runtime::pallet_index(0)]
+	pub type System = frame_system;
+
+	#[runtime::pallet_index(1)]
+	pub type Utility = pallet_utility;
+
+	#[runtime::pallet_index(2)]
+	pub type BulletinUtility = pallet_bulletin_utility;
+
+	#[runtime::pallet_index(3)]
+	pub type Dummy = dummy;
+}
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+	type Block = Block;
+}
+
+impl pallet_utility::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeCall = RuntimeCall;
+	type PalletsOrigin = OriginCaller;
+	type WeightInfo = ();
+}
+
+impl pallet_bulletin_utility::Config for Test {}
+
+impl dummy::Config for Test {}
+
+pub fn new_test_ext() -> TestExternalities {
+	frame_system::GenesisConfig::<Test>::default().build_storage().unwrap().into()
+}

--- a/pallets/bulletin-utility/src/tests.rs
+++ b/pallets/bulletin-utility/src/tests.rs
@@ -1,0 +1,125 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the bulletin-utility pallet.
+
+use crate::mock::*;
+use polkadot_sdk_frame::deps::{
+	frame_support::{assert_ok, dispatch::CheckIfFeeless},
+	frame_system,
+};
+
+const SIGNER: u64 = 1;
+
+fn feeless() -> RuntimeCall {
+	RuntimeCall::Dummy(dummy::Call::feeless_noop {})
+}
+
+fn paid() -> RuntimeCall {
+	RuntimeCall::Dummy(dummy::Call::paid_noop {})
+}
+
+fn origin() -> RuntimeOrigin {
+	RuntimeOrigin::signed(SIGNER)
+}
+
+fn batch(calls: Vec<RuntimeCall>) -> RuntimeCall {
+	RuntimeCall::BulletinUtility(crate::Call::batch { calls })
+}
+
+fn batch_all(calls: Vec<RuntimeCall>) -> RuntimeCall {
+	RuntimeCall::BulletinUtility(crate::Call::batch_all { calls })
+}
+
+fn force_batch(calls: Vec<RuntimeCall>) -> RuntimeCall {
+	RuntimeCall::BulletinUtility(crate::Call::force_batch { calls })
+}
+
+#[test]
+fn batch_of_feeless_calls_is_feeless() {
+	for build in [batch, batch_all, force_batch] {
+		assert!(build(vec![feeless(), feeless()]).is_feeless(&origin()));
+	}
+}
+
+#[test]
+fn batch_with_a_paid_call_is_not_feeless() {
+	for build in [batch, batch_all, force_batch] {
+		assert!(!build(vec![feeless(), paid()]).is_feeless(&origin()));
+		assert!(!build(vec![paid()]).is_feeless(&origin()));
+	}
+}
+
+#[test]
+fn empty_batch_is_not_feeless() {
+	for build in [batch, batch_all, force_batch] {
+		assert!(!build(vec![]).is_feeless(&origin()));
+	}
+}
+
+#[test]
+fn nested_feeless_batch_is_feeless() {
+	let inner = batch(vec![feeless(), feeless()]);
+	assert!(batch(vec![inner]).is_feeless(&origin()));
+
+	let inner_paid = batch(vec![feeless(), paid()]);
+	assert!(!batch(vec![inner_paid]).is_feeless(&origin()));
+}
+
+#[test]
+fn batch_delegates_to_pallet_utility() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		assert_ok!(BulletinUtility::batch(origin(), vec![feeless(), feeless()]));
+		System::assert_has_event(RuntimeEvent::Utility(pallet_utility::Event::BatchCompleted));
+	});
+}
+
+#[test]
+fn batch_all_delegates_to_pallet_utility() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		assert_ok!(BulletinUtility::batch_all(origin(), vec![feeless(), feeless()]));
+		System::assert_has_event(RuntimeEvent::Utility(pallet_utility::Event::BatchCompleted));
+	});
+}
+
+#[test]
+fn force_batch_delegates_to_pallet_utility() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		assert_ok!(BulletinUtility::force_batch(origin(), vec![feeless(), feeless()]));
+		System::assert_has_event(RuntimeEvent::Utility(pallet_utility::Event::BatchCompleted));
+	});
+}
+
+#[test]
+fn batch_all_blocks_nested_batch_all() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		let inner = batch_all(vec![feeless()]);
+		let err = BulletinUtility::batch_all(origin(), vec![inner]).unwrap_err().error;
+		assert_eq!(err, frame_system::Error::<Test>::CallFiltered.into());
+	});
+}
+
+#[test]
+fn batch_allows_nesting() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		let inner = batch(vec![feeless()]);
+		assert_ok!(BulletinUtility::batch(origin(), vec![inner]));
+	});
+}


### PR DESCRIPTION
What this adds
  
  A thin wrapper pallet exposing batch, batch_all and force_batch. Each:

  - carries a feeless_if that holds when the batch is non-empty and every inner call reports feeless (calls.iter().all(|c| c.is_feeless(origin))), and
  - delegates execution straight to pallet_utility::Pallet

  batch_all additionally reproduces upstream's no-nested-atomic-batch guard: pallet_utility's filter only matches its own batch_all variant, so we add a filter for this pallet's variant too.

This PR only introduces the crate (plus workspace registration) — it is not wired into any runtime yet