### PR TITLE
fix: undo source of cmd bot script

### DIFF
--- a/.github/workflows/cmd-run.yml
+++ b/.github/workflows/cmd-run.yml
@@ -196,9 +196,9 @@ jobs:
           git config user.name "cmd[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          echo "Using main branch for cmd-bot scripts"
+          echo "Using cmd-bot branch for cmd-bot scripts"
           TMP_DIR=/tmp/polkadot-bulletin-chain
-          git clone --depth 1 --branch main https://github.com/paritytech/polkadot-bulletin-chain $TMP_DIR
+          git clone --depth 1 --branch cmd-bot https://github.com/paritytech/polkadot-bulletin-chain $TMP_DIR
           BOT_PATH=$TMP_DIR
 
           python3 $BOT_PATH/scripts/cmd/cmd.py $CMD

--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -328,7 +328,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run cmd-run.yml \
-            --ref main \
+            --ref cmd-bot \
             -f cmd="${CMD}" \
             -f repo="${REPO}" \
             -f pr_branch="${PR_BRANCH}" \


### PR DESCRIPTION
Using protected `cmd-bot` branch for `cmd.py`.
> "The protected cmd-bot branch allows to check out `cmd-run.yml` from a trusted source so users can't modify it (as I described in this comment) and at the same time the scope of the branch is narrower than main branch."


Ref: https://github.com/paritytech/security/issues/103