### PR TITLE
fix(transaction-storage): make v3→v4 migration re-run safe

### DIFF
--- a/pallets/transaction-storage/src/migrations.rs
+++ b/pallets/transaction-storage/src/migrations.rs
@@ -524,11 +524,12 @@ pub mod v3 {
 				};
 
 				let Some(block_number) = iter.next() else {
-					// Write this migration's `version_to` explicitly so that when
-					// chained with v3→v4 the on-chain version progresses one step at
-					// a time and the next migration sees the correct starting version.
-					polkadot_sdk_frame::deps::frame_support::traits::StorageVersion::new(3)
-						.put::<Pallet<T>>();
+					// Never downgrade — this MBM can be re-run against state already
+					// at/beyond v3 (e.g. by try-runtime, whose id isn't in `Historic`).
+					use polkadot_sdk_frame::prelude::{GetStorageVersion, StorageVersion};
+					if Pallet::<T>::on_chain_storage_version() < 3 {
+						StorageVersion::new(3).put::<Pallet<T>>();
+					}
 					cursor = None;
 					break;
 				};
@@ -710,8 +711,12 @@ pub mod v4 {
 				};
 
 				let Some(content_hash) = iter.next() else {
-					polkadot_sdk_frame::deps::frame_support::traits::StorageVersion::new(4)
-						.put::<Pallet<T>>();
+					// Never downgrade — this MBM can be re-run against state already
+					// at/beyond v4 (e.g. by try-runtime, whose id isn't in `Historic`).
+					use polkadot_sdk_frame::prelude::{GetStorageVersion, StorageVersion};
+					if Pallet::<T>::on_chain_storage_version() < 4 {
+						StorageVersion::new(4).put::<Pallet<T>>();
+					}
 					cursor = None;
 					break;
 				};
@@ -748,14 +753,28 @@ pub mod v4 {
 			let prefix = AutoRenewals::<T>::final_prefix();
 			let mut previous_key = prefix.to_vec();
 			let mut count: u64 = 0;
+			// `step` only converts entries still in the v3 layout; pre-existing v4 entries
+			// (e.g. prepaid `paid=true`) are left untouched, so `post_upgrade` asserts only
+			// on the converted ones.
+			let mut to_migrate: Vec<Vec<u8>> = Vec::new();
 			while let Some(key) =
 				sp_io::storage::next_key(&previous_key).filter(|k| k.starts_with(&prefix))
 			{
-				previous_key = key;
+				previous_key = key.clone();
 				count += 1;
+				let raw = sp_io::storage::get(&key)
+					.ok_or("v3->v4 pre_upgrade: missing AutoRenewals entry")?;
+				if RenewalData::<T::AccountId>::decode(&mut &raw[..]).is_err() {
+					to_migrate.push(key);
+				}
 			}
-			tracing::info!(target: LOG_TARGET, count, "v3->v4 pre_upgrade: AutoRenewals entries");
-			Ok(count.encode())
+			tracing::info!(
+				target: LOG_TARGET,
+				count,
+				to_migrate = to_migrate.len(),
+				"v3->v4 pre_upgrade: AutoRenewals entries"
+			);
+			Ok((count, to_migrate).encode())
 		}
 
 		#[cfg(feature = "try-runtime")]
@@ -764,20 +783,15 @@ pub mod v4 {
 		) -> Result<(), polkadot_sdk_frame::deps::sp_runtime::TryRuntimeError> {
 			use polkadot_sdk_frame::deps::frame_support::storage::StoragePrefixedMap;
 
-			let old_count =
-				u64::decode(&mut &state[..]).map_err(|_| "Failed to decode pre_upgrade state")?;
+			let (old_count, to_migrate) = <(u64, Vec<Vec<u8>>)>::decode(&mut &state[..])
+				.map_err(|_| "Failed to decode pre_upgrade state")?;
 
-			let prefix = AutoRenewals::<T>::final_prefix();
-			let mut previous_key = prefix.to_vec();
-			let mut new_count: u64 = 0;
-			while let Some(key) =
-				sp_io::storage::next_key(&previous_key).filter(|k| k.starts_with(&prefix))
-			{
-				previous_key = key.clone();
-				let raw = sp_io::storage::get(&key)
-					.ok_or("v3->v4 post_upgrade: missing AutoRenewals entry")?;
+			// Each converted entry must now be v4, recurring, and unpaid.
+			for key in &to_migrate {
+				let raw = sp_io::storage::get(key)
+					.ok_or("v3->v4 post_upgrade: migrated entry missing")?;
 				let decoded = RenewalData::<T::AccountId>::decode(&mut &raw[..])
-					.map_err(|_| "v3->v4 post_upgrade: remaining entry is not v4")?;
+					.map_err(|_| "v3->v4 post_upgrade: migrated entry is not v4")?;
 				polkadot_sdk_frame::prelude::ensure!(
 					decoded.recurring,
 					"v3->v4 post_upgrade: migrated entry must have recurring=true",
@@ -786,6 +800,15 @@ pub mod v4 {
 					!decoded.paid,
 					"v3->v4 post_upgrade: migrated entry must have paid=false",
 				);
+			}
+
+			let prefix = AutoRenewals::<T>::final_prefix();
+			let mut previous_key = prefix.to_vec();
+			let mut new_count: u64 = 0;
+			while let Some(key) =
+				sp_io::storage::next_key(&previous_key).filter(|k| k.starts_with(&prefix))
+			{
+				previous_key = key;
 				new_count += 1;
 			}
 
@@ -797,6 +820,7 @@ pub mod v4 {
 				target: LOG_TARGET,
 				old_count,
 				new_count,
+				migrated = to_migrate.len(),
 				"v3->v4 post_upgrade: valid"
 			);
 			Ok(())

--- a/pallets/transaction-storage/src/tests.rs
+++ b/pallets/transaction-storage/src/tests.rs
@@ -4029,6 +4029,85 @@ fn migrate_v2_to_v3_skips_already_v3_entries() {
 	});
 }
 
+/// `post_upgrade` must accept pre-existing v4 entries (e.g. prepaid `paid=true`) that `step`
+/// leaves untouched. Regression for the summit migration check.
+#[cfg(feature = "try-runtime")]
+#[test]
+fn migrate_v3_to_v4_post_upgrade_allows_preexisting_v4_paid_entries() {
+	use crate::migrations::v4::{MigrateV3ToV4, V3AutoRenewalData};
+	use polkadot_sdk_frame::deps::frame_support::{
+		migrations::SteppedMigration, weights::WeightMeter,
+	};
+
+	new_test_ext().execute_with(|| {
+		StorageVersion::new(3).put::<TransactionStorage>();
+
+		// A genuine v3 entry (just `{ account }`), written raw at the AutoRenewals key.
+		let v3_hash: super::ContentHash = [1u8; 32];
+		unhashed::put(&AutoRenewals::hashed_key_for(v3_hash), &V3AutoRenewalData { account: 1u64 });
+
+		// A pre-existing v4 entry with `paid=true` — the case that broke on summit.
+		let v4_hash: super::ContentHash = [2u8; 32];
+		AutoRenewals::insert(
+			v4_hash,
+			super::RenewalData { account: 2u64, recurring: true, paid: true },
+		);
+
+		let state = MigrateV3ToV4::<Test>::pre_upgrade().expect("pre_upgrade succeeds");
+
+		let mut meter = WeightMeter::new();
+		let mut cursor: Option<<MigrateV3ToV4<Test> as SteppedMigration>::Cursor> = None;
+		loop {
+			cursor = MigrateV3ToV4::<Test>::step(cursor, &mut meter).expect("step should not fail");
+			if cursor.is_none() {
+				break;
+			}
+		}
+
+		MigrateV3ToV4::<Test>::post_upgrade(state).expect("pre-existing v4 entries are allowed");
+
+		let migrated = AutoRenewals::get(v3_hash).expect("v3 entry migrated");
+		assert!(migrated.recurring && !migrated.paid);
+		let preexisting = AutoRenewals::get(v4_hash).expect("v4 entry preserved");
+		assert!(preexisting.paid, "pre-existing v4 paid=true entry must be left untouched");
+
+		assert_eq!(TransactionStorage::on_chain_storage_version(), StorageVersion::new(4));
+	});
+}
+
+/// Re-running `step` against state already at/beyond v4 must not downgrade the storage version.
+#[test]
+fn migrate_v3_to_v4_does_not_downgrade_storage_version() {
+	use crate::migrations::v4::MigrateV3ToV4;
+	use polkadot_sdk_frame::deps::frame_support::{
+		migrations::SteppedMigration, weights::WeightMeter,
+	};
+
+	new_test_ext().execute_with(|| {
+		// Chain is already at v5 (e.g. summit), with a v4-format entry present.
+		StorageVersion::new(5).put::<TransactionStorage>();
+		AutoRenewals::insert(
+			[2u8; 32] as super::ContentHash,
+			super::RenewalData { account: 2u64, recurring: true, paid: true },
+		);
+
+		let mut meter = WeightMeter::new();
+		let mut cursor: Option<<MigrateV3ToV4<Test> as SteppedMigration>::Cursor> = None;
+		loop {
+			cursor = MigrateV3ToV4::<Test>::step(cursor, &mut meter).expect("step should not fail");
+			if cursor.is_none() {
+				break;
+			}
+		}
+
+		assert_eq!(
+			TransactionStorage::on_chain_storage_version(),
+			StorageVersion::new(5),
+			"migration must not downgrade the storage version",
+		);
+	});
+}
+
 /// Stale `Transactions[block]` leftovers (block < current - RetentionPeriod) — e.g. from
 /// a chain whose `RetentionPeriod` was previously longer — must be pruned by the v2→v3
 /// migration rather than carried forward, otherwise `try_state` rejects them.


### PR DESCRIPTION
## Why

The `Check Runtime Migrations` CI job fails on the **summit** instance ([example run](https://github.com/paritytech/polkadot-bulletin-chain/actions/runs/27652661677/job/81780128207)):

```
Post-upgrade failed.: Other("v3->v4 post_upgrade: migrated entry must have paid=false")
```

`try-runtime on-runtime-upgrade` force-runs every declared MBM against a live snapshot, regardless of the on-chain `StorageVersion` or `pallet-migrations` `Historic` set. Summit's `Historic` doesn't record these migration ids, so they actually execute — which means the migration must tolerate being **re-run against already-migrated state**. Two latent bugs surfaced:

1. **`v3→v4` `post_upgrade` was too strict.** `step()` is idempotent and skips entries already in the v4 layout, but `post_upgrade` asserted `paid=false`/`recurring=true` on *every* `AutoRenewals` entry. Summit's live state already contains prepaid (`paid=true`) auto-renewals, which `step()` correctly leaves untouched but `post_upgrade` wrongly rejected.

2. **Both `v2→v3` and `v3→v4` `step()` downgraded the storage version.** The completion branch wrote `version_to` unconditionally, so re-running against state already at a higher version (summit is at v5) would roll `StorageVersion` backwards (→ 4). Beyond CI, this is a production hazard: since `Historic` is empty for these ids, a real upgrade would run them and downgrade, potentially letting the single-block `v4→v5` migration re-fire later.

## What

- `post_upgrade`: record the keys still in the v3 layout during `pre_upgrade`, and assert `recurring`/`paid` only on those converted entries (plus an unchanged total count). Pre-existing v4 entries are no longer asserted on.
- `v2→v3` and `v3→v4` `step()`: guard the `StorageVersion` write so it only bumps when below the target — never downgrades. Kept the data pass (idempotent) so any lingering old-format entries are still translated.
- Added regression tests:
  - `migrate_v3_to_v4_post_upgrade_allows_preexisting_v4_paid_entries`
  - `migrate_v3_to_v4_does_not_downgrade_storage_version`

## Testing

- `clippy --features try-runtime --all-targets -- -D warnings`: clean
- `cargo test -p pallet-bulletin-transaction-storage --features try-runtime migrate`: 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)