### PR TITLE
Drop historical migrations from paseo runtime

### DIFF
--- a/runtimes/bulletin-paseo/src/lib.rs
+++ b/runtimes/bulletin-paseo/src/lib.rs
@@ -135,21 +135,9 @@ pub mod migrations {
 	use super::*;
 
 	/// Unreleased migrations. Add new ones here:
-	pub type Unreleased = (
-		pallet_collator_selection::migration::v2::MigrationToV2<Runtime>,
-		cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
-		cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
-		pallet_session::migrations::v1::MigrateV0ToV1<
-			Runtime,
-			pallet_session::migrations::v1::InitOffenceSeverity<Runtime>,
-		>,
-		cumulus_pallet_aura_ext::migration::MigrateV0ToV1<Runtime>,
-		cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
-		cumulus_pallet_parachain_system::migration::Migration<Runtime>,
-		pallet_bulletin_transaction_storage::migrations::v1::MigrateV0ToV1<Runtime>,
-		pallet_bulletin_transaction_storage::migrations::v2::MigrateV1ToV2<Runtime>,
-		pallet_bulletin_transaction_storage::migrations::v5::MigrateV4ToV5<Runtime>,
-	);
+	///
+	/// Paseo is a fresh chain, so the historical version-bump migrations do not apply.
+	pub type Unreleased = ();
 
 	/// Migrations/checks that do not need to be versioned and can run on every update.
 	pub type Permanent = (
@@ -164,10 +152,9 @@ pub mod migrations {
 	pub type SingleBlockMigrations = (Unreleased, Permanent);
 
 	/// MBM migrations to apply on runtime upgrade.
-	pub type MbmMigrations = (
-		pallet_bulletin_transaction_storage::migrations::v3::MigrateV2ToV3<Runtime>,
-		pallet_bulletin_transaction_storage::migrations::v4::MigrateV3ToV4<Runtime>,
-	);
+	///
+	/// Paseo is a fresh chain, so the historical transaction-storage MBM migrations do not apply.
+	pub type MbmMigrations = ();
 }
 
 /// Executive: handles dispatch to the various modules.

--- a/scripts/runtimes-matrix.json
+++ b/scripts/runtimes-matrix.json
@@ -24,7 +24,6 @@
       "spec_name_check": "--disable-spec-name-check",
       "extra_flags": "--blocktime 24000 --disable-spec-version-check",
       "instances": [
-        { "name": "paseo",       "uris": ["wss://paseo-bulletin-rpc.polkadot.io"] },
         { "name": "next-v2",    "uris": ["wss://paseo-bulletin-next-rpc.polkadot.io"] },
         { "name": "previewnet", "uris": ["wss://previewnet.substrate.dev/bulletin"] }
       ]


### PR DESCRIPTION
## Summary

Paseo is a fresh chain, so the historical migrations carried over from the westend runtime do not apply to it. This empties both migration tuples in the paseo runtime:

- `Unreleased` (single-block version-bump migrations) → `()`
- `MbmMigrations` (transaction-storage `v2->v3`, `v3->v4`) → `()`

`pallet_migrations` stays wired in (construct_runtime index 7, `frame_system::MultiBlockMigrator`) for future use — no pallet-index/metadata churn.

`Permanent` migrations (`MigrateToLatestXcmVersion`, `SetRetentionPeriodIfZero`) are left intact, as those are idempotent checks meant to run on every upgrade rather than historical version bumps.

## Test

- `cargo check -p bulletin-paseo-runtime`
- `cargo clippy -p bulletin-paseo-runtime --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all`