### PR TITLE
feat(console-ui): add HOP pool status dashboard

### DIFF
--- a/console-ui/src/App.tsx
+++ b/console-ui/src/App.tsx
@@ -12,6 +12,7 @@ import { Renew } from "@/pages/Renew/Renew";
 import { Explorer } from "@/pages/Explorer/Explorer";
 import { Authorizations } from "@/pages/Authorizations/Authorizations";
 import { Accounts } from "@/pages/Accounts/Accounts";
+import { Hop } from "@/pages/Hop/Hop";
 import { restoreWalletConnection } from "@/state/wallet.state";
 
 export default function App() {
@@ -31,6 +32,7 @@ export default function App() {
             <Route path="/explorer" element={<Explorer />} />
             <Route path="/authorizations" element={<Authorizations />} />
             <Route path="/accounts" element={<Accounts />} />
+            <Route path="/hop" element={<Hop />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </main>

--- a/console-ui/src/components/Header.tsx
+++ b/console-ui/src/components/Header.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { Link, useLocation } from "react-router-dom";
-import { Database, Upload, Download, RefreshCw, Search, Shield, Wallet, Menu, AlertTriangle, HelpCircle, BookOpen, ExternalLink, ChevronDown, X } from "lucide-react";
+import { Database, Upload, Download, RefreshCw, Search, Shield, Wallet, Menu, AlertTriangle, HelpCircle, BookOpen, ExternalLink, ChevronDown, X, Boxes } from "lucide-react";
 
 // Brand icons were removed in lucide-react 1.x — inline the Github icon SVG from 0.577.0
 const GithubIcon = ({ className }: { className?: string }) => (
@@ -43,6 +43,7 @@ const navItems = [
   { path: "/upload", label: "Upload", icon: Upload, requiresAuth: true },
   { path: "/download", label: "Download", icon: Download, requiresAuth: false },
   { path: "/renew", label: "Renew", icon: RefreshCw, requiresAuth: true },
+  { path: "/hop", label: "HOP", icon: Boxes, requiresAuth: false },
 ] as const;
 
 function ConnectionStatus() {

--- a/console-ui/src/config/networks.ts
+++ b/console-ui/src/config/networks.ts
@@ -36,6 +36,10 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
     name: "Bulletin Paseo Next v2",
     endpoints: ["wss://paseo-bulletin-next-rpc.polkadot.io"],
     lightClient: false,
+    hopNodes: [
+      "wss://paseo-hop-next-0.polkadot.io",
+      "wss://paseo-hop-next-1.polkadot.io",
+    ],
   },
   summit: {
     id: "summit",
@@ -52,6 +56,10 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
     name: "Bulletin Previewnet",
     endpoints: ["wss://previewnet.substrate.dev/bulletin"],
     lightClient: false,
+    hopNodes: [
+      "wss://previewnet.substrate.dev/bulletin-hop-0",
+      "wss://previewnet.substrate.dev/bulletin-hop-1",
+    ],
   },
   polkadot: {
     id: "polkadot",

--- a/console-ui/src/config/networks.ts
+++ b/console-ui/src/config/networks.ts
@@ -7,6 +7,9 @@ export interface Network {
   endpoints: string[];
   lightClient: boolean;
   chainSpec?: string;
+  // HOP relay nodes for this network, exposing the public `hop_poolStatus`
+  // JSON-RPC method over HTTPS POST. Polled by the HOP dashboard.
+  hopNodes?: string[];
 }
 
 export const BULLETIN_NETWORKS: Record<string, Network> = {
@@ -39,6 +42,10 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
     name: "Bulletin Summit",
     endpoints: ["wss://summit-bulletin-rpc.polkadot.io"],
     lightClient: false,
+    hopNodes: [
+      "https://summit-hop-0.polkadot.io",
+      "https://summit-hop-1.polkadot.io",
+    ],
   },
   previewnet: {
     id: "previewnet",

--- a/console-ui/src/pages/Hop/Hop.tsx
+++ b/console-ui/src/pages/Hop/Hop.tsx
@@ -1,0 +1,284 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Boxes, RefreshCw, Plus, X, AlertTriangle, Settings2 } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Badge } from "@/components/ui/Badge";
+import { Spinner } from "@/components/ui/Spinner";
+import { useChainState } from "@/state/chain.state";
+import {
+  fetchHopPoolStatus,
+  getHopRefreshSecs,
+  setHopRefreshSecs,
+  type HopPoolStatus,
+} from "@/state/hop.state";
+import { formatBytes, formatNumber, formatTimestamp } from "@/utils/format";
+
+interface NodeResult {
+  status: "idle" | "loading" | "ok" | "error";
+  data?: HopPoolStatus;
+  error?: string;
+  fetchedAt?: number;
+}
+
+function usagePercent(s: HopPoolStatus): number {
+  if (s.maxBytes <= 0) return 0;
+  return (s.totalBytes / s.maxBytes) * 100;
+}
+
+function StatusBadge({ result }: { result: NodeResult | undefined }) {
+  if (!result || result.status === "idle") return <Badge variant="secondary">—</Badge>;
+  if (result.status === "loading") return <Badge variant="warning">Loading…</Badge>;
+  if (result.status === "error") return <Badge variant="destructive">Error</Badge>;
+  return <Badge variant="success">OK</Badge>;
+}
+
+function NodeRow({ url, result }: { url: string; result: NodeResult | undefined }) {
+  const data = result?.data;
+  return (
+    <tr className="border-b last:border-0 align-top">
+      <td className="py-2 pr-4 font-mono text-xs break-all">{url}</td>
+      <td className="py-2 pr-4">
+        <StatusBadge result={result} />
+      </td>
+      <td className="py-2 pr-4 text-right font-mono">
+        {data ? formatNumber(data.entryCount) : "—"}
+      </td>
+      <td className="py-2 pr-4 text-right font-mono">
+        {data ? formatBytes(data.totalBytes) : "—"}
+      </td>
+      <td className="py-2 pr-4 text-right font-mono">
+        {data ? formatBytes(data.maxBytes) : "—"}
+      </td>
+      <td className="py-2 pr-4 text-right font-mono">
+        {data ? `${usagePercent(data).toFixed(2)}%` : "—"}
+      </td>
+      <td className="py-2 text-xs text-muted-foreground">
+        {result?.status === "error" ? (
+          <span className="text-destructive break-all">{result.error}</span>
+        ) : result?.fetchedAt ? (
+          formatTimestamp(result.fetchedAt)
+        ) : (
+          "—"
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function ConfigCard({
+  nodes,
+  setNodes,
+  intervalSecs,
+  setIntervalSecs,
+  autoRefresh,
+  setAutoRefresh,
+}: {
+  nodes: string[];
+  setNodes: (n: string[]) => void;
+  intervalSecs: number;
+  setIntervalSecs: (n: number) => void;
+  autoRefresh: boolean;
+  setAutoRefresh: (b: boolean) => void;
+}) {
+  const updateNode = (i: number, value: string) => {
+    const next = [...nodes];
+    next[i] = value;
+    setNodes(next);
+  };
+  const removeNode = (i: number) => setNodes(nodes.filter((_, idx) => idx !== i));
+  const addNode = () => setNodes([...nodes, ""]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Settings2 className="h-5 w-5" />
+          HOP Nodes
+        </CardTitle>
+        <CardDescription>
+          Seeded from the selected network. Add ad-hoc endpoints below for this session.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          {nodes.map((url, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <Input
+                value={url}
+                onChange={(e) => updateNode(i, e.target.value)}
+                placeholder="https://… or wss://…"
+                className="font-mono text-xs"
+                spellCheck={false}
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => removeNode(i)}
+                title="Remove node"
+                className="shrink-0"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+          <Button variant="outline" size="sm" onClick={addNode}>
+            <Plus className="h-4 w-4 mr-1.5" />
+            Add node
+          </Button>
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-end gap-6">
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={autoRefresh}
+              onChange={(e) => setAutoRefresh(e.target.checked)}
+              className="h-4 w-4"
+            />
+            Auto-refresh
+          </label>
+          <div className="space-y-1">
+            <p className="text-xs text-muted-foreground">Interval (seconds)</p>
+            <Input
+              type="number"
+              min={1}
+              value={intervalSecs}
+              onChange={(e) => setIntervalSecs(Math.max(1, Number(e.target.value) || 1))}
+              className="w-28"
+            />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function Hop() {
+  const { network } = useChainState();
+
+  const [nodes, setNodes] = useState<string[]>(() => network.hopNodes ?? []);
+  const [intervalSecs, setIntervalSecsState] = useState<number>(() => getHopRefreshSecs());
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const [results, setResults] = useState<Record<string, NodeResult>>({});
+
+  const nodesRef = useRef(nodes);
+  nodesRef.current = nodes;
+
+  const setIntervalSecs = useCallback((secs: number) => {
+    setIntervalSecsState(secs);
+    setHopRefreshSecs(secs);
+  }, []);
+
+  const refreshAll = useCallback(async (urlsArg?: string[]) => {
+    const urls = (urlsArg ?? nodesRef.current).map((u) => u.trim()).filter(Boolean);
+    setResults((prev) => {
+      const next: Record<string, NodeResult> = {};
+      for (const url of urls) next[url] = { ...prev[url], status: "loading" };
+      return next;
+    });
+    await Promise.all(
+      urls.map(async (url) => {
+        try {
+          const data = await fetchHopPoolStatus(url);
+          setResults((prev) => ({ ...prev, [url]: { status: "ok", data, fetchedAt: Date.now() } }));
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          setResults((prev) => ({
+            ...prev,
+            [url]: { status: "error", error: message, fetchedAt: Date.now() },
+          }));
+        }
+      }),
+    );
+  }, []);
+
+  // Re-seed the node list from the selected network (and refresh) on switch.
+  useEffect(() => {
+    const next = network.hopNodes ?? [];
+    setNodes(next);
+    setResults({});
+    refreshAll(next);
+  }, [network.id, refreshAll]);
+
+  // Auto-refresh on the configured interval.
+  useEffect(() => {
+    if (!autoRefresh || intervalSecs <= 0) return;
+    const id = setInterval(() => refreshAll(), intervalSecs * 1000);
+    return () => clearInterval(id);
+  }, [autoRefresh, intervalSecs, refreshAll]);
+
+  const anyLoading = Object.values(results).some((r) => r.status === "loading");
+  const activeUrls = nodes.map((u) => u.trim()).filter(Boolean);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">HOP Pool Status</h1>
+          <p className="text-muted-foreground">
+            Live <code>hop_poolStatus</code> from <strong>{network.name}</strong> HOP relay nodes
+          </p>
+        </div>
+        <Button onClick={() => refreshAll()} disabled={anyLoading}>
+          <RefreshCw className={anyLoading ? "h-4 w-4 mr-2 animate-spin" : "h-4 w-4 mr-2"} />
+          Refresh
+        </Button>
+      </div>
+
+      <ConfigCard
+        nodes={nodes}
+        setNodes={setNodes}
+        intervalSecs={intervalSecs}
+        setIntervalSecs={setIntervalSecs}
+        autoRefresh={autoRefresh}
+        setAutoRefresh={setAutoRefresh}
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Boxes className="h-5 w-5" />
+            Pool Status
+            {anyLoading && <Spinner size="sm" className="text-muted-foreground" />}
+          </CardTitle>
+          <CardDescription>
+            <code>totalBytes</code> is accounted bytes (blob + 40 B/recipient), not raw disk usage.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {activeUrls.length === 0 ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground py-4">
+              <AlertTriangle className="h-4 w-4" />
+              {network.name} has no HOP nodes configured. Add one above, or switch network.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="py-2 pr-4 font-medium">Node</th>
+                    <th className="py-2 pr-4 font-medium">Status</th>
+                    <th className="py-2 pr-4 font-medium text-right">Entries</th>
+                    <th className="py-2 pr-4 font-medium text-right">Accounted</th>
+                    <th className="py-2 pr-4 font-medium text-right">Capacity</th>
+                    <th className="py-2 pr-4 font-medium text-right">Usage</th>
+                    <th className="py-2 font-medium">Updated</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {activeUrls.map((url) => (
+                    <NodeRow key={url} url={url} result={results[url]} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/console-ui/src/state/hop.state.ts
+++ b/console-ui/src/state/hop.state.ts
@@ -1,0 +1,61 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+// Aggregate read returned by the HOP `hop_poolStatus` JSON-RPC method.
+export interface HopPoolStatus {
+  // Blobs currently held (live, not yet fully acked/expired).
+  entryCount: number;
+  // Accounted bytes: blob size + recipients * 40-byte metadata, NOT raw disk usage.
+  totalBytes: number;
+  // Hard capacity ceiling.
+  maxBytes: number;
+}
+
+const STORAGE_KEY_HOP_INTERVAL = "bulletin-hop-refresh-secs";
+
+export const DEFAULT_HOP_REFRESH_SECS = 10;
+
+export function getHopRefreshSecs(): number {
+  const raw = localStorage.getItem(STORAGE_KEY_HOP_INTERVAL);
+  const n = raw === null ? NaN : Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_HOP_REFRESH_SECS;
+}
+
+export function setHopRefreshSecs(secs: number): void {
+  localStorage.setItem(STORAGE_KEY_HOP_INTERVAL, String(secs));
+}
+
+// HOP nodes also accept HTTPS POST JSON-RPC at any path, so we talk to them
+// directly over fetch. ws/wss URLs are normalised to http/https for the POST.
+function toHttpUrl(url: string): string {
+  return url.replace(/^wss:\/\//i, "https://").replace(/^ws:\/\//i, "http://");
+}
+
+export async function fetchHopPoolStatus(
+  url: string,
+  signal?: AbortSignal,
+): Promise<HopPoolStatus> {
+  const res = await fetch(toHttpUrl(url), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ id: 1, jsonrpc: "2.0", method: "hop_poolStatus", params: [] }),
+    signal,
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText}`);
+  }
+  const json = await res.json();
+  if (json.error) {
+    throw new Error(json.error.message ?? "JSON-RPC error");
+  }
+  const result = json.result;
+  if (
+    !result ||
+    typeof result.entryCount !== "number" ||
+    typeof result.totalBytes !== "number" ||
+    typeof result.maxBytes !== "number"
+  ) {
+    throw new Error("Unexpected hop_poolStatus response shape");
+  }
+  return result as HopPoolStatus;
+}


### PR DESCRIPTION
Add a HOP tab that polls hop_poolStatus from the selected network's configured HOP relay nodes and shows entryCount/totalBytes/maxBytes per node, with manual refresh and a configurable auto-refresh interval (default 10s). HOP nodes are an optional per-network config field; summit is seeded with summit-hop-0/1.