### PR TITLE
Remove decommissioned Summit network

### DIFF
--- a/console-ui/src/config/networks.ts
+++ b/console-ui/src/config/networks.ts
@@ -41,16 +41,6 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
       "wss://paseo-hop-next-1.polkadot.io",
     ],
   },
-  summit: {
-    id: "summit",
-    name: "Bulletin Summit",
-    endpoints: ["wss://summit-bulletin-rpc.polkadot.io"],
-    lightClient: false,
-    hopNodes: [
-      "https://summit-hop-0.polkadot.io",
-      "https://summit-hop-1.polkadot.io",
-    ],
-  },
   previewnet: {
     id: "previewnet",
     name: "Bulletin Previewnet",

--- a/console-ui/src/lib/ipfs.ts
+++ b/console-ui/src/lib/ipfs.ts
@@ -13,7 +13,6 @@ export const IPFS_GATEWAYS: Record<string, string> = {
   local: "http://127.0.0.1:8283",
   paseo: "https://paseo-ipfs.polkadot.io",
   "paseo-next-v2": "https://paseo-bulletin-next-ipfs.polkadot.io",
-  summit: "https://summit-ipfs.polkadot.io",
   previewnet: "https://previewnet.substrate.dev",
 };
 
@@ -27,7 +26,6 @@ export const PREFERRED_DOWNLOAD_METHOD: Record<string, "p2p" | "gateway"> = {
   westend: "p2p",
   paseo: "gateway",
   "paseo-next-v2": "gateway",
-  summit: "gateway",
   previewnet: "gateway",
 };
 

--- a/console-ui/src/pages/Download/Download.tsx
+++ b/console-ui/src/pages/Download/Download.tsx
@@ -58,12 +58,6 @@ const P2P_MULTIADDRS: Record<string, string> = {
     "/dns4/paseo-bulletin-next-rpc-node-0.polkadot.io/tcp/443/wss/p2p/12D3KooWS4ptBbHGritdb1T7JPxKT2EN7FXvqq9rUp12jUvjnqQ1",
     "/dns4/paseo-bulletin-next-rpc-node-1.polkadot.io/tcp/443/wss/p2p/12D3KooWKMc4jJsU7fdEsis4AsM8Assk5jFqhEUEa2ZSiWJGKpfv",
   ].join("\n"),
-  summit: [
-    "/dns4/summit-bulletin-collator-node-0.parity-chains.parity.io/tcp/443/wss/p2p/12D3KooWC6q8q3NXscVcpxMbteYrmzjpy7NvYnD4QDRkAQJ9ng8r",
-    "/dns4/summit-bulletin-collator-node-1.parity-chains.parity.io/tcp/443/wss/p2p/12D3KooWRiRRk8EzmENBD6SkP7v2riWa6s74X7wzhnx84SxfD4yr",
-    "/dns4/summit-bulletin-rpc-node-0.parity-chains.parity.io/tcp/443/wss/p2p/12D3KooWSCrFvEXpRn9J5VC7TiabNwofVfbg3QPzJK9R5ZoDGjVq",
-    "/dns4/summit-bulletin-rpc-node-1.parity-chains.parity.io/tcp/443/wss/p2p/12D3KooWHV6qNxpwkbTezwgsDW1xBL4J56o3xZnJXvRzHLdsMQJG",
-  ].join("\n"),
 };
 
 interface FetchResult {

--- a/console-ui/src/state/chain.state.ts
+++ b/console-ui/src/state/chain.state.ts
@@ -26,7 +26,6 @@ const DESCRIPTORS: Record<string, any> = {
   westend: bulletin_westend,
   paseo: bulletin_paseo,
   "paseo-next-v2": bulletin_paseo_next_v2,
-  summit: bulletin_paseo_next_v2,
   polkadot: bulletin_polkadot,
   previewnet: bulletin_westend,
 };

--- a/scripts/runtimes-matrix.json
+++ b/scripts/runtimes-matrix.json
@@ -32,22 +32,5 @@
       "pallet_xcm_benchmarks::generic": "templates/xcm-bench-template.hbs",
       "pallet_xcm_benchmarks::fungible": "templates/xcm-bench-template.hbs"
     }
-  },
-  {
-    "name": "bulletin-summit",
-    "package": "bulletin-paseo-runtime",
-    "path": "runtimes/bulletin-paseo",
-    "integration_tests": true,
-    "try_runtime": {
-      "spec_name_check": "--disable-spec-name-check",
-      "extra_flags": "--blocktime 24000 --disable-spec-version-check",
-      "instances": [
-        { "name": "summit",     "uris": ["wss://summit-bulletin-rpc.polkadot.io"] }
-      ]
-    },
-    "benchmarks_templates": {
-      "pallet_xcm_benchmarks::generic": "templates/xcm-bench-template.hbs",
-      "pallet_xcm_benchmarks::fungible": "templates/xcm-bench-template.hbs"
-    }
   }
 ]


### PR DESCRIPTION
Summit was a one-off event network and is now decommissioned.

Drops it from:
- `scripts/runtimes-matrix.json` (try-runtime / benchmark matrix)
- console-ui network list, IPFS gateways, preferred download method, descriptors, and P2P peer addresses

The regression-test comments in `pallet-transaction-storage` that reference the summit migration bug are kept, since they document why that test exists.