### PR TITLE
Add Paseo instance to try-runtime matrix

### DIFF
--- a/runtimes/bulletin-paseo/src/lib.rs
+++ b/runtimes/bulletin-paseo/src/lib.rs
@@ -136,8 +136,11 @@ pub mod migrations {
 
 	/// Unreleased migrations. Add new ones here:
 	///
-	/// Paseo is a fresh chain, so the historical version-bump migrations do not apply.
-	pub type Unreleased = ();
+	/// `MigrateV4ToV5` is single-block, so it runs in `on_runtime_upgrade`. On a chain still
+	/// at v3 it is a no-op (its v4 guard); the v3->v4 MBM below bumps to v4, then a following
+	/// runtime upgrade lets this step bump v4->v5. Idempotent on chains already at v5.
+	pub type Unreleased =
+		(pallet_bulletin_transaction_storage::migrations::v5::MigrateV4ToV5<Runtime>,);
 
 	/// Migrations/checks that do not need to be versioned and can run on every update.
 	pub type Permanent = (
@@ -153,8 +156,10 @@ pub mod migrations {
 
 	/// MBM migrations to apply on runtime upgrade.
 	///
-	/// Paseo is a fresh chain, so the historical transaction-storage MBM migrations do not apply.
-	pub type MbmMigrations = ();
+	/// `MigrateV3ToV4` walks `AutoRenewals` to the v4 layout. Self-guarded and idempotent, so
+	/// it is a no-op on chains already at/beyond v4.
+	pub type MbmMigrations =
+		(pallet_bulletin_transaction_storage::migrations::v4::MigrateV3ToV4<Runtime>,);
 }
 
 /// Executive: handles dispatch to the various modules.

--- a/runtimes/bulletin-paseo/src/lib.rs
+++ b/runtimes/bulletin-paseo/src/lib.rs
@@ -136,11 +136,8 @@ pub mod migrations {
 
 	/// Unreleased migrations. Add new ones here:
 	///
-	/// `MigrateV4ToV5` is single-block, so it runs in `on_runtime_upgrade`. On a chain still
-	/// at v3 it is a no-op (its v4 guard); the v3->v4 MBM below bumps to v4, then a following
-	/// runtime upgrade lets this step bump v4->v5. Idempotent on chains already at v5.
-	pub type Unreleased =
-		(pallet_bulletin_transaction_storage::migrations::v5::MigrateV4ToV5<Runtime>,);
+	/// Paseo is a fresh chain, so the historical version-bump migrations do not apply.
+	pub type Unreleased = ();
 
 	/// Migrations/checks that do not need to be versioned and can run on every update.
 	pub type Permanent = (
@@ -156,10 +153,8 @@ pub mod migrations {
 
 	/// MBM migrations to apply on runtime upgrade.
 	///
-	/// `MigrateV3ToV4` walks `AutoRenewals` to the v4 layout. Self-guarded and idempotent, so
-	/// it is a no-op on chains already at/beyond v4.
-	pub type MbmMigrations =
-		(pallet_bulletin_transaction_storage::migrations::v4::MigrateV3ToV4<Runtime>,);
+	/// Paseo is a fresh chain, so the historical transaction-storage MBM migrations do not apply.
+	pub type MbmMigrations = ();
 }
 
 /// Executive: handles dispatch to the various modules.

--- a/scripts/runtimes-matrix.json
+++ b/scripts/runtimes-matrix.json
@@ -7,7 +7,8 @@
     "try_runtime": {
       "extra_flags": "--blocktime 24000 --disable-spec-version-check",
       "instances": [
-        { "name": "westend", "uris": ["wss://westend-bulletin-rpc.polkadot.io"] }
+        { "name": "westend", "uris": ["wss://westend-bulletin-rpc.polkadot.io"] },
+        { "name": "paseo",   "uris": ["wss://paseo-bulletin-rpc.polkadot.io"] }
       ]
     },
     "benchmarks_templates": {
@@ -24,7 +25,6 @@
       "spec_name_check": "--disable-spec-name-check",
       "extra_flags": "--blocktime 24000 --disable-spec-version-check",
       "instances": [
-        { "name": "paseo",      "uris": ["wss://paseo-bulletin-rpc.polkadot.io"] },
         { "name": "next-v2",    "uris": ["wss://paseo-bulletin-next-rpc.polkadot.io"] },
         { "name": "previewnet", "uris": ["wss://previewnet.substrate.dev/bulletin"] }
       ]

--- a/scripts/runtimes-matrix.json
+++ b/scripts/runtimes-matrix.json
@@ -7,8 +7,7 @@
     "try_runtime": {
       "extra_flags": "--blocktime 24000 --disable-spec-version-check",
       "instances": [
-        { "name": "westend", "uris": ["wss://westend-bulletin-rpc.polkadot.io"] },
-        { "name": "paseo",   "uris": ["wss://paseo-bulletin-rpc.polkadot.io"] }
+        { "name": "westend", "uris": ["wss://westend-bulletin-rpc.polkadot.io"] }
       ]
     },
     "benchmarks_templates": {
@@ -25,6 +24,7 @@
       "spec_name_check": "--disable-spec-name-check",
       "extra_flags": "--blocktime 24000 --disable-spec-version-check",
       "instances": [
+        { "name": "paseo",      "uris": ["wss://paseo-bulletin-rpc.polkadot.io"] },
         { "name": "next-v2",    "uris": ["wss://paseo-bulletin-next-rpc.polkadot.io"] },
         { "name": "previewnet", "uris": ["wss://previewnet.substrate.dev/bulletin"] }
       ]

--- a/scripts/runtimes-matrix.json
+++ b/scripts/runtimes-matrix.json
@@ -24,6 +24,7 @@
       "spec_name_check": "--disable-spec-name-check",
       "extra_flags": "--blocktime 24000 --disable-spec-version-check",
       "instances": [
+        { "name": "paseo",      "uris": ["wss://paseo-bulletin-rpc.polkadot.io"] },
         { "name": "next-v2",    "uris": ["wss://paseo-bulletin-next-rpc.polkadot.io"] },
         { "name": "previewnet", "uris": ["wss://previewnet.substrate.dev/bulletin"] }
       ]


### PR DESCRIPTION
Adds the original Bulletin Paseo (`wss://paseo-bulletin-rpc.polkadot.io`) as a try-runtime instance under `bulletin-paseo`, ahead of migrating it onto the `bulletin-paseo` runtime.

Note: this is *not* Paseo Next V2.

### Why under `bulletin-paseo` (not `bulletin-westend`)

old Paseo currently runs `bulletin-westend` (`1_000_015`), but every pallet storage version is already current except transaction-storage (v4 vs v5):

```
                     old-Paseo   PaseoNextV2
  ParachainSystem        3            3
  CollatorSelection      2            2
  XcmpQueue              6            6
  Session                1            1
  AuraExt                1            1
  TransactionStorage     4            5   <- only delta
  PolkadotXcm            1            1
```

The 1_000_015 `bulletin-westend` deploy already ran the historical migrations (ParachainSystem 2->3 etc.), so the earlier "ParachainSystem 2 vs 3" try-runtime failure no longer applies. `bulletin-paseo` wires `MigrateV4ToV5`, which closes the only remaining gap. So old Paseo can be upgraded directly onto `bulletin-paseo`, and its try-runtime check belongs under `bulletin-paseo` (with `--disable-spec-name-check`).

Refs #612