### PR TITLE
Wire transaction-storage v3→v5 migrations for bulletin-paseo

### DIFF
--- a/runtimes/bulletin-paseo/src/lib.rs
+++ b/runtimes/bulletin-paseo/src/lib.rs
@@ -136,8 +136,11 @@ pub mod migrations {
 
 	/// Unreleased migrations. Add new ones here:
 	///
-	/// Paseo is a fresh chain, so the historical version-bump migrations do not apply.
-	pub type Unreleased = ();
+	/// `MigrateV4ToV5` is single-block, so it runs in `on_runtime_upgrade`. On a chain still
+	/// at v3 it is a no-op (its v4 guard); the v3->v4 MBM below bumps to v4, then a following
+	/// runtime upgrade lets this step bump v4->v5. Idempotent on chains already at v5.
+	pub type Unreleased =
+		(pallet_bulletin_transaction_storage::migrations::v5::MigrateV4ToV5<Runtime>,);
 
 	/// Migrations/checks that do not need to be versioned and can run on every update.
 	pub type Permanent = (
@@ -153,8 +156,10 @@ pub mod migrations {
 
 	/// MBM migrations to apply on runtime upgrade.
 	///
-	/// Paseo is a fresh chain, so the historical transaction-storage MBM migrations do not apply.
-	pub type MbmMigrations = ();
+	/// `MigrateV3ToV4` walks `AutoRenewals` to the v4 layout. Self-guarded and idempotent, so
+	/// it is a no-op on chains already at/beyond v4.
+	pub type MbmMigrations =
+		(pallet_bulletin_transaction_storage::migrations::v4::MigrateV3ToV4<Runtime>,);
 }
 
 /// Executive: handles dispatch to the various modules.


### PR DESCRIPTION
The live Bulletin Paseo chain is at transaction-storage storage version 3, while the in-code version is 5. The `bulletin-paseo` runtime wired no versioned migrations, so a runtime upgrade left the chain at v3 and failed the storage-version check.

Wires the staged path:
- `MigrateV3ToV4` (MBM) walks `AutoRenewals` to the v4 layout
- `MigrateV4ToV5` (single-block) translates the authorizer budget

Both are self-guarded and idempotent, so they no-op on Paseo Next V2 and previewnet, which are already at v5.

Note on sequencing: the two steps run at different times. The single-block v4→v5 fires during `on_runtime_upgrade` (skips while the chain is at v3); the MBM then walks v3→v4. So one upgrade moves an old v3 chain to v4, and a following upgrade takes it v4→v5.

Prerequisite for #612.