### PR TITLE
Fix shebang position in upgrade_runtime.js

### DIFF
--- a/examples/upgrade_runtime.js
+++ b/examples/upgrade_runtime.js
@@ -1,7 +1,7 @@
+#!/usr/bin/env node
 // Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-#!/usr/bin/env node
 /**
  * Runtime Upgrade Script for Bulletin Chain Networks
  *


### PR DESCRIPTION
The shebang `#!/usr/bin/env node` was on line 4, after the license header. A shebang is only honored on line 1; mid-file Node parses `#` as code, so the script died with `SyntaxError: Invalid or unexpected token` and couldn't run at all.

Moved it to line 1, license header below it.

Verified the fixed script runs:
```
node upgrade_runtime.js --verify-only --network paseo
```