### PR TITLE
Bump col11 eviction probe timeout to 450s

### DIFF
--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -45,8 +45,9 @@ const BITSWAP_TIMEOUT_SECS: u64 = 30;
 const BITSWAP_VERIFY_CONCURRENCY: usize = 16;
 /// `--blocks-pruning` deletion + col11 refcount-zero cleanup runs asynchronously after the
 /// finalized-height metric crosses; under CI load that lag can be tens of seconds (paseo runs
-/// observed >180s before eviction). 300s gives margin without making fast-cleanup runs slow.
-const BITSWAP_EVICTION_TIMEOUT_SECS: u64 = 300;
+/// observed >180s, and westend/mixed has exceeded 300s). 450s gives margin without making
+/// fast-cleanup runs slow.
+const BITSWAP_EVICTION_TIMEOUT_SECS: u64 = 450;
 
 const NUM_RENEWAL_CYCLES: u64 = 2;
 const TOPUP_TX_COUNT: u32 = 5;


### PR DESCRIPTION
`parachain_auto_renew_many_items_prune_eviction_test` flaked on `westend/mixed`: the first-item col11 eviction probe timed out at 300s while async cleanup lagged the finalized-height crossing under CI load. It passed in the other 7/8 matrix cells.

Bumps `BITSWAP_EVICTION_TIMEOUT_SECS` 300 -> 450. No logic change; fast-cleanup runs still return early.