### PR TITLE
utils: IPFS gateway debug tools

### DIFF
--- a/utils/ipfs-debug/README.md
+++ b/utils/ipfs-debug/README.md
@@ -1,0 +1,60 @@
+# IPFS gateway debug tools
+
+Small tools for tracing a missing IPFS CID: deciding whether it is on the
+Bulletin chain at all, and (for web content) which dotNS app references it.
+Built while investigating a 504 storm on the Paseo bulletin gateway, where
+Polkadot Desktop polled one missing CID once a minute for hours.
+
+## `bulletin-has-cid.mjs` — is this CID stored on Bulletin?
+
+The authoritative check. `pallet-transaction-storage::store` content-addresses
+with blake2b + raw codec, so a `bafk2bzace…` CID maps directly to an on-chain
+`content_hash`. This queries `TransactionByContentHash` for that digest.
+
+```bash
+# extract the 32-byte blake2b digest from the CID first (see find_cid_parent.cid_parts),
+# then:
+node bulletin-has-cid.mjs 0x<content-hash>
+# -> STORED: yes — block #…, index …    (within retention)
+# -> STORED: no  — expired or never stored
+```
+
+Needs a papi project with the `bulletin` descriptor generated
+(`@polkadot-api/descriptors`) and `polkadot-api` installed. Env: `BULLETIN_RPC`
+(default `wss://paseo-bulletin-next-rpc.polkadot.io`).
+
+## `find_cid_parent.py` — which bundle contains a leaf?
+
+Given a gateway and dag-pb root CIDs, walks each root's tree and reports whether
+a target CID is a descendant — without fetching the (possibly missing) target,
+since it matches on the parent's link list.
+
+```bash
+python3 find_cid_parent.py --gateway https://paseo-bulletin-next-ipfs.polkadot.io \
+  --target <cid> <rootCID1> <rootCID2> ...
+```
+
+Fetches raw blocks (`?format=raw`) and parses dag-pb locally. Matches CIDs by
+(codec, multihash) so v0/v1 and base differences don't cause misses. Needs
+`curl` (the system Python's TLS is too old for some gateways).
+
+## `find-app-for-cid.sh` — which dotNS app references a CID?
+
+Resolves candidate `.dot` names to bundle roots via the `dotns` CLI, then walks
+each bundle with `find_cid_parent.py`.
+
+```bash
+./find-app-for-cid.sh <cid> bulletin-benchmarks dotns my-app ...
+```
+
+Env: `DOTNS` (how to invoke the CLI), `KEY_URI` (any address-mapped account;
+reads are dry-runs), `GATEWAY`. dotNS has no on-chain "list all names", so you
+supply candidate names (playground/demo apps, an indexer, or known owners via
+`dotns lookup`).
+
+## Hash types matter
+
+dotNS web-app bundles use sha256 leaves (`bafkrei…`). Bulletin-native content
+(preimages, `dotns bulletin upload` blobs) uses blake2b (`bafk2bzace…`). A
+blake2b leaf will not be found inside a sha256 web bundle, so for those start
+with `bulletin-has-cid.mjs` (chain truth) rather than walking dotNS bundles.

--- a/utils/ipfs-debug/bulletin-has-cid.mjs
+++ b/utils/ipfs-debug/bulletin-has-cid.mjs
@@ -1,0 +1,32 @@
+import { createClient, Binary, FixedSizeBinary } from "polkadot-api";
+import { getWsProvider } from "polkadot-api/ws-provider/node";
+import { bulletin } from "@polkadot-api/descriptors";
+
+const RPC = process.env.BULLETIN_RPC ?? "wss://paseo-bulletin-next-rpc.polkadot.io";
+const contentHash = process.argv[2]; // 0x… 32-byte blake2b digest
+if (!contentHash) {
+  console.error("usage: node bulletin-has-cid.mjs <0x-content-hash>");
+  process.exit(2);
+}
+
+const client = createClient(getWsProvider(RPC));
+const api = client.getTypedApi(bulletin);
+
+// content_hash is a fixed 32-byte type.
+const arg = FixedSizeBinary.fromHex(contentHash);
+
+const stored = await api.query.TransactionStorage.TransactionByContentHash.getValue(arg);
+const retention = await api.query.TransactionStorage.RetentionPeriod.getValue().catch(() => null);
+const head = await client.getFinalizedBlock();
+
+console.log(`bulletin: ${RPC}`);
+console.log(`content_hash: ${contentHash}`);
+console.log(`finalized head: #${head.number}`);
+if (retention != null) console.log(`retention period: ${retention} blocks`);
+if (stored) {
+  const [block, index] = Array.isArray(stored) ? stored : [stored.block ?? stored[0], stored.index ?? stored[1]];
+  console.log(`STORED: yes — block #${block}, index ${index}`);
+} else {
+  console.log(`STORED: no — not currently in TransactionByContentHash (expired or never stored)`);
+}
+client.destroy();

--- a/utils/ipfs-debug/find-app-for-cid.sh
+++ b/utils/ipfs-debug/find-app-for-cid.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Find which dotNS app references a (missing) IPFS CID.
+#
+# Resolves each candidate .dot name to its bundle root via the dotns CLI, then
+# walks each bundle on the bulletin gateway for the target CID.
+#
+# dotNS has no on-chain "list all names", so you pass candidate names (the
+# playground/demo apps, or names from an indexer/known owners).
+#
+# Requires: the `dotns` CLI reachable (default: the published @parity/dotns-cli),
+#           python3, and find_cid_parent.py alongside this script.
+#
+# Usage:
+#   ./find-app-for-cid.sh <target-cid> <name> [<name> ...]
+# Env overrides:
+#   DOTNS="node node_modules/@parity/dotns-cli/dist/cli.js"   # how to invoke the CLI
+#   KEY_URI=//Alice                                           # any mapped account (reads are dry-runs)
+#   GATEWAY=https://paseo-bulletin-next-ipfs.polkadot.io
+set -euo pipefail
+
+TARGET=${1:?usage: find-app-for-cid.sh <target-cid> <name>...}; shift
+[ $# -ge 1 ] || { echo "give at least one .dot name"; exit 2; }
+
+DOTNS=${DOTNS:-dotns}
+KEY_URI=${KEY_URI:-//Alice}
+GATEWAY=${GATEWAY:-https://paseo-bulletin-next-ipfs.polkadot.io}
+HERE=$(cd "$(dirname "$0")" && pwd)
+
+roots=()
+echo "resolving $# name(s) via dotNS..."
+for name in "$@"; do
+  name=${name%.dot}
+  cid=$(eval "$DOTNS --env paseo-v2 content view \"$name\" --key-uri \"$KEY_URI\"" 2>/dev/null \
+        | sed -n 's/.*cid:[[:space:]]*//p' | head -1)
+  if [ -n "$cid" ] && [ "$cid" != "(not set)" ]; then
+    echo "  $name.dot -> $cid"; roots+=("$cid")
+  else
+    echo "  $name.dot -> (no content)"
+  fi
+done
+
+[ ${#roots[@]} -gt 0 ] || { echo "no resolvable roots; nothing to walk"; exit 1; }
+
+echo
+echo "walking ${#roots[@]} bundle(s) for $TARGET ..."
+python3 "$HERE/find_cid_parent.py" --gateway "$GATEWAY" --target "$TARGET" "${roots[@]}"

--- a/utils/ipfs-debug/find_cid_parent.py
+++ b/utils/ipfs-debug/find_cid_parent.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Find which dag-pb bundle contains a given (leaf) CID.
+
+Given a gateway and one or more root CIDs, walks each root's dag-pb tree and
+reports whether the target CID appears as a descendant. Use it to map a missing
+raw leaf (e.g. a file inside an app bundle) back to the bundle/app that
+references it.
+
+Each node is read as its raw block (`?format=raw`) and the dag-pb protobuf is
+parsed locally to get child links (gateways won't convert dag-pb to dag-json
+server-side). Non-dag-pb codecs (raw leaves) are terminal.
+
+Usage:
+  find_cid_parent.py --gateway https://ipfs.io --target <leafCID> <rootCID>...
+"""
+import argparse
+import base64
+import subprocess
+import sys
+
+DAG_PB = 0x70
+
+
+def _b32decode(s):
+    s = s.upper()
+    s += "=" * ((8 - len(s) % 8) % 8)
+    return base64.b32decode(s)
+
+
+def _b32encode(b):
+    return base64.b32encode(b).decode().lower().rstrip("=")
+
+
+def _b58decode(s):
+    alpha = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    n = 0
+    for c in s:
+        n = n * 58 + alpha.index(c)
+    full = n.to_bytes((n.bit_length() + 7) // 8, "big")
+    pad = len(s) - len(s.lstrip("1"))
+    return b"\x00" * pad + full
+
+
+def _uvarint(b, i):
+    x = s = 0
+    while True:
+        c = b[i]
+        i += 1
+        x |= (c & 0x7F) << s
+        if not c & 0x80:
+            return x, i
+        s += 7
+
+
+def _putvarint(n):
+    out = bytearray()
+    while True:
+        b = n & 0x7F
+        n >>= 7
+        out.append(b | (0x80 if n else 0))
+        if not n:
+            return bytes(out)
+
+
+def cid_str_to_bin(cidstr):
+    if cidstr.startswith("Qm") or cidstr.startswith("1"):  # CIDv0: bytes are the multihash
+        mh = _b58decode(cidstr)
+        return b"\x01" + _putvarint(DAG_PB) + mh  # normalize to v1 dag-pb
+    return _b32decode(cidstr[1:])  # strip 'b' multibase, base32
+
+
+def cid_parts_from_bin(b):
+    """(codec, multihash_bytes), normalized across versions."""
+    if b[0] == 0x12 and b[1] == 0x20:  # bare CIDv0 sha256 multihash
+        return DAG_PB, b
+    if b[0] != 0x01:
+        raise ValueError("unsupported CID binary")
+    codec, i = _uvarint(b, 1)
+    return codec, b[i:]
+
+
+def cid_parts(cidstr):
+    return cid_parts_from_bin(cid_str_to_bin(cidstr))
+
+
+def bin_to_v1_str(b):
+    """Binary CID -> base32 CIDv1 string (for the gateway path)."""
+    if b[0] == 0x12 and b[1] == 0x20:  # CIDv0 multihash -> wrap as v1 dag-pb
+        b = b"\x01" + _putvarint(DAG_PB) + b
+    return "b" + _b32encode(b)
+
+
+def same_cid(a_str, b_str):
+    try:
+        return cid_parts(a_str) == cid_parts(b_str)
+    except Exception:
+        return a_str == b_str
+
+
+def fetch_raw(gateway, cidstr, timeout):
+    # Shell out to curl: the system Python's TLS is too old for some gateways.
+    url = f"{gateway.rstrip('/')}/ipfs/{cidstr}?format=raw"
+    p = subprocess.run(
+        ["curl", "-fsS", "--max-time", str(int(timeout)), "-A", "cid-walker/1.0",
+         "-H", "Accept: application/vnd.ipld.raw", url],
+        capture_output=True, timeout=timeout + 5,
+    )
+    if p.returncode != 0:
+        raise RuntimeError(f"curl rc={p.returncode}: {p.stderr.decode('utf-8','replace').strip()[:120]}")
+    return p.stdout
+
+
+def parse_dagpb_links(block):
+    """Return [(name, binary_cid)] from a dag-pb block. PBNode.Links = field 2."""
+    links, i, n = [], 0, len(block)
+    while i < n:
+        tag, i = _uvarint(block, i)
+        field, wire = tag >> 3, tag & 7
+        if wire == 2:
+            ln, i = _uvarint(block, i)
+            chunk = block[i : i + ln]
+            i += ln
+            if field == 2:  # a PBLink message
+                links.append(_parse_pblink(chunk))
+        elif wire == 0:
+            _, i = _uvarint(block, i)
+        else:
+            break
+    return [lk for lk in links if lk]
+
+
+def _parse_pblink(chunk):
+    h = name = None
+    i, n = 0, len(chunk)
+    while i < n:
+        tag, i = _uvarint(chunk, i)
+        field, wire = tag >> 3, tag & 7
+        if wire == 2:
+            ln, i = _uvarint(chunk, i)
+            val = chunk[i : i + ln]
+            i += ln
+            if field == 1:
+                h = val  # Hash = binary CID
+            elif field == 2:
+                name = val.decode("utf-8", "replace")
+        elif wire == 0:
+            _, i = _uvarint(chunk, i)  # Tsize
+        else:
+            break
+    return (name or "", h) if h else None
+
+
+def walk(gateway, root, target, timeout, max_nodes):
+    seen, stack, visited = set(), [(root, "")], 0
+    while stack:
+        cid, path = stack.pop()
+        if cid in seen:
+            continue
+        seen.add(cid)
+        visited += 1
+        if same_cid(cid, target):
+            return path or "<root>", visited
+        if visited >= max_nodes:
+            print(f"  ! stopped at {max_nodes} nodes", file=sys.stderr)
+            break
+        try:
+            codec, _ = cid_parts(cid)
+        except Exception:
+            continue
+        if codec != DAG_PB:
+            continue
+        try:
+            block = fetch_raw(gateway, cid, timeout)
+            for name, bincid in parse_dagpb_links(block):
+                child = bin_to_v1_str(bincid)
+                label = name or child[:12] + "…"
+                stack.append((child, f"{path}/{label}"))
+        except Exception as e:
+            print(f"  ! {cid[:16]}…: {e}", file=sys.stderr)
+    return None, visited
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--gateway", required=True)
+    ap.add_argument("--target", required=True)
+    ap.add_argument("--timeout", type=float, default=30.0)
+    ap.add_argument("--max-nodes", type=int, default=5000)
+    ap.add_argument("roots", nargs="+")
+    a = ap.parse_args()
+
+    print(f"target:  {a.target}\ngateway: {a.gateway}\n")
+    hit = False
+    for root in a.roots:
+        where, n = walk(a.gateway, root, a.target, a.timeout, a.max_nodes)
+        if where:
+            print(f"FOUND in root {root}\n  path: {where}  (scanned {n} nodes)")
+            hit = True
+        else:
+            print(f"not in root {root}  (scanned {n} nodes)")
+    sys.exit(0 if hit else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a few small tools under `utils/ipfs-debug/` for tracing a missing IPFS CID on the Bulletin gateway.

## Why

While investigating a 504 storm on the Paseo bulletin gateway, we traced it to Polkadot Desktop polling a single CID once a minute for hours, every request timing out because no node had the content. These tools answer the two questions that came up: is the CID actually on the chain, and (for web content) which app references it.

## What's included

- `bulletin-has-cid.mjs` — the authoritative check. `store` content-addresses with blake2b + raw codec, so a `bafk2bzace…` CID maps to an on-chain `content_hash`. This queries `TransactionByContentHash` to tell whether the CID is stored (within retention) or gone.
- `find_cid_parent.py` — given dag-pb roots, walks each on the gateway and reports whether a target CID is a descendant, and at what path. Matches on the parent's links, so it works even though the target itself 404/504s.
- `find-app-for-cid.sh` — resolves candidate `.dot` names to bundle roots via the `dotns` CLI, then walks each with the script above.
- `README.md` — usage and a note on hash types (dotNS web bundles use sha256, Bulletin-native content uses blake2b).

## Notes

- The Python tools are dependency-light (need `curl`). `bulletin-has-cid.mjs` needs a papi project with the `bulletin` descriptor.
- All three were tested against live Paseo: resolving real apps, walking real bundles on the gateway, and a chain lookup confirming the offending CID is not stored.