### PR TITLE
Prepare for the Paseo relay chain replacement

### DIFF
--- a/runtimes/bulletin-paseo/src/lib.rs
+++ b/runtimes/bulletin-paseo/src/lib.rs
@@ -33,7 +33,7 @@ use crate::paseo_constants::{
 	time::*,
 };
 use alloc::{vec, vec::Vec};
-use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
+use cumulus_pallet_parachain_system::AnyRelayNumber;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
 	derive_impl,
@@ -135,12 +135,7 @@ pub mod migrations {
 	use super::*;
 
 	/// Unreleased migrations. Add new ones here:
-	///
-	/// `MigrateV4ToV5` is single-block, so it runs in `on_runtime_upgrade`. On a chain still
-	/// at v3 it is a no-op (its v4 guard); the v3->v4 MBM below bumps to v4, then a following
-	/// runtime upgrade lets this step bump v4->v5. Idempotent on chains already at v5.
-	pub type Unreleased =
-		(pallet_bulletin_transaction_storage::migrations::v5::MigrateV4ToV5<Runtime>,);
+	pub type Unreleased = ();
 
 	/// Migrations/checks that do not need to be versioned and can run on every update.
 	pub type Permanent = (
@@ -155,11 +150,7 @@ pub mod migrations {
 	pub type SingleBlockMigrations = (Unreleased, Permanent);
 
 	/// MBM migrations to apply on runtime upgrade.
-	///
-	/// `MigrateV3ToV4` walks `AutoRenewals` to the v4 layout. Self-guarded and idempotent, so
-	/// it is a no-op on chains already at/beyond v4.
-	pub type MbmMigrations =
-		(pallet_bulletin_transaction_storage::migrations::v4::MigrateV3ToV4<Runtime>,);
+	pub type MbmMigrations = ();
 }
 
 /// Executive: handles dispatch to the various modules.
@@ -184,7 +175,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("bulletin-paseo"),
 	impl_name: alloc::borrow::Cow::Borrowed("bulletin-paseo"),
 	authoring_version: 1,
-	spec_version: 1_000_019,
+	spec_version: 1_000_020,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -342,7 +333,9 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type XcmpMessageHandler = XcmpQueue;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
-	type CheckAssociatedRelayNumber = RelayNumberMonotonicallyIncreases;
+	// Temporary for the Paseo relay chain replacement (new relay genesis restarts block
+	// numbers). Revert to `RelayNumberMonotonicallyIncreases` once stable on the new relay.
+	type CheckAssociatedRelayNumber = AnyRelayNumber;
 	type ConsensusHook = ConsensusHook;
 	type RelayParentOffset = ConstU32<0>;
 }


### PR DESCRIPTION
## Why

The Paseo relay chain is being replaced: the current relay is downsizing since 2026-07-02 and its validators stop on **2026-07-04 12:00 CEST**; the replacement relay is a **new genesis**, so relay block numbers restart from ~0 ([announcement + migration guide](https://forum.polkadot.network/t/paseo-testnet-relay-downsizing-sunset/17995)).

The chain to migrate is **bulletin paseo-next (para 1501**, `paseo-next-v2`, currently on runtime 1_000_018). With the current `RelayNumberMonotonicallyIncreases`, the first parachain block built on the new relay would panic in `set_validation_data` (relay parent number regresses from ~12.36M). This upgrade must be **enacted on the live chain before the old relay halts**; otherwise the chain can only be recovered by re-genesis from exported state, losing block history.

## Changes

- `CheckAssociatedRelayNumber = AnyRelayNumber` — temporary for the cutover; revert to `RelayNumberMonotonicallyIncreases` once stable on the new relay. Same one-line change as the [Asset Hub Paseo reference](https://github.com/paseo-network/runtimes/blob/main/system-parachains/asset-hub-paseo/src/lib.rs).
- `spec_version`: 1_000_019 → **1_000_020** (para 1501 goes 1_000_018 → 1_000_020 directly).
- Remove executed migrations from the paseo runtime: `v4::MigrateV3ToV4` (MBM) and `v5::MigrateV4ToV5` (single-block). Verified on-chain for both paseo instances: para 1501 and para 5118 each report `TransactionStorage` storage version **5** and an empty `MultiBlockMigrations::Cursor` (1501 started at v5 via its v2 re-genesis). `Permanent` migrations are kept.
