### PR TITLE
Bring back `RelayNumberMonotonicallyIncreases` after migration

### DIFF
--- a/runtimes/bulletin-paseo/src/lib.rs
+++ b/runtimes/bulletin-paseo/src/lib.rs
@@ -33,7 +33,7 @@ use crate::paseo_constants::{
 	time::*,
 };
 use alloc::{vec, vec::Vec};
-use cumulus_pallet_parachain_system::AnyRelayNumber;
+use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
 	derive_impl,
@@ -175,7 +175,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("bulletin-paseo"),
 	impl_name: alloc::borrow::Cow::Borrowed("bulletin-paseo"),
 	authoring_version: 1,
-	spec_version: 1_000_020,
+	spec_version: 1_000_021,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -333,9 +333,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type XcmpMessageHandler = XcmpQueue;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
-	// Temporary for the Paseo relay chain replacement (new relay genesis restarts block
-	// numbers). Revert to `RelayNumberMonotonicallyIncreases` once stable on the new relay.
-	type CheckAssociatedRelayNumber = AnyRelayNumber;
+	type CheckAssociatedRelayNumber = RelayNumberMonotonicallyIncreases;
 	type ConsensusHook = ConsensusHook;
 	type RelayParentOffset = ConstU32<0>;
 }


### PR DESCRIPTION
Related to https://github.com/paritytech/polkadot-bulletin-chain/pull/648

Brings back `CheckAssociatedRelayNumber = RelayNumberMonotonicallyIncreases` config after succesful migration onto new Paseo relay

Bumps the `bulletin-paseo` runtime version to `1_000_021` for the purpose of creating a release after this is merged