### PR TITLE
testing: add smoldotRpcSource and node RPC cross-check to smoldot example

### DIFF
--- a/examples/api.js
+++ b/examples/api.js
@@ -267,6 +267,9 @@ export const gatewaySource = (httpIpfsApi) =>
 export const nodeRpcSource = (client, label = 'bitswap-rpc') =>
     ({ name: label, fetch: (cid) => fetchCidFromNode(client, cid) });
 
+/** Smoldot serves the same `bitswap_v1_get`, fetching the block from its peers over p2p bitswap. */
+export const smoldotRpcSource = (client) => nodeRpcSource(client, 'smoldot-bitswap-rpc');
+
 /**
  * Fetch the block `cid` addresses from every source and assert each hashes to the
  * CID. Verifying every block against the CID also proves they are byte-identical

--- a/examples/authorize_and_store_papi_smoldot.js
+++ b/examples/authorize_and_store_papi_smoldot.js
@@ -6,8 +6,9 @@ import * as smoldot from 'smoldot';
 import { readFileSync } from 'fs';
 import { createClient } from 'polkadot-api';
 import { getSmProvider } from 'polkadot-api/sm-provider';
+import { getWsProvider } from 'polkadot-api/ws';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
-import { authorizeAccount, fetchAndVerifyBlock, gatewaySource, nodeRpcSource, store, TX_MODE_FINALIZED_BLOCK } from './api.js';
+import { authorizeAccount, fetchAndVerifyBlock, gatewaySource, nodeRpcSource, smoldotRpcSource, store, TX_MODE_FINALIZED_BLOCK } from './api.js';
 import { setupKeyringAndSigners, waitForChainReady, waitForBlockProduction, DEFAULT_IPFS_GATEWAY_URL } from './common.js';
 import { logHeader, logConfig, logSuccess, logError, logTestResult } from './logger.js';
 import { cidFromBytes } from "./cid_dag_metadata.js";
@@ -109,9 +110,9 @@ async function main() {
     const chainSpecPath = process.argv[2];
     if (!chainSpecPath) {
         logError('Chain spec path is required as first argument');
-        console.error('Usage: node authorize_and_store_papi_smoldot.js <chain-spec-path> [parachain-spec-path] [ipfs-api-url]');
-        console.error('  For parachains: <relay-chain-spec-path> <parachain-spec-path> [ipfs-api-url]');
-        console.error('  For solochains: <solo-chain-spec-path> [ipfs-api-url]');
+        console.error('Usage: node authorize_and_store_papi_smoldot.js <chain-spec-path> [parachain-spec-path] [ipfs-api-url] [node-ws-url]');
+        console.error('  For parachains: <relay-chain-spec-path> <parachain-spec-path> [ipfs-api-url] [node-ws-url]');
+        console.error('  For solochains: <solo-chain-spec-path> [ipfs-api-url] [node-ws-url]');
         process.exit(1);
     }
 
@@ -119,15 +120,18 @@ async function main() {
     const parachainSpecPath = process.argv[3] || null;
     // Optional IPFS API URL
     const HTTP_IPFS_API = process.argv[4] || DEFAULT_IPFS_GATEWAY_URL;
+    // Optional node WS URL; adds the node's bitswap_v1_get RPC to the read-back cross-check
+    const NODE_WS_URL = process.argv[5] || null;
 
     logConfig({
         'Mode': 'Smoldot Light Client',
         'Chain Spec': chainSpecPath,
         'Parachain Spec': parachainSpecPath || 'N/A (solochain)',
-        'IPFS API': HTTP_IPFS_API
+        'IPFS API': HTTP_IPFS_API,
+        'Node WS': NODE_WS_URL || 'N/A (smoldot-only cross-check)'
     });
     
-    let sd, client, resultCode;
+    let sd, client, nodeClient, resultCode;
     try {
         // Init Smoldot PAPI client and typed api.
         ({ client, sd } = await createSmoldotClient(chainSpecPath, parachainSpecPath));
@@ -162,9 +166,15 @@ async function main() {
         const { cid } = await store(bulletinAPI, whoSigner, dataToStore);
         logSuccess(`Data stored successfully with CID: ${cid}`);
 
-        // Read back from IPFS and smoldot's bitswap_v1_get (forwarded to peers
-        // over p2p bitswap), verifying both match.
-        let downloadedContent = await fetchAndVerifyBlock(cid, gatewaySource(HTTP_IPFS_API), nodeRpcSource(client));
+        // Read back from IPFS, smoldot's bitswap_v1_get (forwarded to peers
+        // over p2p bitswap) and, when a node WS URL is given, the node's
+        // bitswap_v1_get RPC, verifying all match.
+        const sources = [gatewaySource(HTTP_IPFS_API), smoldotRpcSource(client)];
+        if (NODE_WS_URL) {
+            nodeClient = createClient(getWsProvider(NODE_WS_URL));
+            sources.push(nodeRpcSource(nodeClient));
+        }
+        let downloadedContent = await fetchAndVerifyBlock(cid, ...sources);
         logSuccess(`Downloaded content: ${downloadedContent.toString()}`);
         assert.deepStrictEqual(
             cid,
@@ -185,6 +195,7 @@ async function main() {
         console.error(error);
         resultCode = 1;
     } finally {
+        if (nodeClient) nodeClient.destroy();
         if (client) client.destroy();
         if (sd) sd.terminate();
         process.exit(resultCode);

--- a/examples/justfile
+++ b/examples/justfile
@@ -505,7 +505,7 @@ stop-services test_dir ipfs_mode="kubo-docker":
 #   test_dir - Test directory where services are running
 #   runtime - Runtime name for smoldot chainspec path resolution
 #   mode - Connection mode: "ws" (WebSocket RPC node) or "smoldot" (light client)
-#   ws_url - WebSocket URL (default: ws://127.0.0.1:10000, only used in ws mode)
+#   ws_url - WebSocket URL (default: ws://127.0.0.1:10000; submit node in ws mode, node bitswap RPC cross-check in smoldot mode)
 #   seed - Account seed phrase or dev seed (default: //Eve, only used in ws mode)
 #   http_ipfs_api - IPFS API URL (default: http://127.0.0.1:8283)
 run-test-authorize-and-store test_dir runtime mode="ws" ws_url="ws://127.0.0.1:10000" seed="//Eve" http_ipfs_api="http://127.0.0.1:8283":
@@ -534,7 +534,7 @@ run-test-authorize-and-store test_dir runtime mode="ws" ws_url="ws://127.0.0.1:1
             echo "❌ Unhandled runtime: {{ runtime }}"
             exit 1
         fi
-        node $SCRIPT_NAME "$RELAY_CHAINSPEC_PATH" "$PARACHAIN_CHAINSPEC_PATH" "{{ http_ipfs_api }}"
+        node $SCRIPT_NAME "$RELAY_CHAINSPEC_PATH" "$PARACHAIN_CHAINSPEC_PATH" "{{ http_ipfs_api }}" "{{ ws_url }}"
     else
         node $SCRIPT_NAME "{{ ws_url }}" "{{ seed }}" "{{ http_ipfs_api }}"
     fi
@@ -743,7 +743,7 @@ run-authorize-and-store runtime mode="ws" ipfs_mode="kubo-docker": npm-install
             echo "❌ Unhandled runtime: {{ runtime }}"
             exit 1
         fi
-        node $SCRIPT_NAME "$RELAY_CHAINSPEC_PATH" "$PARACHAIN_CHAINSPEC_PATH" "http://127.0.0.1:8283"
+        node $SCRIPT_NAME "$RELAY_CHAINSPEC_PATH" "$PARACHAIN_CHAINSPEC_PATH" "http://127.0.0.1:8283" "ws://127.0.0.1:10000"
     else
         node $SCRIPT_NAME "ws://127.0.0.1:10000" "//Eve" "http://127.0.0.1:8283"
     fi


### PR DESCRIPTION
Follow-up to [this comment](https://github.com/paritytech/polkadot-bulletin-chain/pull/669#discussion_r3620704582) on #669.

- `smoldotRpcSource(client)` names smoldot's `bitswap_v1_get` retrieval path (the smoldot example already used it, but under the generic `nodeRpcSource` label).
- The smoldot example takes an optional node WS URL and, when given, also cross-checks the node's `bitswap_v1_get` RPC, so the stored block is verified over three paths: IPFS gateway, smoldot p2p bitswap and node RPC.
- The justfile passes the node WS URL in both smoldot invocations, so CI and local runs cover all three.

Verified locally against a zombienet network (kubo-native): the smoldot example fetched the block from the gateway, smoldot and the node RPC, and all hashed back to the CID.