### PR TITLE
ci: split mixed zombienet group into three parallel cells

### DIFF
--- a/.github/workflows/zombienet-tests.yml
+++ b/.github/workflows/zombienet-tests.yml
@@ -81,7 +81,9 @@ jobs:
           - archive
           - pruning
           - restart
-          - mixed
+          - mixed-1
+          - mixed-2
+          - mixed-3
     steps:
       - name: Checkout sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/justfile
+++ b/justfile
@@ -125,6 +125,15 @@ test-zombienet-auto-renew runtime="westend" group="all":
             filter_args=("{{group}}")
             ;;
     esac
+    # A filter matching zero tests exits 0; fail loudly instead (e.g. a stale
+    # group name from another branch would otherwise go silently green).
+    matched=$(cargo test --release -p bulletin-chain-zombienet-sdk-tests \
+        --features bulletin-chain-zombienet-sdk-tests/zombie-auto-renew-tests \
+        -- --list "${filter_args[@]}" | grep -c ': test$' || true)
+    if [ "$matched" -eq 0 ]; then
+        echo "group '{{group}}' matched no tests" >&2
+        exit 1
+    fi
     cargo test --release -p bulletin-chain-zombienet-sdk-tests \
         --features bulletin-chain-zombienet-sdk-tests/zombie-auto-renew-tests \
         -- --test-threads=1 --nocapture "${filter_args[@]}"

--- a/justfile
+++ b/justfile
@@ -69,8 +69,8 @@ test-pallets:
 #   archive  — collator in archive mode, RP=10 (shared network)
 #   pruning  — collator with --blocks-pruning=15, RP=10 (shared network)
 #   restart  — scenarios that change pruning args across collator restarts
-#   mixed    — heterogeneous standalone tests (each spawns its own network);
-#              CI runs the mixed-1/2/3 slices in parallel, `mixed` is the union
+#   mixed-1/2/3 — heterogeneous standalone tests (each spawns its own network),
+#              sliced into three groups so CI can run them in parallel
 #   <substr> — any other value is treated as a cargo-test substring filter
 test-zombienet-auto-renew runtime="westend" group="all":
     #!/usr/bin/env bash
@@ -104,15 +104,6 @@ test-zombienet-auto-renew runtime="westend" group="all":
             ;;
         restart)
             filter_args=(parachain_restart_)
-            ;;
-        mixed)
-            filter_args=(--exact \
-                auto_renew_storage::parachain_check_proof_fails_under_pruning_test \
-                auto_renew_storage::parachain_auto_renew_under_pruning_chain_halts_test \
-                auto_renew_storage::parachain_auto_renew_many_items_worst_case_test \
-                auto_renew_storage::parachain_auto_renew_many_items_prune_eviction_test \
-                auto_renew_storage::parachain_on_initialize_cleanup_test \
-                auto_renew_storage::parachain_on_initialize_no_renewals_weight_test)
             ;;
         # Slices balanced by runtime: worst_case alone is ~17 min.
         mixed-1)

--- a/justfile
+++ b/justfile
@@ -69,7 +69,8 @@ test-pallets:
 #   archive  — collator in archive mode, RP=10 (shared network)
 #   pruning  — collator with --blocks-pruning=15, RP=10 (shared network)
 #   restart  — scenarios that change pruning args across collator restarts
-#   mixed    — heterogeneous standalone tests (each spawns its own network)
+#   mixed    — heterogeneous standalone tests (each spawns its own network);
+#              CI runs the mixed-1/2/3 slices in parallel, `mixed` is the union
 #   <substr> — any other value is treated as a cargo-test substring filter
 test-zombienet-auto-renew runtime="westend" group="all":
     #!/usr/bin/env bash
@@ -112,6 +113,22 @@ test-zombienet-auto-renew runtime="westend" group="all":
                 auto_renew_storage::parachain_auto_renew_many_items_prune_eviction_test \
                 auto_renew_storage::parachain_on_initialize_cleanup_test \
                 auto_renew_storage::parachain_on_initialize_no_renewals_weight_test)
+            ;;
+        # Slices balanced by runtime: worst_case alone is ~17 min.
+        mixed-1)
+            filter_args=(--exact \
+                auto_renew_storage::parachain_auto_renew_many_items_worst_case_test \
+                auto_renew_storage::parachain_on_initialize_no_renewals_weight_test)
+            ;;
+        mixed-2)
+            filter_args=(--exact \
+                auto_renew_storage::parachain_auto_renew_many_items_prune_eviction_test \
+                auto_renew_storage::parachain_auto_renew_under_pruning_chain_halts_test)
+            ;;
+        mixed-3)
+            filter_args=(--exact \
+                auto_renew_storage::parachain_check_proof_fails_under_pruning_test \
+                auto_renew_storage::parachain_on_initialize_cleanup_test)
             ;;
         *)
             filter_args=("{{group}}")


### PR DESCRIPTION
Run the six standalone `mixed` scenarios as three parallel matrix cells (`mixed-1/2/3`, balanced so the 17-min worst-case test gets the lightest partner), cutting wall clock from ~56 to ~22 min with identical coverage; the hand-maintained `mixed` union group is removed.