### PR TITLE
sdk: tolerate unsubscribe on a closed connection

### DIFF
--- a/sdk/typescript/src/async-client.ts
+++ b/sdk/typescript/src/async-client.ts
@@ -755,9 +755,8 @@ export class AsyncBulletinClient implements BulletinClientInterface {
         try {
           subscription.unsubscribe()
         } catch {
-          // Unsubscribing sends transaction_v1_stop; if the client was
-          // destroyed while a background watch was still alive, the transport
-          // is gone and the send throws. Teardown must not.
+          // The transport may already be gone (client destroyed while a
+          // background watch was alive); teardown must not throw.
         }
       }
 

--- a/sdk/typescript/src/async-client.ts
+++ b/sdk/typescript/src/async-client.ts
@@ -752,7 +752,13 @@ export class AsyncBulletinClient implements BulletinClientInterface {
 
       const cleanup = () => {
         clearTimeout(timerId)
-        subscription.unsubscribe()
+        try {
+          subscription.unsubscribe()
+        } catch {
+          // Unsubscribing sends transaction_v1_stop; if the client was
+          // destroyed while a background watch was still alive, the transport
+          // is gone and the send throws. Teardown must not.
+        }
       }
 
       const finish = (

--- a/sdk/typescript/test/unit/chunked-tx-lifecycle.test.ts
+++ b/sdk/typescript/test/unit/chunked-tx-lifecycle.test.ts
@@ -108,4 +108,56 @@ describe("chunked upload tx subscription lifecycle", () => {
     finalized(2)
     expect(unsubscribed).toEqual([true, true, true])
   })
+
+  it("tolerates unsubscribe failing after the transport is gone", async () => {
+    const observers: Observer[] = []
+    const makeTx = () => ({
+      signSubmitAndWatch: () => ({
+        subscribe: (obs: Observer) => {
+          observers.push(obs)
+          return {
+            unsubscribe: () => {
+              // client.destroy() closes the socket; transaction_v1_stop then
+              // rejects exactly like PAPI's raw client does.
+              throw new Error("Not connected")
+            },
+          }
+        },
+      }),
+      getBareTx: async () => new Uint8Array(),
+      decodedCall: {},
+      signAndSubmit: async () => ({ txHash: "0x01" }),
+    })
+    const api = {
+      tx: { TransactionStorage: { store: makeTx } },
+    }
+    const client = new AsyncBulletinClient(
+      // biome-ignore lint/suspicious/noExplicitAny: testing with mock objects
+      api as any,
+      // biome-ignore lint/suspicious/noExplicitAny: testing with mock objects
+      signer as any,
+      submitFn,
+    )
+
+    const pending = client.storeWithOptions(new Uint8Array([1, 2]), {
+      waitFor: "in_block",
+    })
+
+    await vi.waitFor(() => expect(observers).toHaveLength(1))
+    observers[0].next({
+      txHash: "0x00",
+      type: "txBestBlocksState",
+      found: true,
+      block: { hash: "0xbe57", number: 10, index: 0 },
+    })
+    await expect(pending).resolves.toBeDefined()
+
+    // Finalized after the socket died: release path must swallow the throw.
+    expect(() =>
+      observers[0].next({
+        type: "finalized",
+        block: { hash: "0xf1a1", number: 10, index: 0 },
+      }),
+    ).not.toThrow()
+  })
 })

--- a/sdk/typescript/test/unit/chunked-tx-lifecycle.test.ts
+++ b/sdk/typescript/test/unit/chunked-tx-lifecycle.test.ts
@@ -117,8 +117,7 @@ describe("chunked upload tx subscription lifecycle", () => {
           observers.push(obs)
           return {
             unsubscribe: () => {
-              // client.destroy() closes the socket; transaction_v1_stop then
-              // rejects exactly like PAPI's raw client does.
+              // What PAPI's raw client throws once the socket is closed.
               throw new Error("Not connected")
             },
           }


### PR DESCRIPTION
The background watch added in #688 throws an unhandled UnsubscriptionError ("Not connected") when the client is destroyed before a watched transaction finalizes, failing test runs after all tests pass; the release path now swallows transport errors on teardown.