### PR TITLE
sdk: retry once on mortality era expiry (AncientBirthBlock)

### DIFF
--- a/sdk/typescript/src/async-client.ts
+++ b/sdk/typescript/src/async-client.ts
@@ -237,7 +237,6 @@ interface MappedTxStatus {
   }
 }
 
-/** Result of a completed sign-submit-watch cycle. */
 interface SignSubmitResult {
   blockHash: string
   txHash: string
@@ -246,13 +245,8 @@ interface SignSubmitResult {
   events?: RuntimeEvent[]
 }
 
-/**
- * PAPI's `InvalidTxError` for a transaction whose mortality era expired:
- * `{ type: "Invalid", value: { type: "AncientBirthBlock" } }`. Matched by
- * error name and shape (not instanceof) so it works across polkadot-api
- * module instances. Deliberately narrow: other invalid types (BadProof,
- * Stale, ...) must not be retried.
- */
+// Shape-matched (not instanceof) to work across polkadot-api instances;
+// narrow on purpose: no other invalid type is safe to retry.
 function isAncientBirthBlockError(err: unknown): boolean {
   if (!(err instanceof Error) || err.name !== "InvalidTxError") return false
   const e = (err as { error?: { type?: unknown; value?: { type?: unknown } } })
@@ -753,16 +747,10 @@ export class AsyncBulletinClient implements BulletinClientInterface {
    * transaction stays broadcast and watched in the background until it
    * finalizes, so a reorg cannot silently drop it.
    *
-   * Retries once if the submission dies of mortality-era expiry
-   * (AncientBirthBlock): the node's fork-aware pool can silently lose a
-   * ready transaction around a reorg (transaction_v1_broadcast gives no
-   * drop feedback), and PAPI only reports the loss once the 64-block era
-   * boundary finalizes. The retry is safe because past that finalized
-   * boundary the original transaction's era check fails in every possible
-   * block, so it can never be included and the re-signed submission (PAPI
-   * anchors a fresh mortality era and nonce per subscribe) cannot
-   * double-store. One retry only: a second consecutive era expiry means
-   * ~13 minutes without inclusion, which is genuinely fatal.
+   * Retries once on mortality-era expiry (AncientBirthBlock): the node's
+   * pool can silently lose a broadcast tx around a reorg, surfacing only as
+   * era expiry. Safe: past the finalized era boundary the original
+   * signature can never be included, so re-signing cannot double-store.
    *
    * @param tx - The transaction to submit
    * @param progressCallback - Optional callback to receive transaction status events
@@ -794,11 +782,8 @@ export class AsyncBulletinClient implements BulletinClientInterface {
     }
   }
 
-  /**
-   * One sign-submit-watch cycle. `willRetryEraExpiry` suppresses the
-   * Invalid progress signal for an era-expired attempt the caller retries;
-   * the retry emits its own Signed/Broadcasted events.
-   */
+  // One sign-submit-watch cycle. `willRetryEraExpiry` keeps a retried
+  // attempt from emitting a misleading Invalid signal.
   private signAndSubmitAttempt(
     tx: PapiTransaction,
     progressCallback: ProgressCallback | undefined,

--- a/sdk/typescript/src/async-client.ts
+++ b/sdk/typescript/src/async-client.ts
@@ -237,6 +237,29 @@ interface MappedTxStatus {
   }
 }
 
+/** Result of a completed sign-submit-watch cycle. */
+interface SignSubmitResult {
+  blockHash: string
+  txHash: string
+  blockNumber?: number
+  txIndex?: number
+  events?: RuntimeEvent[]
+}
+
+/**
+ * PAPI's `InvalidTxError` for a transaction whose mortality era expired:
+ * `{ type: "Invalid", value: { type: "AncientBirthBlock" } }`. Matched by
+ * error name and shape (not instanceof) so it works across polkadot-api
+ * module instances. Deliberately narrow: other invalid types (BadProof,
+ * Stale, ...) must not be retried.
+ */
+function isAncientBirthBlockError(err: unknown): boolean {
+  if (!(err instanceof Error) || err.name !== "InvalidTxError") return false
+  const e = (err as { error?: { type?: unknown; value?: { type?: unknown } } })
+    .error
+  return e?.type === "Invalid" && e?.value?.type === "AncientBirthBlock"
+}
+
 /**
  * Map a raw PAPI transaction status event to SDK progress events.
  *
@@ -730,6 +753,17 @@ export class AsyncBulletinClient implements BulletinClientInterface {
    * transaction stays broadcast and watched in the background until it
    * finalizes, so a reorg cannot silently drop it.
    *
+   * Retries once if the submission dies of mortality-era expiry
+   * (AncientBirthBlock): the node's fork-aware pool can silently lose a
+   * ready transaction around a reorg (transaction_v1_broadcast gives no
+   * drop feedback), and PAPI only reports the loss once the 64-block era
+   * boundary finalizes. The retry is safe because past that finalized
+   * boundary the original transaction's era check fails in every possible
+   * block, so it can never be included and the re-signed submission (PAPI
+   * anchors a fresh mortality era and nonce per subscribe) cannot
+   * double-store. One retry only: a second consecutive era expiry means
+   * ~13 minutes without inclusion, which is genuinely fatal.
+   *
    * @param tx - The transaction to submit
    * @param progressCallback - Optional callback to receive transaction status events
    * @param waitFor - What to wait for: "in_block" (faster) or "finalized" (safer, default)
@@ -739,13 +773,39 @@ export class AsyncBulletinClient implements BulletinClientInterface {
     progressCallback?: ProgressCallback,
     waitFor: "in_block" | "finalized" = "finalized",
     chunkIndex?: number,
-  ): Promise<{
-    blockHash: string
-    txHash: string
-    blockNumber?: number
-    txIndex?: number
-    events?: RuntimeEvent[]
-  }> {
+  ): Promise<SignSubmitResult> {
+    try {
+      return await this.signAndSubmitAttempt(
+        tx,
+        progressCallback,
+        waitFor,
+        chunkIndex,
+        true,
+      )
+    } catch (err) {
+      if (!isAncientBirthBlockError(err)) throw err
+      return this.signAndSubmitAttempt(
+        tx,
+        progressCallback,
+        waitFor,
+        chunkIndex,
+        false,
+      )
+    }
+  }
+
+  /**
+   * One sign-submit-watch cycle. `willRetryEraExpiry` suppresses the
+   * Invalid progress signal for an era-expired attempt the caller retries;
+   * the retry emits its own Signed/Broadcasted events.
+   */
+  private signAndSubmitAttempt(
+    tx: PapiTransaction,
+    progressCallback: ProgressCallback | undefined,
+    waitFor: "in_block" | "finalized",
+    chunkIndex: number | undefined,
+    willRetryEraExpiry: boolean,
+  ): Promise<SignSubmitResult> {
     return new Promise((resolve, reject) => {
       let resolved = false
       let txHash: string | undefined
@@ -798,7 +858,10 @@ export class AsyncBulletinClient implements BulletinClientInterface {
           }
           resolved = true
           cleanup()
-          if (progressCallback) {
+          if (
+            progressCallback &&
+            !(willRetryEraExpiry && isAncientBirthBlockError(err))
+          ) {
             const errorMsg = err instanceof Error ? err.message : String(err)
             // Distinguish pool-related drops from other transaction errors
             const isDropped =

--- a/sdk/typescript/test/unit/era-expiry-retry.test.ts
+++ b/sdk/typescript/test/unit/era-expiry-retry.test.ts
@@ -1,0 +1,109 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import { InvalidTxError } from "polkadot-api"
+import { describe, expect, it, vi } from "vitest"
+import { AsyncBulletinClient } from "../../src/async-client"
+
+// The node's fork-aware pool can silently lose a broadcast tx around a
+// reorg; PAPI reports it as InvalidTxError/AncientBirthBlock once the
+// 64-block era boundary finalizes. The SDK must re-sign and resubmit once
+// (safe: the expired signature can never be included), and must NOT retry
+// other invalid types.
+
+interface Observer {
+  next: (ev: unknown) => void
+  error: (err: unknown) => void
+  complete?: () => void
+}
+
+const signer = {
+  publicKey: new Uint8Array(32),
+  sign: async () => new Uint8Array(64),
+}
+
+const submitFn = async () => ({
+  ok: true,
+  block: { hash: "0x02", number: 1, index: 0 },
+  txHash: "0x01",
+  events: [],
+})
+
+const invalidError = (type: string) =>
+  new InvalidTxError({ type: "Invalid", value: { type, value: undefined } })
+
+const setup = () => {
+  const observers: Observer[] = []
+  const makeTx = () => ({
+    signSubmitAndWatch: () => ({
+      subscribe: (obs: Observer) => {
+        observers.push(obs)
+        return { unsubscribe: () => {} }
+      },
+    }),
+    getBareTx: async () => new Uint8Array(),
+    decodedCall: {},
+    signAndSubmit: async () => ({ txHash: "0x01" }),
+  })
+  const api = {
+    tx: {
+      TransactionStorage: { store: makeTx, store_with_cid_config: makeTx },
+    },
+  }
+  const client = new AsyncBulletinClient(
+    // biome-ignore lint/suspicious/noExplicitAny: testing with mock objects
+    api as any,
+    // biome-ignore lint/suspicious/noExplicitAny: testing with mock objects
+    signer as any,
+    submitFn,
+  )
+  return { observers, client }
+}
+
+describe("mortality era expiry retry", () => {
+  it("re-signs and resubmits once on AncientBirthBlock, then resolves", async () => {
+    const { observers, client } = setup()
+
+    const pending = client.storeWithOptions(new Uint8Array([1, 2, 3]), {
+      waitFor: "in_block",
+    })
+
+    await vi.waitFor(() => expect(observers).toHaveLength(1))
+    observers[0].error(invalidError("AncientBirthBlock"))
+
+    // The retry re-invokes the full sign-submit-watch cycle
+    await vi.waitFor(() => expect(observers).toHaveLength(2))
+    observers[1].next({
+      txHash: "0x01",
+      type: "txBestBlocksState",
+      found: true,
+      block: { hash: "0xbe57", number: 10, index: 0 },
+    })
+
+    const result = await pending
+    expect(result.cid).toBeDefined()
+    expect(observers).toHaveLength(2)
+
+    // Release the background finalization watch
+    observers[1].next({
+      type: "finalized",
+      block: { hash: "0xf1a1", number: 10, index: 0 },
+    })
+  })
+
+  it("does not retry other invalid types (BadSigner)", async () => {
+    const { observers, client } = setup()
+
+    const pending = client.storeWithOptions(new Uint8Array([1, 2, 3]), {
+      waitFor: "in_block",
+    })
+
+    await vi.waitFor(() => expect(observers).toHaveLength(1))
+    observers[0].error(invalidError("BadSigner"))
+
+    await expect(pending).rejects.toThrow("BadSigner")
+    // Give a hypothetical retry a chance to subscribe before asserting
+    await new Promise((r) => setTimeout(r, 0))
+    expect(observers).toHaveLength(1)
+  })
+})

--- a/sdk/typescript/test/unit/era-expiry-retry.test.ts
+++ b/sdk/typescript/test/unit/era-expiry-retry.test.ts
@@ -5,11 +5,8 @@ import { InvalidTxError } from "polkadot-api"
 import { describe, expect, it, vi } from "vitest"
 import { AsyncBulletinClient } from "../../src/async-client"
 
-// The node's fork-aware pool can silently lose a broadcast tx around a
-// reorg; PAPI reports it as InvalidTxError/AncientBirthBlock once the
-// 64-block era boundary finalizes. The SDK must re-sign and resubmit once
-// (safe: the expired signature can never be included), and must NOT retry
-// other invalid types.
+// Era expiry is the only invalid outcome that is safe to retry (the
+// expired signature can never be included); nothing else may be.
 
 interface Observer {
   next: (ev: unknown) => void
@@ -71,7 +68,6 @@ describe("mortality era expiry retry", () => {
     await vi.waitFor(() => expect(observers).toHaveLength(1))
     observers[0].error(invalidError("AncientBirthBlock"))
 
-    // The retry re-invokes the full sign-submit-watch cycle
     await vi.waitFor(() => expect(observers).toHaveLength(2))
     observers[1].next({
       txHash: "0x01",


### PR DESCRIPTION
The txpool can silently drop a broadcast transaction around a reorg and PAPI only reports it as InvalidTxError/AncientBirthBlock once the 64-block era boundary finalizes, at which point the original signature can never be included, so the SDK now re-signs and resubmits once (fresh mortality anchor and nonce) instead of failing the store.