### PR TITLE
sdk: retry preimage-auth store once on Invalid/Payment

### DIFF
--- a/sdk/typescript/src/async-client.ts
+++ b/sdk/typescript/src/async-client.ts
@@ -254,6 +254,15 @@ function isAncientBirthBlockError(err: unknown): boolean {
   return e?.type === "Invalid" && e?.value?.type === "AncientBirthBlock"
 }
 
+// Same shape-matching as isAncientBirthBlockError; only Invalid/Payment
+// is safe to retry here (see storeWithPreimageAuth).
+function isPaymentInvalidError(err: unknown): boolean {
+  if (!(err instanceof Error) || err.name !== "InvalidTxError") return false
+  const e = (err as { error?: { type?: unknown; value?: { type?: unknown } } })
+    .error
+  return e?.type === "Invalid" && e?.value?.type === "Payment"
+}
+
 /**
  * Map a raw PAPI transaction status event to SDK progress events.
  *
@@ -1499,7 +1508,20 @@ export class AsyncBulletinClient implements BulletinClientInterface {
     try {
       const tx = this.createStoreTx(data, cidCodec, hashAlgorithm)
       const bareTx = await tx.getBareTx()
-      const finalized = await this.submit(bareTx)
+      let finalized: Awaited<ReturnType<SubmitFn>>
+      try {
+        finalized = await this.submit(bareTx)
+      } catch (err) {
+        // Payment here means "no authorization", which is transient when
+        // the authorization was reorg-retracted and re-included: PAPI
+        // validated the tx on the retracted fork, settled it as invalid
+        // and never re-checks, so the first submit cannot self-recover.
+        // Unlike the era-expiry retry, the original tx could still land,
+        // but resubmitting the identical bare bytes keeps the same tx
+        // hash, so inclusion stays idempotent.
+        if (!isPaymentInvalidError(err)) throw err
+        finalized = await this.submit(bareTx)
+      }
 
       if (!finalized.ok) {
         throw new BulletinError(

--- a/sdk/typescript/test/integration/client.test.ts
+++ b/sdk/typescript/test/integration/client.test.ts
@@ -490,9 +490,11 @@ describe("AsyncBulletinClient Integration Tests", {
       )
       const contentHash = blake2b256(data)
 
-      // Authorize the preimage first
+      // Authorize the preimage first. Wait for finality so the unsigned
+      // store below cannot validate on a fork that lacks the authorization.
       await authorizer
         .authorizePreimage(contentHash, BigInt(data.length))
+        .withWaitFor("finalized")
         .send()
 
       // Store with preimage auth (unsigned transaction)

--- a/sdk/typescript/test/unit/preimage-payment-retry.test.ts
+++ b/sdk/typescript/test/unit/preimage-payment-retry.test.ts
@@ -1,0 +1,70 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import { InvalidTxError } from "polkadot-api"
+import { describe, expect, it, vi } from "vitest"
+import { AsyncBulletinClient, type SubmitFn } from "../../src/async-client"
+
+// A reorg can retract a fresh preimage authorization; PAPI then settles
+// the pending bare store as Invalid/Payment and never re-checks, even
+// though the authorization is re-included. Only that exact shape may be
+// retried; every other invalid type must surface.
+
+const signer = {
+  publicKey: new Uint8Array(32),
+  sign: async () => new Uint8Array(64),
+}
+
+const invalidError = (type: string) =>
+  new InvalidTxError({ type: "Invalid", value: { type, value: undefined } })
+
+const submitSuccess = {
+  ok: true,
+  block: { hash: "0x02", number: 1, index: 0 },
+  txHash: "0x01",
+  events: [],
+}
+
+const setup = (submit: SubmitFn) => {
+  const makeTx = () => ({
+    getBareTx: async () => new Uint8Array([1]),
+    decodedCall: {},
+  })
+  const api = {
+    tx: {
+      TransactionStorage: { store: makeTx, store_with_cid_config: makeTx },
+    },
+  }
+  return new AsyncBulletinClient(
+    // biome-ignore lint/suspicious/noExplicitAny: testing with mock objects
+    api as any,
+    // biome-ignore lint/suspicious/noExplicitAny: testing with mock objects
+    signer as any,
+    submit,
+  )
+}
+
+describe("preimage store Payment retry", () => {
+  it("resubmits once on Invalid/Payment, then resolves", async () => {
+    const submit = vi
+      .fn<SubmitFn>()
+      .mockRejectedValueOnce(invalidError("Payment"))
+      .mockResolvedValueOnce(submitSuccess)
+    const client = setup(submit)
+
+    const result = await client.storeWithPreimageAuth(new Uint8Array([1, 2, 3]))
+
+    expect(result.cid).toBeDefined()
+    expect(submit).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not retry other invalid types (Future)", async () => {
+    const submit = vi.fn<SubmitFn>().mockRejectedValue(invalidError("Future"))
+    const client = setup(submit)
+
+    await expect(
+      client.storeWithPreimageAuth(new Uint8Array([1, 2, 3])),
+    ).rejects.toThrow("Future")
+    expect(submit).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Retries the unsigned preimage-authorized store once when polkadot-api settles it as Invalid/Payment after a reorg retracts the just-created authorization, and waits for finality on the authorization in the preimage-store integration test.