### PR TITLE
Use wss://bullet.tunastaking.eu as primary Products Devnet endpoint

### DIFF
--- a/console-ui/.papi/polkadot-api.json
+++ b/console-ui/.papi/polkadot-api.json
@@ -27,7 +27,7 @@
       "codeHash": "0xbf2cd56d20198f00ab6f38d7e77f15a9d5671d47beb5d456012ed45d23572045"
     },
     "bulletin_products_devnet": {
-      "wsUrl": "wss://bullet.sik.rocks",
+      "wsUrl": "wss://bullet.tunastaking.eu",
       "metadata": ".papi/metadata/bulletin_products_devnet.scale",
       "genesis": "0xe101f0fa4627d29a257645e02be86d80378fea1a2bf8fa6a918d150ebc760a59",
       "codeHash": "0x919b08470811f08edef7c2d15d387182adf5b501c2a2c8486c5b829a2c78018b"

--- a/console-ui/README.md
+++ b/console-ui/README.md
@@ -80,7 +80,7 @@ Select "Bulletin Polkadot" from the network dropdown. The UI connects to `wss://
 
 ### Paseo Testnet
 
-Select "Products Devnet" from the network dropdown. The UI connects to `wss://bullet.sik.rocks`.
+Select "Products Devnet" from the network dropdown. The UI connects to `wss://bullet.tunastaking.eu`.
 
 ## IPFS Gateway
 

--- a/console-ui/src/config/networks.ts
+++ b/console-ui/src/config/networks.ts
@@ -203,7 +203,7 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
   "products-devnet": {
     id: "products-devnet",
     name: "Products Devnet",
-    endpoints: ["wss://bullet.sik.rocks"],
+    endpoints: ["wss://bullet.tunastaking.eu", "wss://bullet.sik.rocks"],
     lightClient: false,
     descriptor: bulletin_products_devnet,
     peerMultiaddrs: [
@@ -218,7 +218,7 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
       sentryChunkUploadSpan: SENTRY_CHUNK_UPLOAD_SPAN,
       sentryChainProbeSpan: SENTRY_CHAIN_PROBE_SPAN,
       telemetry: TELEMETRY_POLKADOT,
-      polkadotJs: polkadotJsAppsLink("wss://bullet.sik.rocks"),
+      polkadotJs: polkadotJsAppsLink("wss://bullet.tunastaking.eu"),
     },
     hopNodes: [
       "wss://bullet.sik.rocks",

--- a/console-ui/src/config/networks.ts
+++ b/console-ui/src/config/networks.ts
@@ -25,8 +25,6 @@ export interface MonitoringLinks {
   sentryChainProbeSpan?: string;
   /** Substrate telemetry view. */
   telemetry?: string;
-  /** PolkadotJS Apps deep-link. */
-  polkadotJs?: string;
   /** Block explorer (Subscan etc.). */
   explorer?: string;
   /** Operational runbook. */
@@ -123,7 +121,7 @@ function bitswapLink(chain: string): string {
   );
 }
 
-function polkadotJsAppsLink(endpoint: string): string {
+export function polkadotJsAppsLink(endpoint: string): string {
   return `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(endpoint)}`;
 }
 
@@ -173,9 +171,7 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
       "/ip4/127.0.0.1/tcp/10001/ws/p2p/12D3KooWKjTeRJH8nMcFytc7qTTCQy7JrFgiZFr7iUjd1aPEBn8v",
       "/ip4/127.0.0.1/tcp/12347/ws/p2p/12D3KooWM8qgmWsh9ddbdX3kqR7W8tWuh62zhsdpwfs81eSnQuaH",
     ],
-    monitoring: {
-      polkadotJs: polkadotJsAppsLink("ws://localhost:10000"),
-    },
+    monitoring: {},
   },
   westend: {
     id: "westend",
@@ -197,7 +193,6 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
       sentryChunkUploadSpan: SENTRY_CHUNK_UPLOAD_SPAN,
       sentryChainProbeSpan: SENTRY_CHAIN_PROBE_SPAN,
       telemetry: TELEMETRY_POLKADOT,
-      polkadotJs: polkadotJsAppsLink("wss://westend-bulletin-rpc.polkadot.io"),
     },
   },
   "products-devnet": {
@@ -218,7 +213,6 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
       sentryChunkUploadSpan: SENTRY_CHUNK_UPLOAD_SPAN,
       sentryChainProbeSpan: SENTRY_CHAIN_PROBE_SPAN,
       telemetry: TELEMETRY_POLKADOT,
-      polkadotJs: polkadotJsAppsLink("wss://bullet.tunastaking.eu"),
     },
     hopNodes: [
       "wss://bullet.sik.rocks",
@@ -251,7 +245,6 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
       sentryChunkUploadSpan: SENTRY_CHUNK_UPLOAD_SPAN,
       sentryChainProbeSpan: SENTRY_CHAIN_PROBE_SPAN,
       telemetry: TELEMETRY_PASEO_NEXT_V2,
-      polkadotJs: polkadotJsAppsLink("wss://paseo-bulletin-next-rpc.polkadot.io"),
       collatorLogs: lokiLogsLink("bulletin-next-paseo"),
     },
     hopNodes: [
@@ -268,7 +261,6 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
     ipfsGateway: "https://previewnet.substrate.dev",
     preferredDownloadMethod: "gateway",
     monitoring: {
-      polkadotJs: polkadotJsAppsLink("wss://previewnet.substrate.dev/bulletin"),
     },
     hopNodes: [
       "wss://previewnet.substrate.dev/bulletin-hop-0",
@@ -289,7 +281,6 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
       sentryChunkUploadSpan: SENTRY_CHUNK_UPLOAD_SPAN,
       sentryChainProbeSpan: SENTRY_CHAIN_PROBE_SPAN,
       telemetry: TELEMETRY_POLKADOT,
-      polkadotJs: polkadotJsAppsLink("wss://bulletin-rpc.polkadot.io"),
     },
   },
   custom: {
@@ -298,6 +289,7 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
     endpoints: [],
     lightClient: false,
     descriptor: bulletin_paseo_next_v2,
+    monitoring: {},
   },
 };
 

--- a/console-ui/src/pages/Ops/Ops.tsx
+++ b/console-ui/src/pages/Ops/Ops.tsx
@@ -2,7 +2,7 @@ import { Activity, BarChart3, BookOpen, ExternalLink, Globe, LineChart, Network,
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { useChainState } from "@/state/chain.state";
-import type { MonitoringLinks } from "@/config/networks";
+import { type MonitoringLinks, polkadotJsAppsLink } from "@/config/networks";
 
 type LinkSpec = {
   label: string;
@@ -14,7 +14,7 @@ type LinkSpec = {
 type Subgroup = { title: string; items: LinkSpec[] };
 type Group    = { title: string; items?: LinkSpec[]; subgroups?: Subgroup[] };
 
-function group(monitoring: MonitoringLinks | undefined): Group[] {
+function group(monitoring: MonitoringLinks | undefined, endpoint: string | undefined): Group[] {
   if (!monitoring) return [];
 
   const chainHealth: LinkSpec[] = [];
@@ -50,10 +50,10 @@ function group(monitoring: MonitoringLinks | undefined): Group[] {
       description: "Live list of every node running this chain (version, block height, peers).",
     });
   }
-  if (monitoring.polkadotJs) {
+  if (endpoint) {
     chainHealth.push({
       label: "PolkadotJS Apps",
-      href: monitoring.polkadotJs,
+      href: polkadotJsAppsLink(endpoint),
       icon: ExternalLink,
       description: "Inspect chain state and events.",
     });
@@ -165,7 +165,7 @@ function LinkGrid({ items }: { items: LinkSpec[] }) {
 
 export function Ops() {
   const { network } = useChainState();
-  const groups = group(network?.monitoring);
+  const groups = group(network?.monitoring, network?.endpoints[0]);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
- Make `wss://bullet.tunastaking.eu` the primary Products Devnet RPC endpoint, keeping `wss://bullet.sik.rocks` as a fallback in `endpoints`; update the papi config and README accordingly.
- Derive the PolkadotJS Apps link on the Ops page from the actually selected endpoint (`network.endpoints[0]`, so custom URLs and overrides are reflected) instead of per-network hardcoded links. The `custom` network now also shows the link once an endpoint is set.