### PR TITLE
Extract the split-independent changes from #571

### DIFF
--- a/.github/workflows/zombienet-tests.yml
+++ b/.github/workflows/zombienet-tests.yml
@@ -126,7 +126,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zombienet-auto-renew-test-logs-${{ matrix.runtime.name }}-${{ matrix.group }}
-          path: /tmp/zombie-*/**/*.log
+          path: |
+            /tmp/zombie-*/**/*.log
+            !/tmp/zombie-*/**/db/**/*.log
           retention-days: 14
 
   zombienet-sync-tests:
@@ -186,7 +188,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zombienet-sync-test-logs-bulletin-${{ matrix.runtime.name }}
-          path: /tmp/zombie-*/**/*.log
+          path: |
+            /tmp/zombie-*/**/*.log
+            !/tmp/zombie-*/**/db/**/*.log
           retention-days: 14
 
   zombienet-hop-tests:
@@ -240,7 +244,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zombienet-hop-test-logs-bulletin-${{ matrix.runtime.name }}
-          path: /tmp/zombie-*/**/*.log
+          path: |
+            /tmp/zombie-*/**/*.log
+            !/tmp/zombie-*/**/db/**/*.log
           retention-days: 14
 
   zombienet-tests-complete:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,6 +2164,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io",
+ "sp-runtime",
  "sp-transaction-storage-proof",
  "tracing",
 ]

--- a/pallets/hop-promotion/src/lib.rs
+++ b/pallets/hop-promotion/src/lib.rs
@@ -94,6 +94,7 @@ pub mod pallet {
 		type WeightInfo: crate::WeightInfo;
 
 		/// Pool params for `promote`. `integrity_test` enforces its priority below `store`'s.
+		#[pallet::constant]
 		type PromoteTxParams: Get<ValidTransactionParams>;
 	}
 

--- a/pallets/hop-promotion/src/lib.rs
+++ b/pallets/hop-promotion/src/lib.rs
@@ -70,9 +70,7 @@ pub mod pallet {
 	};
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
-	use pallet_bulletin_transaction_storage::{
-		Config as TxStorageConfig, WeightInfo as _, BAD_DATA_SIZE,
-	};
+	use pallet_bulletin_transaction_storage::{WeightInfo as _, BAD_DATA_SIZE};
 	use sp_runtime::{
 		traits::{IdentifyAccount, Verify},
 		AccountId32, MultiSignature, MultiSigner,
@@ -104,7 +102,7 @@ pub mod pallet {
 		fn integrity_test() {
 			// Promotion must not outbid the `store` traffic it shares blockspace with.
 			let promote = T::PromoteTxParams::get().priority;
-			let store = <T as TxStorageConfig>::StoreTxParams::get().priority;
+			let store = T::StoreTxParams::get().priority;
 			assert!(
 				promote < store,
 				"promote priority ({promote}) must be strictly below store priority ({store})",

--- a/pallets/hop-promotion/src/lib.rs
+++ b/pallets/hop-promotion/src/lib.rs
@@ -70,7 +70,9 @@ pub mod pallet {
 	};
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
-	use pallet_bulletin_transaction_storage::{WeightInfo as _, BAD_DATA_SIZE};
+	use pallet_bulletin_transaction_storage::{
+		Config as TxStorageConfig, WeightInfo as _, BAD_DATA_SIZE,
+	};
 	use sp_runtime::{
 		traits::{IdentifyAccount, Verify},
 		AccountId32, MultiSignature, MultiSigner,
@@ -93,9 +95,7 @@ pub mod pallet {
 		/// Weight information for this pallet.
 		type WeightInfo: crate::WeightInfo;
 
-		/// Pool params for `promote`. Its priority must stay below the `store` priority —
-		/// promotion only fills otherwise-unused blockspace — which `integrity_test`
-		/// enforces.
+		/// Pool params for `promote`. `integrity_test` enforces its priority below `store`'s.
 		type PromoteTxParams: Get<ValidTransactionParams>;
 	}
 
@@ -104,16 +104,14 @@ pub mod pallet {
 		fn integrity_test() {
 			// Promotion must not outbid the `store` traffic it shares blockspace with.
 			let promote = T::PromoteTxParams::get().priority;
-			let store =
-				<T as pallet_bulletin_transaction_storage::Config>::StoreTxParams::get().priority;
+			let store = <T as TxStorageConfig>::StoreTxParams::get().priority;
 			assert!(
 				promote < store,
 				"promote priority ({promote}) must be strictly below store priority ({store})",
 			);
 
-			// `promote` tags on the bare data hash, as do preimage `store` and the
-			// preimage-authorization cleanup.
-			pallet_bulletin_transaction_storage::Pallet::<T>::assert_tag_prefixes_distinct(&[(
+			// `promote` tags on the bare data hash, as do preimage `store` and cleanup.
+			pallet_bulletin_transaction_storage::Pallet::<T>::assert_pool_families_distinct(&[(
 				"PromoteTxParams",
 				T::PromoteTxParams::get(),
 			)]);
@@ -192,9 +190,8 @@ pub mod pallet {
 			}
 
 			Ok((
-				// `propagate: false` is a property of the call, not a runtime knob:
-				// `promote` is rejected for `TransactionSource::External`, so gossiping it
-				// is pointless.
+				// Not a runtime knob: `promote` is rejected for `TransactionSource::External`,
+				// so gossiping it is pointless.
 				ValidTransaction {
 					propagate: false,
 					..T::PromoteTxParams::get().provides(data_hash)

--- a/pallets/hop-promotion/src/lib.rs
+++ b/pallets/hop-promotion/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! Promotes near-expiry HOP pool data to permanent chain storage via
 //! `pallet-transaction-storage`. Uses general transactions with
-//! `#[pallet::authorize]` — no signature, no fees, priority 0, and no
+//! `#[pallet::authorize]` — no signature, no fees, lowest priority, and no
 //! debit of the submitter's Bulletin allowance: promotion only lands in
 //! blockspace that would otherwise be unused, so charging the user
 //! would just leave that space empty for no benefit.
@@ -66,11 +66,11 @@ pub mod pallet {
 	use alloc::vec::Vec;
 	use bulletin_transaction_storage_primitives::{
 		cids::{HashingAlgorithm, RAW_CODEC},
-		ContentHash,
+		ContentHash, ValidTransactionParams,
 	};
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
-	use pallet_bulletin_transaction_storage::WeightInfo as _;
+	use pallet_bulletin_transaction_storage::{WeightInfo as _, BAD_DATA_SIZE};
 	use sp_runtime::{
 		traits::{IdentifyAccount, Verify},
 		AccountId32, MultiSignature, MultiSigner,
@@ -92,6 +92,32 @@ pub mod pallet {
 
 		/// Weight information for this pallet.
 		type WeightInfo: crate::WeightInfo;
+
+		/// Pool params for `promote`. Its priority must stay below the `store` priority —
+		/// promotion only fills otherwise-unused blockspace — which `integrity_test`
+		/// enforces.
+		type PromoteTxParams: Get<ValidTransactionParams>;
+	}
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn integrity_test() {
+			// Promotion must not outbid the `store` traffic it shares blockspace with.
+			let promote = T::PromoteTxParams::get().priority;
+			let store =
+				<T as pallet_bulletin_transaction_storage::Config>::StoreTxParams::get().priority;
+			assert!(
+				promote < store,
+				"promote priority ({promote}) must be strictly below store priority ({store})",
+			);
+
+			// `promote` tags on the bare data hash, as do preimage `store` and the
+			// preimage-authorization cleanup.
+			pallet_bulletin_transaction_storage::Pallet::<T>::assert_tag_prefixes_distinct(&[(
+				"PromoteTxParams",
+				T::PromoteTxParams::get(),
+			)]);
+		}
 	}
 
 	impl<T: Config> Pallet<T> {
@@ -135,7 +161,7 @@ pub mod pallet {
 				return Err(InvalidTransaction::Call.into());
 			}
 			if !pallet_bulletin_transaction_storage::Pallet::<T>::data_size_ok(data.len()) {
-				return Err(InvalidTransaction::Custom(0).into());
+				return Err(BAD_DATA_SIZE.into());
 			}
 
 			// Mirrors the early-out in pallet_bulletin_transaction_storage so we don't pay for
@@ -166,13 +192,13 @@ pub mod pallet {
 			}
 
 			Ok((
-				ValidTransaction::with_tag_prefix("HopPromotion")
-					.priority(0)
-					.longevity(5)
-					.propagate(false)
-					.and_provides(data_hash)
-					.build()
-					.expect("builder always succeeds; qed"),
+				// `propagate: false` is a property of the call, not a runtime knob:
+				// `promote` is rejected for `TransactionSource::External`, so gossiping it
+				// is pointless.
+				ValidTransaction {
+					propagate: false,
+					..T::PromoteTxParams::get().provides(data_hash)
+				},
 				Weight::zero(),
 			))
 		}

--- a/pallets/hop-promotion/src/mock.rs
+++ b/pallets/hop-promotion/src/mock.rs
@@ -82,7 +82,7 @@ parameter_types! {
 		ValidTransactionParams::new("Store", TransactionPriority::MAX, 10);
 	pub const PromoteTxParams: ValidTransactionParams =
 		ValidTransactionParams::new("HopPromotion", 0, 5);
-	// Never exercised here; only their prefixes matter, which `integrity_test` checks.
+	// Never exercised; only their prefixes matter, for `integrity_test`.
 	pub const RenewTxParams: ValidTransactionParams =
 		ValidTransactionParams::new("Renew", TransactionPriority::MAX, 10);
 	pub const AuthorizeTxParams: ValidTransactionParams =

--- a/pallets/hop-promotion/src/mock.rs
+++ b/pallets/hop-promotion/src/mock.rs
@@ -28,6 +28,9 @@ use sp_runtime::{traits::IdentityLookup, AccountId32};
 
 type Block = MockBlock<Test>;
 
+const PRIORITY: TransactionPriority = TransactionPriority::MAX;
+const LONGEVITY: TransactionLongevity = 10;
+
 #[frame_support::runtime]
 mod runtime {
 	#[runtime::runtime]
@@ -79,20 +82,20 @@ parameter_types! {
 	pub const AuthorizationPeriod: BlockNumberFor<Test> = 10;
 	// `static` so a test can lower the priority and check `integrity_test` rejects it.
 	pub static StoreTxParams: ValidTransactionParams =
-		ValidTransactionParams::new("Store", TransactionPriority::MAX, 10);
+		ValidTransactionParams::new("Store", PRIORITY, LONGEVITY);
 	pub const PromoteTxParams: ValidTransactionParams =
 		ValidTransactionParams::new("HopPromotion", 0, 5);
 	// Never exercised; only their prefixes matter, for `integrity_test`.
 	pub const RenewTxParams: ValidTransactionParams =
-		ValidTransactionParams::new("Renew", TransactionPriority::MAX, 10);
+		ValidTransactionParams::new("Renew", PRIORITY, LONGEVITY);
 	pub const AuthorizeTxParams: ValidTransactionParams =
-		ValidTransactionParams::new("Authorize", TransactionPriority::MAX, 10);
+		ValidTransactionParams::new("Authorize", PRIORITY, LONGEVITY);
 	pub const RemoveExpiredAccountAuthorizationTxParams: ValidTransactionParams =
-		ValidTransactionParams::new("ExpiredAccountAuth", TransactionPriority::MAX, 10);
+		ValidTransactionParams::new("ExpiredAccountAuth", PRIORITY, LONGEVITY);
 	pub const RemoveExpiredPreimageAuthorizationTxParams: ValidTransactionParams =
-		ValidTransactionParams::new("ExpiredPreimageAuth", TransactionPriority::MAX, 10);
+		ValidTransactionParams::new("ExpiredPreimageAuth", PRIORITY, LONGEVITY);
 	pub const RemoveExhaustedAuthorizerTxParams: ValidTransactionParams =
-		ValidTransactionParams::new("ExhaustedAuthorizer", TransactionPriority::MAX, 10);
+		ValidTransactionParams::new("ExhaustedAuthorizer", PRIORITY, LONGEVITY);
 }
 
 /// Use a small max transaction size for test efficiency.

--- a/pallets/hop-promotion/src/mock.rs
+++ b/pallets/hop-promotion/src/mock.rs
@@ -17,7 +17,7 @@
 
 use crate as pallet_bulletin_hop_promotion;
 use bulletin_pallets_common::NoCurrency;
-use pallet_bulletin_transaction_storage::AsAuthorizer;
+use pallet_bulletin_transaction_storage::{AsAuthorizer, ValidTransactionParams};
 use polkadot_sdk_frame::{
 	deps::{frame_support, frame_system},
 	prelude::*,
@@ -77,10 +77,22 @@ impl pallet_timestamp::Config for Test {
 
 parameter_types! {
 	pub const AuthorizationPeriod: BlockNumberFor<Test> = 10;
-	pub const StoreRenewPriority: TransactionPriority = TransactionPriority::MAX;
-	pub const StoreRenewLongevity: TransactionLongevity = 10;
-	pub const RemoveExpiredAuthorizationPriority: TransactionPriority = TransactionPriority::MAX;
-	pub const RemoveExpiredAuthorizationLongevity: TransactionLongevity = 10;
+	// `static` so a test can lower the priority and check `integrity_test` rejects it.
+	pub static StoreTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("Store", TransactionPriority::MAX, 10);
+	pub const PromoteTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("HopPromotion", 0, 5);
+	// Never exercised here; only their prefixes matter, which `integrity_test` checks.
+	pub const RenewTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("Renew", TransactionPriority::MAX, 10);
+	pub const AuthorizeTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("Authorize", TransactionPriority::MAX, 10);
+	pub const RemoveExpiredAccountAuthorizationTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("ExpiredAccountAuth", TransactionPriority::MAX, 10);
+	pub const RemoveExpiredPreimageAuthorizationTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("ExpiredPreimageAuth", TransactionPriority::MAX, 10);
+	pub const RemoveExhaustedAuthorizerTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("ExhaustedAuthorizer", TransactionPriority::MAX, 10);
 }
 
 /// Use a small max transaction size for test efficiency.
@@ -107,10 +119,12 @@ impl pallet_bulletin_transaction_storage::Config for Test {
 	type AuthorizerRegistrarOrigin = EnsureRoot<Self::AccountId>;
 	type Authorizer =
 		AsAuthorizer<EnsureRoot<Self::AccountId>, Self::AccountId, BlockNumberFor<Self>>;
-	type StoreRenewPriority = StoreRenewPriority;
-	type StoreRenewLongevity = StoreRenewLongevity;
-	type RemoveExpiredAuthorizationPriority = RemoveExpiredAuthorizationPriority;
-	type RemoveExpiredAuthorizationLongevity = RemoveExpiredAuthorizationLongevity;
+	type StoreTxParams = StoreTxParams;
+	type RenewTxParams = RenewTxParams;
+	type AuthorizeTxParams = AuthorizeTxParams;
+	type RemoveExpiredAccountAuthorizationTxParams = RemoveExpiredAccountAuthorizationTxParams;
+	type RemoveExpiredPreimageAuthorizationTxParams = RemoveExpiredPreimageAuthorizationTxParams;
+	type RemoveExhaustedAuthorizerTxParams = RemoveExhaustedAuthorizerTxParams;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper =
 		pallet_bulletin_transaction_storage::benchmarking::DefaultCheckProofHelper;
@@ -119,6 +133,7 @@ impl pallet_bulletin_transaction_storage::Config for Test {
 impl pallet_bulletin_hop_promotion::Config for Test {
 	type SubmitTimestampTolerance = SubmitTimestampTolerance;
 	type WeightInfo = ();
+	type PromoteTxParams = PromoteTxParams;
 }
 
 pub fn new_test_ext() -> TestExternalities {

--- a/pallets/hop-promotion/src/tests.rs
+++ b/pallets/hop-promotion/src/tests.rs
@@ -16,6 +16,7 @@
 //! Tests for hop-promotion pallet.
 
 use crate::{mock::*, signing_payload};
+use bulletin_transaction_storage_primitives::ValidTransactionParams;
 use codec::Encode;
 use frame_support::{assert_noop, assert_ok, traits::Authorize};
 use sp_io::hashing::blake2_256;
@@ -173,7 +174,7 @@ fn authorize_rejects_empty_data() {
 		let call = make_promote_call(vec![], signer, sig, TEST_TIMESTAMP_MS);
 		assert_eq!(
 			call.authorize(TransactionSource::Local),
-			Some(Err(InvalidTransaction::Custom(0).into())),
+			Some(Err(pallet_bulletin_transaction_storage::BAD_DATA_SIZE.into())),
 		);
 	});
 }
@@ -187,7 +188,7 @@ fn authorize_rejects_oversized_data() {
 		let call = make_promote_call(data, signer, sig, TEST_TIMESTAMP_MS);
 		assert_eq!(
 			call.authorize(TransactionSource::Local),
-			Some(Err(InvalidTransaction::Custom(0).into())),
+			Some(Err(pallet_bulletin_transaction_storage::BAD_DATA_SIZE.into())),
 		);
 	});
 }
@@ -404,74 +405,45 @@ fn authorize_valid_transaction_properties() {
 		let (signer, sig) = signed_by(Sr25519Keyring::Alice, &data, TEST_TIMESTAMP_MS);
 		let call = make_promote_call(data.clone(), signer, sig, TEST_TIMESTAMP_MS);
 		let (valid_tx, weight) = call.authorize(TransactionSource::Local).unwrap().unwrap();
-		assert_eq!(valid_tx.priority, 0);
-		assert_eq!(valid_tx.longevity, 5);
+		let params = PromoteTxParams::get();
+		assert_eq!(valid_tx.priority, params.priority);
+		assert_eq!(valid_tx.longevity, params.longevity);
 		assert!(!valid_tx.propagate);
 		assert_eq!(weight, frame_support::weights::Weight::zero());
 		let hash = sp_io::hashing::blake2_256(&data);
-		let expected_tag = ("HopPromotion", hash).encode();
+		let expected_tag = (params.tag_prefix, hash).encode();
 		assert!(valid_tx.provides.contains(&expected_tag));
 	});
 }
 
+/// `integrity_test` rejects a `store` priority at or below `promote`'s. The passing
+/// direction is covered by the `#[frame_support::runtime]`-generated integrity test, and
+/// the emitted priority by `authorize_valid_transaction_properties`.
 #[test]
-fn promote_has_lower_priority_than_store_and_renew() {
+#[should_panic(expected = "must be strictly below store priority")]
+fn integrity_test_rejects_promote_priority_at_or_above_store() {
+	use frame_support::traits::IntegrityTest;
+
 	new_test_ext().execute_with(|| {
-		set_now(TEST_TIMESTAMP_MS);
-		System::run_to_block::<AllPalletsWithSystem>(1);
-		frame_system::Pallet::<Test>::set_extrinsic_index(0);
+		StoreTxParams::set(ValidTransactionParams {
+			priority: PromoteTxParams::get().priority,
+			..StoreTxParams::get()
+		});
+		HopPromotion::integrity_test();
+	});
+}
 
-		// Authorize Alice for store + renew + promote.
-		let alice = Sr25519Keyring::Alice.to_account_id();
-		let data = vec![2u8; 100];
-		authorize_account(alice.clone(), 2, 2 * data.len() as u64);
+/// `integrity_test` rejects a `promote` prefix shared with a storage-pallet family.
+#[test]
+#[should_panic(expected = "PromoteTxParams and StoreTxParams must not share the tag prefix")]
+fn integrity_test_rejects_promote_prefix_shared_with_store() {
+	use frame_support::traits::IntegrityTest;
 
-		// Get promote priority.
-		let (signer, sig) = signed_by(Sr25519Keyring::Alice, &data, TEST_TIMESTAMP_MS);
-		let promote_call = make_promote_call(data.clone(), signer, sig, TEST_TIMESTAMP_MS);
-		let (promote_tx, _) = promote_call.authorize(TransactionSource::Local).unwrap().unwrap();
-
-		// Get store priority.
-		let store_call =
-			pallet_bulletin_transaction_storage::Call::<Test>::store { data: data.clone() };
-		let (store_tx, _) = pallet_bulletin_transaction_storage::Pallet::<Test>::validate_signed(
-			&alice,
-			&store_call,
-		)
-		.unwrap();
-
-		// Store data so we can renew it.
-		assert_ok!(pallet_bulletin_transaction_storage::Pallet::<Test>::store(
-			RuntimeOrigin::none(),
-			data,
-		));
-
-		// Advance so the stored transaction is available for renew.
-		run_to_block(3);
-
-		let renew_call = pallet_bulletin_transaction_storage::Call::<Test>::renew {
-			entry: pallet_bulletin_transaction_storage::TransactionRef::Position {
-				block: 1,
-				index: 0,
-			},
-		};
-		let (renew_tx, _) = pallet_bulletin_transaction_storage::Pallet::<Test>::validate_signed(
-			&alice,
-			&renew_call,
-		)
-		.unwrap();
-
-		assert!(
-			promote_tx.priority < store_tx.priority,
-			"promote priority ({}) must be strictly less than store priority ({})",
-			promote_tx.priority,
-			store_tx.priority,
-		);
-		assert!(
-			promote_tx.priority < renew_tx.priority,
-			"promote priority ({}) must be strictly less than renew priority ({})",
-			promote_tx.priority,
-			renew_tx.priority,
-		);
+	new_test_ext().execute_with(|| {
+		StoreTxParams::set(ValidTransactionParams {
+			tag_prefix: PromoteTxParams::get().tag_prefix,
+			..StoreTxParams::get()
+		});
+		HopPromotion::integrity_test();
 	});
 }

--- a/pallets/hop-promotion/src/tests.rs
+++ b/pallets/hop-promotion/src/tests.rs
@@ -416,9 +416,7 @@ fn authorize_valid_transaction_properties() {
 	});
 }
 
-/// `integrity_test` rejects a `store` priority at or below `promote`'s. The passing
-/// direction is covered by the `#[frame_support::runtime]`-generated integrity test, and
-/// the emitted priority by `authorize_valid_transaction_properties`.
+/// The passing direction is covered by the runtime-generated integrity test.
 #[test]
 #[should_panic(expected = "must be strictly below store priority")]
 fn integrity_test_rejects_promote_priority_at_or_above_store() {
@@ -433,7 +431,6 @@ fn integrity_test_rejects_promote_priority_at_or_above_store() {
 	});
 }
 
-/// `integrity_test` rejects a `promote` prefix shared with a storage-pallet family.
 #[test]
 #[should_panic(expected = "PromoteTxParams and StoreTxParams must not share the tag prefix")]
 fn integrity_test_rejects_promote_prefix_shared_with_store() {

--- a/pallets/hop-promotion/src/tests.rs
+++ b/pallets/hop-promotion/src/tests.rs
@@ -18,7 +18,10 @@
 use crate::{mock::*, signing_payload};
 use bulletin_transaction_storage_primitives::ValidTransactionParams;
 use codec::Encode;
-use frame_support::{assert_noop, assert_ok, traits::Authorize};
+use frame_support::{
+	assert_noop, assert_ok,
+	traits::{Authorize, IntegrityTest},
+};
 use sp_io::hashing::blake2_256;
 use sp_keyring::Sr25519Keyring;
 use sp_runtime::{
@@ -420,8 +423,6 @@ fn authorize_valid_transaction_properties() {
 #[test]
 #[should_panic(expected = "must be strictly below store priority")]
 fn integrity_test_rejects_promote_priority_at_or_above_store() {
-	use frame_support::traits::IntegrityTest;
-
 	new_test_ext().execute_with(|| {
 		StoreTxParams::set(ValidTransactionParams {
 			priority: PromoteTxParams::get().priority,
@@ -434,8 +435,6 @@ fn integrity_test_rejects_promote_priority_at_or_above_store() {
 #[test]
 #[should_panic(expected = "PromoteTxParams and StoreTxParams must not share the tag prefix")]
 fn integrity_test_rejects_promote_prefix_shared_with_store() {
-	use frame_support::traits::IntegrityTest;
-
 	new_test_ext().execute_with(|| {
 		StoreTxParams::set(ValidTransactionParams {
 			tag_prefix: PromoteTxParams::get().tag_prefix,

--- a/pallets/transaction-storage/primitives/Cargo.toml
+++ b/pallets/transaction-storage/primitives/Cargo.toml
@@ -17,6 +17,7 @@ cid = { features = ["alloc"], workspace = true }
 codec = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 sp-io = { workspace = true, default-features = false }
+sp-runtime = { workspace = true, default-features = false }
 sp-transaction-storage-proof = { workspace = true, default-features = false }
 tracing = { workspace = true }
 
@@ -27,6 +28,7 @@ std = [
 	"codec/std",
 	"scale-info/std",
 	"sp-io/std",
+	"sp-runtime/std",
 	"sp-transaction-storage-proof/std",
 	"tracing/std",
 ]

--- a/pallets/transaction-storage/primitives/src/lib.rs
+++ b/pallets/transaction-storage/primitives/src/lib.rs
@@ -32,7 +32,7 @@ pub type ContentHash = [u8; 32];
 
 /// A [`ValidTransaction`] minus its `provides` payload. Families that must not evict each
 /// other in the pool need distinct `tag_prefix`es.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Encode, TypeInfo)]
 pub struct ValidTransactionParams {
 	pub tag_prefix: &'static str,
 	pub priority: TransactionPriority,

--- a/pallets/transaction-storage/primitives/src/lib.rs
+++ b/pallets/transaction-storage/primitives/src/lib.rs
@@ -21,11 +21,67 @@ extern crate alloc;
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
+use sp_runtime::transaction_validity::{
+	TransactionLongevity, TransactionPriority, ValidTransaction,
+};
 
 pub mod cids;
 
 /// 32-byte hash of a stored blob of data.
 pub type ContentHash = [u8; 32];
+
+/// A [`ValidTransaction`] minus its `provides` payload.
+///
+/// Transactions sharing a `tag_prefix` *and* a `provides` tag conflict, so families that
+/// must not evict each other need distinct prefixes.
+#[derive(Clone, Copy)]
+pub struct ValidTransactionParams {
+	pub tag_prefix: &'static str,
+	pub priority: TransactionPriority,
+	pub longevity: TransactionLongevity,
+}
+
+impl ValidTransactionParams {
+	pub const fn new(
+		tag_prefix: &'static str,
+		priority: TransactionPriority,
+		longevity: TransactionLongevity,
+	) -> Self {
+		Self { tag_prefix, priority, longevity }
+	}
+
+	pub fn provides(self, provides: impl Encode) -> ValidTransaction {
+		ValidTransaction::with_tag_prefix(self.tag_prefix)
+			.and_provides(provides)
+			.priority(self.priority)
+			.longevity(self.longevity)
+			.into()
+	}
+
+	/// Pricing only, for calls with no dedup tag.
+	pub fn untagged(self) -> ValidTransaction {
+		ValidTransaction {
+			priority: self.priority,
+			longevity: self.longevity,
+			..Default::default()
+		}
+	}
+}
+
+/// Panics if any two of `params` share a `tag_prefix`. Each is named so the panic points at
+/// the runtime's mis-wiring.
+pub fn assert_distinct_tag_prefixes(params: &[(&str, ValidTransactionParams)]) {
+	for (i, (name, one)) in params.iter().enumerate() {
+		for (other_name, other) in params.iter().skip(i + 1) {
+			assert!(
+				one.tag_prefix != other.tag_prefix,
+				"{name} and {other_name} must not share the tag prefix `{}`: their pool tags \
+				 would dedup against each other",
+				one.tag_prefix,
+			);
+		}
+	}
+}
 
 /// Identifies a previously-stored entry in the pallet's `Transactions` map.
 #[derive(
@@ -53,5 +109,26 @@ impl<BlockNumber> From<(BlockNumber, u32)> for TransactionRef<BlockNumber> {
 impl<BlockNumber> From<ContentHash> for TransactionRef<BlockNumber> {
 	fn from(hash: ContentHash) -> Self {
 		Self::ContentHash(hash)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	const A: ValidTransactionParams = ValidTransactionParams::new("a", 1, 1);
+	const B: ValidTransactionParams = ValidTransactionParams::new("b", 2, 2);
+	// Same prefix as `A`, different pricing: pricing is irrelevant to deduping.
+	const A_AGAIN: ValidTransactionParams = ValidTransactionParams::new("a", 3, 3);
+
+	#[test]
+	fn distinct_tag_prefixes_pass() {
+		assert_distinct_tag_prefixes(&[("A", A), ("B", B)]);
+	}
+
+	#[test]
+	#[should_panic(expected = "A and A_AGAIN must not share the tag prefix `a`")]
+	fn shared_tag_prefix_panics() {
+		assert_distinct_tag_prefixes(&[("A", A), ("B", B), ("A_AGAIN", A_AGAIN)]);
 	}
 }

--- a/pallets/transaction-storage/primitives/src/lib.rs
+++ b/pallets/transaction-storage/primitives/src/lib.rs
@@ -30,10 +30,8 @@ pub mod cids;
 /// 32-byte hash of a stored blob of data.
 pub type ContentHash = [u8; 32];
 
-/// A [`ValidTransaction`] minus its `provides` payload.
-///
-/// Transactions sharing a `tag_prefix` *and* a `provides` tag conflict, so families that
-/// must not evict each other need distinct prefixes.
+/// A [`ValidTransaction`] minus its `provides` payload. Families that must not evict each
+/// other in the pool need distinct `tag_prefix`es.
 #[derive(Clone, Copy)]
 pub struct ValidTransactionParams {
 	pub tag_prefix: &'static str,
@@ -68,8 +66,7 @@ impl ValidTransactionParams {
 	}
 }
 
-/// Panics if any two of `params` share a `tag_prefix`. Each is named so the panic points at
-/// the runtime's mis-wiring.
+/// Panics if any two of `params` share a `tag_prefix`. Names are for the panic message.
 pub fn assert_distinct_tag_prefixes(params: &[(&str, ValidTransactionParams)]) {
 	for (i, (name, one)) in params.iter().enumerate() {
 		for (other_name, other) in params.iter().skip(i + 1) {
@@ -118,7 +115,7 @@ mod tests {
 
 	const A: ValidTransactionParams = ValidTransactionParams::new("a", 1, 1);
 	const B: ValidTransactionParams = ValidTransactionParams::new("b", 2, 2);
-	// Same prefix as `A`, different pricing: pricing is irrelevant to deduping.
+	// Same prefix, different pricing: only the prefix matters.
 	const A_AGAIN: ValidTransactionParams = ValidTransactionParams::new("a", 3, 3);
 
 	#[test]

--- a/pallets/transaction-storage/src/lib.rs
+++ b/pallets/transaction-storage/src/lib.rs
@@ -178,19 +178,25 @@ pub mod pallet {
 		>;
 		/// Pool params for signed and preimage-authorized `store`. One prefix is safe: they
 		/// tag on `(who, content_hash)` and `content_hash` respectively.
+		#[pallet::constant]
 		type StoreTxParams: Get<ValidTransactionParams>;
 		/// Pool params for `renew`, `force_renew` and `enable_auto_renew`. Separate from
 		/// `store` so the two do not dedup against each other.
+		#[pallet::constant]
 		type RenewTxParams: Get<ValidTransactionParams>;
 		/// Pool params for `authorize_*` and `refresh_*`, which validate untagged.
+		#[pallet::constant]
 		type AuthorizeTxParams: Get<ValidTransactionParams>;
 		/// Pool params for `remove_expired_account_authorization`. The three cleanup calls get
 		/// their own items because two provide `who` and a `ContentHash` encodes like an
 		/// `AccountId32`, so they need distinct prefixes despite shared pricing.
+		#[pallet::constant]
 		type RemoveExpiredAccountAuthorizationTxParams: Get<ValidTransactionParams>;
 		/// Pool params for `remove_expired_preimage_authorization`.
+		#[pallet::constant]
 		type RemoveExpiredPreimageAuthorizationTxParams: Get<ValidTransactionParams>;
 		/// Pool params for `remove_exhausted_authorizer`.
+		#[pallet::constant]
 		type RemoveExhaustedAuthorizerTxParams: Get<ValidTransactionParams>;
 		/// Benchmark helper — provides pre-computed proof matching this runtime's config.
 		/// Use [`DefaultCheckProofHelper`](crate::benchmarking::DefaultCheckProofHelper) for

--- a/pallets/transaction-storage/src/lib.rs
+++ b/pallets/transaction-storage/src/lib.rs
@@ -176,18 +176,23 @@ pub mod pallet {
 			Self::RuntimeOrigin,
 			Success = Option<AuthorizationOrigin<Self::AccountId, BlockNumberFor<Self>>>,
 		>;
-		/// Priority of store/renew transactions.
-		#[pallet::constant]
-		type StoreRenewPriority: Get<TransactionPriority>;
-		/// Longevity of store/renew transactions.
-		#[pallet::constant]
-		type StoreRenewLongevity: Get<TransactionLongevity>;
-		/// Priority of unsigned transactions to remove expired authorizations.
-		#[pallet::constant]
-		type RemoveExpiredAuthorizationPriority: Get<TransactionPriority>;
-		/// Longevity of unsigned transactions to remove expired authorizations.
-		#[pallet::constant]
-		type RemoveExpiredAuthorizationLongevity: Get<TransactionLongevity>;
+		/// Pool params for signed and preimage-authorized `store`. One prefix is safe
+		/// because they tag on `(who, content_hash)` and `content_hash` respectively.
+		type StoreTxParams: Get<ValidTransactionParams>;
+		/// Pool params for `renew`, `force_renew` and `enable_auto_renew`. Separate from
+		/// `store` so the two families neither share pricing nor dedup against each other.
+		type RenewTxParams: Get<ValidTransactionParams>;
+		/// Pool params for `authorize_*` and `refresh_*`.
+		type AuthorizeTxParams: Get<ValidTransactionParams>;
+		/// Pool params for `remove_expired_account_authorization`. Separate items for the
+		/// three cleanup calls because they share pricing but need distinct prefixes: two
+		/// provide `who`, and a `ContentHash` encodes like an `AccountId32`. Enforced by
+		/// `integrity_test`.
+		type RemoveExpiredAccountAuthorizationTxParams: Get<ValidTransactionParams>;
+		/// Pool params for `remove_expired_preimage_authorization`.
+		type RemoveExpiredPreimageAuthorizationTxParams: Get<ValidTransactionParams>;
+		/// Pool params for `remove_exhausted_authorizer`.
+		type RemoveExhaustedAuthorizerTxParams: Get<ValidTransactionParams>;
 		/// Benchmark helper — provides pre-computed proof matching this runtime's config.
 		/// Use [`DefaultCheckProofHelper`](crate::benchmarking::DefaultCheckProofHelper) for
 		/// [`DEFAULT_MAX_TRANSACTION_SIZE`] / [`DEFAULT_MAX_BLOCK_TRANSACTIONS`].
@@ -480,6 +485,7 @@ pub mod pallet {
 				!T::AuthorizationPeriod::get().is_zero(),
 				"AuthorizationPeriod must be greater than zero"
 			);
+			Self::assert_tag_prefixes_distinct(&[]);
 		}
 	}
 
@@ -2132,12 +2138,35 @@ pub mod pallet {
 			Ok(())
 		}
 
-		fn preimage_store_renew_valid_transaction(content_hash: ContentHash) -> ValidTransaction {
-			ValidTransaction::with_tag_prefix("TransactionStorageStoreRenew")
-				.and_provides(content_hash)
-				.priority(T::StoreRenewPriority::get())
-				.longevity(T::StoreRenewLongevity::get())
-				.into()
+		/// Panics unless this pallet's pool families and `extra` all use distinct tag
+		/// prefixes. `extra` lets dependent pallets fold their own families into the check.
+		pub fn assert_tag_prefixes_distinct(extra: &[(&'static str, ValidTransactionParams)]) {
+			let mut all = extra.to_vec();
+			all.extend([
+				("StoreTxParams", T::StoreTxParams::get()),
+				("RenewTxParams", T::RenewTxParams::get()),
+				(
+					"RemoveExpiredAccountAuthorizationTxParams",
+					T::RemoveExpiredAccountAuthorizationTxParams::get(),
+				),
+				(
+					"RemoveExpiredPreimageAuthorizationTxParams",
+					T::RemoveExpiredPreimageAuthorizationTxParams::get(),
+				),
+				("RemoveExhaustedAuthorizerTxParams", T::RemoveExhaustedAuthorizerTxParams::get()),
+			]);
+			assert_distinct_tag_prefixes(&all);
+		}
+
+		/// Pool params for the store/renew family `is_renew` selects. Distinct prefixes
+		/// keep a `store` and a `force_renew` of the same content hash from deduping
+		/// against each other in the pool.
+		fn store_renew_tx_params(is_renew: bool) -> ValidTransactionParams {
+			if is_renew {
+				T::RenewTxParams::get()
+			} else {
+				T::StoreTxParams::get()
+			}
 		}
 
 		fn check_store_renew_unsigned(
@@ -2165,7 +2194,7 @@ pub mod pallet {
 
 			Ok(context
 				.want_valid_transaction()
-				.then(|| Self::preimage_store_renew_valid_transaction(content_hash)))
+				.then(|| Self::store_renew_tx_params(is_renew).provides(content_hash)))
 		}
 
 		fn check_unsigned(
@@ -2200,42 +2229,24 @@ pub mod pallet {
 				Call::<T>::renew { .. } => Err(InvalidTransaction::Call.into()),
 				Call::<T>::remove_expired_account_authorization { who } => {
 					Self::check_authorization_expired(&AuthorizationScope::Account(who.clone()))?;
-					Ok(context.want_valid_transaction().then(|| {
-						ValidTransaction::with_tag_prefix(
-							"TransactionStorageRemoveExpiredAccountAuthorization",
-						)
-						.and_provides(who)
-						.priority(T::RemoveExpiredAuthorizationPriority::get())
-						.longevity(T::RemoveExpiredAuthorizationLongevity::get())
-						.into()
-					}))
+					Ok(context
+						.want_valid_transaction()
+						.then(|| T::RemoveExpiredAccountAuthorizationTxParams::get().provides(who)))
 				},
 				Call::<T>::remove_expired_preimage_authorization { content_hash } => {
 					Self::check_authorization_expired(&AuthorizationScope::Preimage(
 						*content_hash,
 					))?;
 					Ok(context.want_valid_transaction().then(|| {
-						ValidTransaction::with_tag_prefix(
-							"TransactionStorageRemoveExpiredPreimageAuthorization",
-						)
-						.and_provides(content_hash)
-						.priority(T::RemoveExpiredAuthorizationPriority::get())
-						.longevity(T::RemoveExpiredAuthorizationLongevity::get())
-						.into()
+						T::RemoveExpiredPreimageAuthorizationTxParams::get().provides(content_hash)
 					}))
 				},
 				Call::<T>::remove_exhausted_authorizer { who } => {
 					let budget = AllowedAuthorizers::<T>::get(who).ok_or(AUTHORIZER_NOT_FOUND)?;
 					ensure!(budget.is_inactive(Self::now()), AUTHORIZATION_NOT_EXHAUSTED);
-					Ok(context.want_valid_transaction().then(|| {
-						ValidTransaction::with_tag_prefix(
-							"TransactionStorageRemoveExhaustedAuthorizer",
-						)
-						.and_provides(who)
-						.priority(T::RemoveExpiredAuthorizationPriority::get())
-						.longevity(T::RemoveExpiredAuthorizationLongevity::get())
-						.into()
-					}))
+					Ok(context
+						.want_valid_transaction()
+						.then(|| T::RemoveExhaustedAuthorizerTxParams::get().provides(who)))
 				},
 				// Mandatory inherent — always allowed, no pool validation needed.
 				Call::<T>::apply_block_inherents { .. } => Ok(None),
@@ -2276,11 +2287,9 @@ pub mod pallet {
 					T::Authorizer::ensure_origin(origin)
 						.map_err(|_| InvalidTransaction::BadSigner)?;
 					return Ok((
-						context.want_valid_transaction().then(|| ValidTransaction {
-							priority: T::StoreRenewPriority::get(),
-							longevity: T::StoreRenewLongevity::get(),
-							..Default::default()
-						}),
+						context
+							.want_valid_transaction()
+							.then(|| T::AuthorizeTxParams::get().untagged()),
 						None,
 					));
 				},
@@ -2310,11 +2319,7 @@ pub mod pallet {
 					let scope = AuthorizationScope::Account(who.clone());
 					return Ok((
 						context.want_valid_transaction().then(|| {
-							ValidTransaction::with_tag_prefix("TransactionStorageRenew")
-								.and_provides((who.clone(), info.content_hash))
-								.priority(T::StoreRenewPriority::get())
-								.longevity(T::StoreRenewLongevity::get())
-								.into()
+							T::RenewTxParams::get().provides((who.clone(), info.content_hash))
 						}),
 						Some(scope),
 					));
@@ -2343,11 +2348,7 @@ pub mod pallet {
 					let scope = AuthorizationScope::Account(who.clone());
 					return Ok((
 						context.want_valid_transaction().then(|| {
-							ValidTransaction::with_tag_prefix("TransactionStorageRenew")
-								.and_provides((who.clone(), info.content_hash))
-								.priority(T::StoreRenewPriority::get())
-								.longevity(T::StoreRenewLongevity::get())
-								.into()
+							T::RenewTxParams::get().provides((who.clone(), info.content_hash))
 						}),
 						Some(scope),
 					));
@@ -2369,11 +2370,9 @@ pub mod pallet {
 					}
 					let scope = AuthorizationScope::Account(who.clone());
 					return Ok((
-						context.want_valid_transaction().then(|| ValidTransaction {
-							priority: T::StoreRenewPriority::get(),
-							longevity: T::StoreRenewLongevity::get(),
-							..Default::default()
-						}),
+						context
+							.want_valid_transaction()
+							.then(|| T::RenewTxParams::get().untagged()),
 						Some(scope),
 					));
 				},
@@ -2414,27 +2413,11 @@ pub mod pallet {
 			// execution. The tx tag/priority differs depending on whether preimage or account
 			// authorization was used.
 			let (valid_tx, scope) = if context.want_valid_transaction() {
+				let params = Self::store_renew_tx_params(is_renew);
 				let (valid_tx, scope) = if used_preimage_auth {
-					(
-						Self::preimage_store_renew_valid_transaction(content_hash),
-						AuthorizationScope::Preimage(content_hash),
-					)
+					(params.provides(content_hash), AuthorizationScope::Preimage(content_hash))
 				} else {
-					// Tag prefix differs per family so store and renew operations don't
-					// dedup against each other in the pool.
-					let prefix = if is_renew {
-						"TransactionStorageRenew"
-					} else {
-						"TransactionStorageStore"
-					};
-					(
-						ValidTransaction::with_tag_prefix(prefix)
-							.and_provides((who, content_hash))
-							.priority(T::StoreRenewPriority::get())
-							.longevity(T::StoreRenewLongevity::get())
-							.into(),
-						AuthorizationScope::Account(who.clone()),
-					)
+					(params.provides((who, content_hash)), AuthorizationScope::Account(who.clone()))
 				};
 				(Some(valid_tx), Some(scope))
 			} else {

--- a/pallets/transaction-storage/src/lib.rs
+++ b/pallets/transaction-storage/src/lib.rs
@@ -78,21 +78,6 @@ pub const DEFAULT_MAX_TRANSACTION_SIZE: u32 = 2 * 1024 * 1024;
 /// Default maximum number of indexed transactions in a block.
 pub const DEFAULT_MAX_BLOCK_TRANSACTIONS: u32 = 512;
 
-/// Pool tag prefixes for the [`Config`] families. Runtimes take these instead of
-/// hand-copying the strings; only the pricing beside them is a per-chain choice.
-pub const STORE_TAG_PREFIX: &str = "TransactionStorageStore";
-/// See [`STORE_TAG_PREFIX`].
-pub const RENEW_TAG_PREFIX: &str = "TransactionStorageRenew";
-/// See [`STORE_TAG_PREFIX`].
-pub const REMOVE_EXPIRED_ACCOUNT_AUTHORIZATION_TAG_PREFIX: &str =
-	"TransactionStorageRemoveExpiredAccountAuthorization";
-/// See [`STORE_TAG_PREFIX`].
-pub const REMOVE_EXPIRED_PREIMAGE_AUTHORIZATION_TAG_PREFIX: &str =
-	"TransactionStorageRemoveExpiredPreimageAuthorization";
-/// See [`STORE_TAG_PREFIX`].
-pub const REMOVE_EXHAUSTED_AUTHORIZER_TAG_PREFIX: &str =
-	"TransactionStorageRemoveExhaustedAuthorizer";
-
 /// Encountered an impossible situation, implies a bug.
 pub const IMPOSSIBLE: InvalidTransaction = InvalidTransaction::Custom(0);
 /// Data size is not in the allowed range.
@@ -197,7 +182,7 @@ pub mod pallet {
 		/// Pool params for `renew`, `force_renew` and `enable_auto_renew`. Separate from
 		/// `store` so the two do not dedup against each other.
 		type RenewTxParams: Get<ValidTransactionParams>;
-		/// Pool params for `authorize_*` and `refresh_*`. Untagged, so `tag_prefix` is unused.
+		/// Pool params for `authorize_*` and `refresh_*`, which validate untagged.
 		type AuthorizeTxParams: Get<ValidTransactionParams>;
 		/// Pool params for `remove_expired_account_authorization`. The three cleanup calls get
 		/// their own items because two provide `who` and a `ContentHash` encodes like an
@@ -2152,13 +2137,14 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Panics unless this pallet's tagged families and `extra` use distinct tag prefixes.
-		/// `extra` lets dependent pallets fold in their own. `AuthorizeTxParams` is untagged.
+		/// Panics unless this pallet's families and `extra` use distinct tag prefixes. `extra`
+		/// lets dependent pallets fold in their own.
 		pub fn assert_pool_families_distinct(extra: &[(&str, ValidTransactionParams)]) {
 			let mut all = extra.to_vec();
 			all.extend([
 				("StoreTxParams", T::StoreTxParams::get()),
 				("RenewTxParams", T::RenewTxParams::get()),
+				("AuthorizeTxParams", T::AuthorizeTxParams::get()),
 				(
 					"RemoveExpiredAccountAuthorizationTxParams",
 					T::RemoveExpiredAccountAuthorizationTxParams::get(),
@@ -2169,7 +2155,7 @@ pub mod pallet {
 				),
 				("RemoveExhaustedAuthorizerTxParams", T::RemoveExhaustedAuthorizerTxParams::get()),
 			]);
-			assert_distinct_tag_prefixes(&all);
+			bulletin_transaction_storage_primitives::assert_distinct_tag_prefixes(&all);
 		}
 
 		/// Keeps a `store` and a `force_renew` of the same content hash on separate pool
@@ -2636,10 +2622,12 @@ impl<T: Config> Pallet<T> {
 		let expected = renewed_sum.saturating_add(prepaid_sum);
 
 		// Live state drifts both ways through history this pallet did not create: pre-counter
-		// `Renew` entries were never charged, and Root dropping a prepaid registration never
-		// decrements. Erroring would fail the check-migration jobs on any such chain, so the
-		// equality holds only where state is built from nothing. The cap below is the bound
-		// that matters — `used` gates admission, so under-counting is the dangerous side.
+		// `Renew` entries were never charged (under-count), and Root dropping a prepaid
+		// registration never decrements (over-count). Erroring would fail the check-migration
+		// jobs on any such chain, so the equality holds only where state is built from nothing.
+		// Note the cap check below is not a backstop for the under-count: it compares the same
+		// `used` that drifted. Retiring the two causes — decrementing on the Root path, and a
+		// migration that recomputes `used` — is what would let this be unconditional.
 		if used != expected {
 			if cfg!(test) {
 				return Err(PERMANENT_USED_DRIFT.into());

--- a/pallets/transaction-storage/src/lib.rs
+++ b/pallets/transaction-storage/src/lib.rs
@@ -278,7 +278,7 @@ pub mod pallet {
 	/// Both [`Pallet::renew`] and [`Pallet::enable_auto_renew`] insert with
 	/// `paid: true`: the extension's `check_signed` charges `bytes_permanent`,
 	/// `PermanentStorageUsed`, and one tx slot up front (same as `force_renew`).
-	/// [`Pallet::do_process_auto_renewals`] keys its charge-skip off `paid`: when
+	/// `do_process_auto_renewals` keys its charge-skip off `paid`: when
 	/// `paid` is true the cycle renews without re-charging and then flips `paid`
 	/// to false (for recurring entries) so subsequent cycles pay per-cycle, as
 	/// before. One-shot entries (`recurring: false`) are removed after the single
@@ -798,7 +798,7 @@ pub mod pallet {
 		/// cycle fires at the next `RetentionPeriod` boundary **without**
 		/// re-charging — the slot is already paid for; the cycle then flips
 		/// `paid` to `false`. From that point on, every subsequent cycle charges
-		/// the owner's authorization in [`Self::do_process_auto_renewals`],
+		/// the owner's authorization in `do_process_auto_renewals`,
 		/// dropping the registration with [`Event::AutoRenewalFailed`] if the
 		/// quota is exhausted at cycle time.
 		///
@@ -860,7 +860,7 @@ pub mod pallet {
 		/// (governance/cleanup).
 		///
 		/// Feeless: no token fee and no authorization is consumed. Signed admission is
-		/// gated in [`check_signed`](Self::check_signed) on ownership and the prepaid
+		/// gated in `check_signed` on ownership and the prepaid
 		/// flag, so a caller can issue at most one successful `disable_auto_renew` per
 		/// registration it owns — and only after the first cycle has fired.
 		///
@@ -893,7 +893,7 @@ pub mod pallet {
 		}
 
 		/// Composite block-level inherent: optionally validates a transaction storage proof and
-		/// always drains [`PendingAutoRenewals`].
+		/// always drains `PendingAutoRenewals`.
 		///
 		/// `ProvideInherent::create_inherent` only returns a single `Call`, but this pallet
 		/// has two block-end concerns — verifying the storage proof for the block at
@@ -1846,7 +1846,7 @@ pub mod pallet {
 		/// would currently pass transaction validation for `who`.
 		///
 		/// Mirrors the preconditions enforced by [`Self::store`] +
-		/// [`Self::check_authorization`] (`is_renew = false`):
+		/// `check_authorization` (`is_renew = false`):
 		///
 		/// - `data_len` is within `[1, MaxTransactionSize]`
 		/// - `who` has an unexpired authorization entry
@@ -1864,7 +1864,7 @@ pub mod pallet {
 		/// validation for `who`.
 		///
 		/// Mirrors the preconditions enforced by [`Self::renew`] +
-		/// [`Self::check_authorization`] (`is_renew = true`):
+		/// `check_authorization` (`is_renew = true`):
 		///
 		/// - `entry` resolves to currently-stored data
 		/// - the stored data's size is within `[1, MaxTransactionSize]`
@@ -1894,7 +1894,7 @@ pub mod pallet {
 		/// Returns `true` if `who` has an authorization entry that has not yet expired,
 		/// regardless of how much of the extent remains. The entry is only cleared when
 		/// its expiration is reached and someone calls
-		/// [`remove_expired_account_authorization`], so a fully-consumed-but-in-window
+		/// [`Pallet::remove_expired_account_authorization`], so a fully-consumed-but-in-window
 		/// account still counts as active here. HOP promotion uses this to keep
 		/// promoting blobs for an account that has spent all of its store/renew quota.
 		pub fn account_has_active_authorization(who: &T::AccountId) -> bool {
@@ -1955,7 +1955,7 @@ pub mod pallet {
 		/// Whether `content_hash` is currently stored on-chain — i.e. some
 		/// retained transaction in this pallet indexes it.
 		///
-		/// O(1): one [`TransactionByContentHash`] map read. The map's
+		/// O(1): one `TransactionByContentHash` map read. The map's
 		/// lifecycle matches the question's semantics — `store`/`renew`
 		/// insert (or overwrite to the latest `(block, index)`), and
 		/// `on_initialize` removes the entry when the block it points at
@@ -2593,7 +2593,8 @@ impl<T: Config> Pallet<T> {
 	/// Verify the chain-wide permanent-storage accounting invariants:
 	/// - `PermanentStorageUsed == Σ Renew sizes in Transactions + Σ paid AutoRenewals sizes` — the
 	///   paid term covers the prepayment window between `renew` / `enable_auto_renew` charging the
-	///   counter and `do_process_auto_renewals` writing the `Renew` entry.
+	///   counter and `do_process_auto_renewals` writing the `Renew` entry. Enforced under
+	///   `cfg(test)` only; on live state it is logged (see below).
 	/// - `PermanentStorageUsed <= MaxPermanentStorageSize`.
 	fn check_permanent_storage_accounting(
 		_n: BlockNumberFor<T>,
@@ -2615,10 +2616,28 @@ impl<T: Config> Pallet<T> {
 						.map_or(0, |info| info.size as u64);
 					acc.saturating_add(size)
 				});
+		let expected = renewed_sum.saturating_add(prepaid_sum);
+
+		// `used` gates admission, so under-counting is what lets renewed bytes past the cap;
+		// over-counting only rejects early. Live state drifts both ways through history this
+		// pallet did not create — pre-counter `Renew` entries were never charged, and Root
+		// dropping a prepaid registration never decrements — so the equality is enforced only
+		// where state is built from nothing, and merely logged on a real chain. Erroring there
+		// would fail the check-migration jobs on any chain carrying that history.
+		#[cfg(test)]
 		ensure!(
-			renewed_sum.saturating_add(prepaid_sum) == used,
+			used == expected,
 			"PermanentStorageUsed != Σ renewed sizes + Σ paid auto-renewal sizes",
 		);
+		#[cfg(all(feature = "try-runtime", not(test)))]
+		if used != expected {
+			tracing::warn!(
+				target: LOG_TARGET,
+				used,
+				expected,
+				"PermanentStorageUsed drifts from Σ renewed + Σ paid auto-renewal sizes",
+			);
+		}
 
 		ensure!(
 			used <= T::MaxPermanentStorageSize::get(),

--- a/pallets/transaction-storage/src/lib.rs
+++ b/pallets/transaction-storage/src/lib.rs
@@ -78,6 +78,21 @@ pub const DEFAULT_MAX_TRANSACTION_SIZE: u32 = 2 * 1024 * 1024;
 /// Default maximum number of indexed transactions in a block.
 pub const DEFAULT_MAX_BLOCK_TRANSACTIONS: u32 = 512;
 
+/// Pool tag prefixes for the [`Config`] families. Runtimes take these instead of
+/// hand-copying the strings; only the pricing beside them is a per-chain choice.
+pub const STORE_TAG_PREFIX: &str = "TransactionStorageStore";
+/// See [`STORE_TAG_PREFIX`].
+pub const RENEW_TAG_PREFIX: &str = "TransactionStorageRenew";
+/// See [`STORE_TAG_PREFIX`].
+pub const REMOVE_EXPIRED_ACCOUNT_AUTHORIZATION_TAG_PREFIX: &str =
+	"TransactionStorageRemoveExpiredAccountAuthorization";
+/// See [`STORE_TAG_PREFIX`].
+pub const REMOVE_EXPIRED_PREIMAGE_AUTHORIZATION_TAG_PREFIX: &str =
+	"TransactionStorageRemoveExpiredPreimageAuthorization";
+/// See [`STORE_TAG_PREFIX`].
+pub const REMOVE_EXHAUSTED_AUTHORIZER_TAG_PREFIX: &str =
+	"TransactionStorageRemoveExhaustedAuthorizer";
+
 /// Encountered an impossible situation, implies a bug.
 pub const IMPOSSIBLE: InvalidTransaction = InvalidTransaction::Custom(0);
 /// Data size is not in the allowed range.
@@ -176,18 +191,17 @@ pub mod pallet {
 			Self::RuntimeOrigin,
 			Success = Option<AuthorizationOrigin<Self::AccountId, BlockNumberFor<Self>>>,
 		>;
-		/// Pool params for signed and preimage-authorized `store`. One prefix is safe
-		/// because they tag on `(who, content_hash)` and `content_hash` respectively.
+		/// Pool params for signed and preimage-authorized `store`. One prefix is safe: they
+		/// tag on `(who, content_hash)` and `content_hash` respectively.
 		type StoreTxParams: Get<ValidTransactionParams>;
 		/// Pool params for `renew`, `force_renew` and `enable_auto_renew`. Separate from
-		/// `store` so the two families neither share pricing nor dedup against each other.
+		/// `store` so the two do not dedup against each other.
 		type RenewTxParams: Get<ValidTransactionParams>;
-		/// Pool params for `authorize_*` and `refresh_*`.
+		/// Pool params for `authorize_*` and `refresh_*`. Untagged, so `tag_prefix` is unused.
 		type AuthorizeTxParams: Get<ValidTransactionParams>;
-		/// Pool params for `remove_expired_account_authorization`. Separate items for the
-		/// three cleanup calls because they share pricing but need distinct prefixes: two
-		/// provide `who`, and a `ContentHash` encodes like an `AccountId32`. Enforced by
-		/// `integrity_test`.
+		/// Pool params for `remove_expired_account_authorization`. The three cleanup calls get
+		/// their own items because two provide `who` and a `ContentHash` encodes like an
+		/// `AccountId32`, so they need distinct prefixes despite shared pricing.
 		type RemoveExpiredAccountAuthorizationTxParams: Get<ValidTransactionParams>;
 		/// Pool params for `remove_expired_preimage_authorization`.
 		type RemoveExpiredPreimageAuthorizationTxParams: Get<ValidTransactionParams>;
@@ -485,7 +499,7 @@ pub mod pallet {
 				!T::AuthorizationPeriod::get().is_zero(),
 				"AuthorizationPeriod must be greater than zero"
 			);
-			Self::assert_tag_prefixes_distinct(&[]);
+			Self::assert_pool_families_distinct(&[]);
 		}
 	}
 
@@ -2138,9 +2152,9 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Panics unless this pallet's pool families and `extra` all use distinct tag
-		/// prefixes. `extra` lets dependent pallets fold their own families into the check.
-		pub fn assert_tag_prefixes_distinct(extra: &[(&'static str, ValidTransactionParams)]) {
+		/// Panics unless this pallet's tagged families and `extra` use distinct tag prefixes.
+		/// `extra` lets dependent pallets fold in their own. `AuthorizeTxParams` is untagged.
+		pub fn assert_pool_families_distinct(extra: &[(&str, ValidTransactionParams)]) {
 			let mut all = extra.to_vec();
 			all.extend([
 				("StoreTxParams", T::StoreTxParams::get()),
@@ -2158,9 +2172,8 @@ pub mod pallet {
 			assert_distinct_tag_prefixes(&all);
 		}
 
-		/// Pool params for the store/renew family `is_renew` selects. Distinct prefixes
-		/// keep a `store` and a `force_renew` of the same content hash from deduping
-		/// against each other in the pool.
+		/// Keeps a `store` and a `force_renew` of the same content hash on separate pool
+		/// prefixes, so neither evicts the other.
 		fn store_renew_tx_params(is_renew: bool) -> ValidTransactionParams {
 			if is_renew {
 				T::RenewTxParams::get()
@@ -2526,6 +2539,10 @@ pub mod pallet {
 pub mod extension;
 
 #[cfg(any(test, feature = "try-runtime"))]
+const PERMANENT_USED_DRIFT: &str =
+	"PermanentStorageUsed != Σ renewed sizes + Σ paid auto-renewal sizes";
+
+#[cfg(any(test, feature = "try-runtime"))]
 impl<T: Config> Pallet<T> {
 	pub(crate) fn do_try_state(n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
 		ensure!(!Self::retention_period().is_zero(), "RetentionPeriod must not be zero");
@@ -2594,7 +2611,7 @@ impl<T: Config> Pallet<T> {
 	/// - `PermanentStorageUsed == Σ Renew sizes in Transactions + Σ paid AutoRenewals sizes` — the
 	///   paid term covers the prepayment window between `renew` / `enable_auto_renew` charging the
 	///   counter and `do_process_auto_renewals` writing the `Renew` entry. Enforced under
-	///   `cfg(test)` only; on live state it is logged (see below).
+	///   `cfg(test)`; only logged on live state.
 	/// - `PermanentStorageUsed <= MaxPermanentStorageSize`.
 	fn check_permanent_storage_accounting(
 		_n: BlockNumberFor<T>,
@@ -2618,25 +2635,16 @@ impl<T: Config> Pallet<T> {
 				});
 		let expected = renewed_sum.saturating_add(prepaid_sum);
 
-		// `used` gates admission, so under-counting is what lets renewed bytes past the cap;
-		// over-counting only rejects early. Live state drifts both ways through history this
-		// pallet did not create — pre-counter `Renew` entries were never charged, and Root
-		// dropping a prepaid registration never decrements — so the equality is enforced only
-		// where state is built from nothing, and merely logged on a real chain. Erroring there
-		// would fail the check-migration jobs on any chain carrying that history.
-		#[cfg(test)]
-		ensure!(
-			used == expected,
-			"PermanentStorageUsed != Σ renewed sizes + Σ paid auto-renewal sizes",
-		);
-		#[cfg(all(feature = "try-runtime", not(test)))]
+		// Live state drifts both ways through history this pallet did not create: pre-counter
+		// `Renew` entries were never charged, and Root dropping a prepaid registration never
+		// decrements. Erroring would fail the check-migration jobs on any such chain, so the
+		// equality holds only where state is built from nothing. The cap below is the bound
+		// that matters — `used` gates admission, so under-counting is the dangerous side.
 		if used != expected {
-			tracing::warn!(
-				target: LOG_TARGET,
-				used,
-				expected,
-				"PermanentStorageUsed drifts from Σ renewed + Σ paid auto-renewal sizes",
-			);
+			if cfg!(test) {
+				return Err(PERMANENT_USED_DRIFT.into());
+			}
+			tracing::warn!(target: LOG_TARGET, used, expected, "{PERMANENT_USED_DRIFT}");
 		}
 
 		ensure!(

--- a/pallets/transaction-storage/src/migrations.rs
+++ b/pallets/transaction-storage/src/migrations.rs
@@ -640,7 +640,7 @@ pub mod v3 {
 	}
 }
 
-/// V3 → V4 migration: re-encode each [`AutoRenewals`] entry from
+/// V3 → V4 migration: re-encode each [`crate::AutoRenewals`] entry from
 /// `{ account }` (v3) to `{ account, recurring: true, paid: false }` (v4).
 ///
 /// All existing entries were written by the old fee-paying `enable_auto_renew`,

--- a/pallets/transaction-storage/src/mock.rs
+++ b/pallets/transaction-storage/src/mock.rs
@@ -31,6 +31,10 @@ use polkadot_sdk_frame::{
 
 type Block = MockBlock<Test>;
 
+/// Pool pricing for every family; none of these tests depend on the relative values.
+const PRIORITY: TransactionPriority = TransactionPriority::MAX;
+const LONGEVITY: TransactionLongevity = 10;
+
 // Configure a mock runtime to test the pallet.
 #[frame_support::runtime]
 mod runtime {
@@ -75,17 +79,17 @@ impl frame_system::Config for Test {
 parameter_types! {
 	pub const AuthorizationPeriod: BlockNumberFor<Test> = 10;
 	pub const StoreTxParams: ValidTransactionParams =
-		ValidTransactionParams::new("Store", TransactionPriority::MAX, 10);
+		ValidTransactionParams::new("Store", PRIORITY, LONGEVITY);
 	pub const RenewTxParams: ValidTransactionParams =
-		ValidTransactionParams::new("Renew", TransactionPriority::MAX, 10);
+		ValidTransactionParams::new("Renew", PRIORITY, LONGEVITY);
 	pub const AuthorizeTxParams: ValidTransactionParams =
-		ValidTransactionParams::new("Authorize", TransactionPriority::MAX, 10);
+		ValidTransactionParams::new("Authorize", PRIORITY, LONGEVITY);
 	pub const RemoveExpiredAccountAuthorizationTxParams: ValidTransactionParams =
-		ValidTransactionParams::new("ExpiredAccountAuth", TransactionPriority::MAX, 10);
+		ValidTransactionParams::new("ExpiredAccountAuth", PRIORITY, LONGEVITY);
 	pub const RemoveExpiredPreimageAuthorizationTxParams: ValidTransactionParams =
-		ValidTransactionParams::new("ExpiredPreimageAuth", TransactionPriority::MAX, 10);
+		ValidTransactionParams::new("ExpiredPreimageAuth", PRIORITY, LONGEVITY);
 	pub const RemoveExhaustedAuthorizerTxParams: ValidTransactionParams =
-		ValidTransactionParams::new("ExhaustedAuthorizer", TransactionPriority::MAX, 10);
+		ValidTransactionParams::new("ExhaustedAuthorizer", PRIORITY, LONGEVITY);
 	pub storage MaxPermanentStorageSize: u64 = u64::MAX;
 }
 

--- a/pallets/transaction-storage/src/mock.rs
+++ b/pallets/transaction-storage/src/mock.rs
@@ -17,7 +17,8 @@
 
 use crate::{
 	self as pallet_bulletin_transaction_storage, AsAuthorizer, EnsureAllowedAuthorizers,
-	TransactionStorageProof, DEFAULT_MAX_BLOCK_TRANSACTIONS, DEFAULT_MAX_TRANSACTION_SIZE,
+	TransactionStorageProof, ValidTransactionParams, DEFAULT_MAX_BLOCK_TRANSACTIONS,
+	DEFAULT_MAX_TRANSACTION_SIZE,
 };
 use bulletin_pallets_common::NoCurrency;
 use polkadot_sdk_frame::{
@@ -73,10 +74,18 @@ impl frame_system::Config for Test {
 
 parameter_types! {
 	pub const AuthorizationPeriod: BlockNumberFor<Test> = 10;
-	pub const StoreRenewPriority: TransactionPriority = TransactionPriority::MAX;
-	pub const StoreRenewLongevity: TransactionLongevity = 10;
-	pub const RemoveExpiredAuthorizationPriority: TransactionPriority = TransactionPriority::MAX;
-	pub const RemoveExpiredAuthorizationLongevity: TransactionLongevity = 10;
+	pub const StoreTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("Store", TransactionPriority::MAX, 10);
+	pub const RenewTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("Renew", TransactionPriority::MAX, 10);
+	pub const AuthorizeTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("Authorize", TransactionPriority::MAX, 10);
+	pub const RemoveExpiredAccountAuthorizationTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("ExpiredAccountAuth", TransactionPriority::MAX, 10);
+	pub const RemoveExpiredPreimageAuthorizationTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("ExpiredPreimageAuth", TransactionPriority::MAX, 10);
+	pub const RemoveExhaustedAuthorizerTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("ExhaustedAuthorizer", TransactionPriority::MAX, 10);
 	pub storage MaxPermanentStorageSize: u64 = u64::MAX;
 }
 
@@ -96,10 +105,12 @@ impl pallet_bulletin_transaction_storage::Config for Test {
 		AsAuthorizer<EnsureRoot<Self::AccountId>, Self::AccountId, BlockNumberFor<Self>>,
 		EnsureAllowedAuthorizers<Self>,
 	>;
-	type StoreRenewPriority = StoreRenewPriority;
-	type StoreRenewLongevity = StoreRenewLongevity;
-	type RemoveExpiredAuthorizationPriority = RemoveExpiredAuthorizationPriority;
-	type RemoveExpiredAuthorizationLongevity = RemoveExpiredAuthorizationLongevity;
+	type StoreTxParams = StoreTxParams;
+	type RenewTxParams = RenewTxParams;
+	type AuthorizeTxParams = AuthorizeTxParams;
+	type RemoveExpiredAccountAuthorizationTxParams = RemoveExpiredAccountAuthorizationTxParams;
+	type RemoveExpiredPreimageAuthorizationTxParams = RemoveExpiredPreimageAuthorizationTxParams;
+	type RemoveExhaustedAuthorizerTxParams = RemoveExhaustedAuthorizerTxParams;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = crate::benchmarking::DefaultCheckProofHelper;
 }

--- a/pallets/transaction-storage/src/tests.rs
+++ b/pallets/transaction-storage/src/tests.rs
@@ -1659,7 +1659,7 @@ fn try_state_detects_permanent_used_mismatch_with_transactions() {
 		PermanentStorageUsed::put(2000);
 		assert_err!(
 			TransactionStorage::do_try_state(System::block_number()),
-			"PermanentStorageUsed != Σ renewed sizes + Σ paid auto-renewal sizes"
+			crate::PERMANENT_USED_DRIFT
 		);
 
 		// Under-count: the direction that lets renewed bytes past the cap.
@@ -1680,7 +1680,7 @@ fn try_state_detects_permanent_used_mismatch_with_transactions() {
 		);
 		assert_err!(
 			TransactionStorage::do_try_state(System::block_number()),
-			"PermanentStorageUsed != Σ renewed sizes + Σ paid auto-renewal sizes"
+			crate::PERMANENT_USED_DRIFT
 		);
 	});
 }

--- a/pallets/transaction-storage/src/tests.rs
+++ b/pallets/transaction-storage/src/tests.rs
@@ -24,7 +24,7 @@ use super::{
 	extension::ValidateStorageCalls,
 	mock::{
 		new_test_ext, run_to_block, MaxPermanentStorageSize, RuntimeCall, RuntimeEvent,
-		RuntimeOrigin, StoreRenewPriority, System, Test, TransactionStorage,
+		RuntimeOrigin, StoreTxParams, System, Test, TransactionStorage,
 	},
 	pallet::Origin,
 	AllowedAuthorizers, AuthorizationExtent, AuthorizationOrigin, AuthorizationScope,
@@ -1782,7 +1782,7 @@ fn authorize_storage_extension_transforms_origin() {
 		let (valid_tx, val, transformed_origin) = result.unwrap();
 
 		// Verify the transaction is valid with correct priority
-		assert_eq!(valid_tx.priority, StoreRenewPriority::get());
+		assert_eq!(valid_tx.priority, StoreTxParams::get().priority);
 
 		// Verify val contains the signer
 		assert_eq!(val, Some(caller));

--- a/pallets/transaction-storage/src/tests.rs
+++ b/pallets/transaction-storage/src/tests.rs
@@ -1650,13 +1650,37 @@ fn try_state_passes_during_enable_auto_renew_prepayment_window() {
 	});
 }
 
-/// `PermanentStorageUsed` desync from `Σ size of renewed Transactions entries` is caught.
+/// Both drift directions between `PermanentStorageUsed` and `Σ size of renewed
+/// Transactions entries` are caught on clean state; a live chain only logs. See
+/// `check_permanent_storage_accounting`.
 #[test]
 fn try_state_detects_permanent_used_mismatch_with_transactions() {
 	new_test_ext().execute_with(|| {
 		run_to_block(1, || None);
-		// Bump the counter without writing any matching renewed `Transactions` entry.
+		// Counter above the (empty) on-chain sums: over-count, conservative but still wrong.
 		PermanentStorageUsed::put(2000);
+		assert_err!(
+			TransactionStorage::do_try_state(System::block_number()),
+			"PermanentStorageUsed != Σ renewed sizes + Σ paid auto-renewal sizes"
+		);
+
+		// Counter below the on-chain renewed sum: under-count, the direction that lets real
+		// renewed bytes past `MaxPermanentStorageSize`.
+		PermanentStorageUsed::put(0);
+		let renewed = TransactionInfo {
+			chunk_root: Default::default(),
+			content_hash: [1u8; 32],
+			hashing: HashingAlgorithm::Blake2b256,
+			cid_codec: 0x55,
+			size: 1000,
+			extrinsic_index: u32::MAX,
+			block_chunks: num_chunks(1000),
+			kind: TransactionKind::Renew,
+		};
+		Transactions::insert(
+			1u64,
+			BoundedVec::<TransactionInfo, _>::try_from(vec![renewed]).unwrap(),
+		);
 		assert_err!(
 			TransactionStorage::do_try_state(System::block_number()),
 			"PermanentStorageUsed != Σ renewed sizes + Σ paid auto-renewal sizes"

--- a/pallets/transaction-storage/src/tests.rs
+++ b/pallets/transaction-storage/src/tests.rs
@@ -1650,22 +1650,19 @@ fn try_state_passes_during_enable_auto_renew_prepayment_window() {
 	});
 }
 
-/// Both drift directions between `PermanentStorageUsed` and `Σ size of renewed
-/// Transactions entries` are caught on clean state; a live chain only logs. See
-/// `check_permanent_storage_accounting`.
+/// Both drift directions are caught on clean state; a live chain only logs.
 #[test]
 fn try_state_detects_permanent_used_mismatch_with_transactions() {
 	new_test_ext().execute_with(|| {
 		run_to_block(1, || None);
-		// Counter above the (empty) on-chain sums: over-count, conservative but still wrong.
+		// Over-count: conservative, but still wrong.
 		PermanentStorageUsed::put(2000);
 		assert_err!(
 			TransactionStorage::do_try_state(System::block_number()),
 			"PermanentStorageUsed != Σ renewed sizes + Σ paid auto-renewal sizes"
 		);
 
-		// Counter below the on-chain renewed sum: under-count, the direction that lets real
-		// renewed bytes past `MaxPermanentStorageSize`.
+		// Under-count: the direction that lets renewed bytes past the cap.
 		PermanentStorageUsed::put(0);
 		let renewed = TransactionInfo {
 			chunk_root: Default::default(),

--- a/pallets/transaction-storage/src/types.rs
+++ b/pallets/transaction-storage/src/types.rs
@@ -15,13 +15,11 @@
 
 //! Type definitions for the transaction storage pallet.
 
-pub use bulletin_transaction_storage_primitives::{
-	assert_distinct_tag_prefixes, TransactionRef, ValidTransactionParams,
-};
 use bulletin_transaction_storage_primitives::{
 	cids::{CidCodec, HashingAlgorithm},
 	ContentHash,
 };
+pub use bulletin_transaction_storage_primitives::{TransactionRef, ValidTransactionParams};
 use codec::{Decode, Encode, MaxEncodedLen};
 #[cfg(feature = "runtime-benchmarks")]
 use polkadot_sdk_frame::deps::frame_benchmarking;

--- a/pallets/transaction-storage/src/types.rs
+++ b/pallets/transaction-storage/src/types.rs
@@ -15,7 +15,9 @@
 
 //! Type definitions for the transaction storage pallet.
 
-pub use bulletin_transaction_storage_primitives::TransactionRef;
+pub use bulletin_transaction_storage_primitives::{
+	assert_distinct_tag_prefixes, TransactionRef, ValidTransactionParams,
+};
 use bulletin_transaction_storage_primitives::{
 	cids::{CidCodec, HashingAlgorithm},
 	ContentHash,

--- a/pallets/transaction-storage/src/types.rs
+++ b/pallets/transaction-storage/src/types.rs
@@ -109,7 +109,7 @@ pub enum AuthorizedCaller<AccountId> {
 	/// A root call (e.g. via `sudo`).
 	Root,
 	/// An unsigned transaction validated by [`ValidateUnsigned`].
-	/// TODO: replaced by https://github.com/paritytech/polkadot-bulletin-chain/pull/194
+	/// TODO: replaced by <https://github.com/paritytech/polkadot-bulletin-chain/pull/194>
 	Unsigned,
 }
 

--- a/runtimes/bulletin-paseo/src/storage.rs
+++ b/runtimes/bulletin-paseo/src/storage.rs
@@ -15,8 +15,6 @@ use frame_support::{
 use pallet_bulletin_transaction_storage::{
 	AsAuthorizer, CallInspector, EnsureAllowedAuthorizers, ValidTransactionParams,
 	DEFAULT_MAX_BLOCK_TRANSACTIONS, DEFAULT_MAX_TRANSACTION_SIZE,
-	REMOVE_EXHAUSTED_AUTHORIZER_TAG_PREFIX, REMOVE_EXPIRED_ACCOUNT_AUTHORIZATION_TAG_PREFIX,
-	REMOVE_EXPIRED_PREIMAGE_AUTHORIZATION_TAG_PREFIX, RENEW_TAG_PREFIX, STORE_TAG_PREFIX,
 };
 use pallet_xcm::EnsureXcm;
 use sp_runtime::transaction_validity::{TransactionLongevity, TransactionPriority};
@@ -28,43 +26,37 @@ parameter_types! {
 	pub storage MaxPermanentStorageSize: u64 = 17 * 1024 * 1024 * 1024 * 1024 / 10;
 }
 
+/// Cleanup runs before stores compete for blockspace.
+const CLEANUP_PRIORITY: TransactionPriority = TransactionPriority::MAX;
+/// Below `MAX` so `AllowanceBasedPriority` can add its boost without saturating `u64`.
+const STORE_PRIORITY: TransactionPriority = TransactionPriority::MAX / 4;
+const TX_LONGEVITY: TransactionLongevity = crate::DAYS as TransactionLongevity;
+
 parameter_types! {
 	pub const AuthorizationPeriod: crate::BlockNumber = 14 * crate::DAYS;
-	// Cleanup sits at `MAX` so it always runs before stores compete for blockspace. The
-	// rest sit well below it so `AllowanceBasedPriority` can add its boost without
-	// saturating `u64`. Prefixes come from the pallet; only this pricing is per-chain.
-	pub const StoreTxParams: ValidTransactionParams = ValidTransactionParams::new(
-		STORE_TAG_PREFIX,
-		TransactionPriority::MAX / 4,
-		crate::DAYS as TransactionLongevity,
-	);
-	pub const RenewTxParams: ValidTransactionParams = ValidTransactionParams::new(
-		RENEW_TAG_PREFIX,
-		TransactionPriority::MAX / 4,
-		crate::DAYS as TransactionLongevity,
-	);
-	pub const AuthorizeTxParams: ValidTransactionParams = ValidTransactionParams::new(
-		"TransactionStorageAuthorize",
-		TransactionPriority::MAX / 4,
-		crate::DAYS as TransactionLongevity,
-	);
+	pub const StoreTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("TransactionStorageStore", STORE_PRIORITY, TX_LONGEVITY);
+	pub const RenewTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("TransactionStorageRenew", STORE_PRIORITY, TX_LONGEVITY);
+	pub const AuthorizeTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("TransactionStorageAuthorize", STORE_PRIORITY, TX_LONGEVITY);
 	pub const RemoveExpiredAccountAuthorizationTxParams: ValidTransactionParams =
 		ValidTransactionParams::new(
-			REMOVE_EXPIRED_ACCOUNT_AUTHORIZATION_TAG_PREFIX,
-			TransactionPriority::MAX,
-			crate::DAYS as TransactionLongevity,
+			"TransactionStorageRemoveExpiredAccountAuthorization",
+			CLEANUP_PRIORITY,
+			TX_LONGEVITY,
 		);
 	pub const RemoveExpiredPreimageAuthorizationTxParams: ValidTransactionParams =
 		ValidTransactionParams::new(
-			REMOVE_EXPIRED_PREIMAGE_AUTHORIZATION_TAG_PREFIX,
-			TransactionPriority::MAX,
-			crate::DAYS as TransactionLongevity,
+			"TransactionStorageRemoveExpiredPreimageAuthorization",
+			CLEANUP_PRIORITY,
+			TX_LONGEVITY,
 		);
 	pub const RemoveExhaustedAuthorizerTxParams: ValidTransactionParams =
 		ValidTransactionParams::new(
-			REMOVE_EXHAUSTED_AUTHORIZER_TAG_PREFIX,
-			TransactionPriority::MAX,
-			crate::DAYS as TransactionLongevity,
+			"TransactionStorageRemoveExhaustedAuthorizer",
+			CLEANUP_PRIORITY,
+			TX_LONGEVITY,
 		);
 }
 

--- a/runtimes/bulletin-paseo/src/storage.rs
+++ b/runtimes/bulletin-paseo/src/storage.rs
@@ -15,6 +15,8 @@ use frame_support::{
 use pallet_bulletin_transaction_storage::{
 	AsAuthorizer, CallInspector, EnsureAllowedAuthorizers, ValidTransactionParams,
 	DEFAULT_MAX_BLOCK_TRANSACTIONS, DEFAULT_MAX_TRANSACTION_SIZE,
+	REMOVE_EXHAUSTED_AUTHORIZER_TAG_PREFIX, REMOVE_EXPIRED_ACCOUNT_AUTHORIZATION_TAG_PREFIX,
+	REMOVE_EXPIRED_PREIMAGE_AUTHORIZATION_TAG_PREFIX, RENEW_TAG_PREFIX, STORE_TAG_PREFIX,
 };
 use pallet_xcm::EnsureXcm;
 use sp_runtime::transaction_validity::{TransactionLongevity, TransactionPriority};
@@ -28,18 +30,16 @@ parameter_types! {
 
 parameter_types! {
 	pub const AuthorizationPeriod: crate::BlockNumber = 14 * crate::DAYS;
-	// Pool params per family. Cleanup sits at `MAX` so it always runs before stores
-	// compete for blockspace; store and renew sit well below it so
-	// `AllowanceBasedPriority` can add its boost without saturating `u64`. Renew prices
-	// separately from store, equal for now. Distinct prefixes keep the two from deduping
-	// against each other.
+	// Cleanup sits at `MAX` so it always runs before stores compete for blockspace. The
+	// rest sit well below it so `AllowanceBasedPriority` can add its boost without
+	// saturating `u64`. Prefixes come from the pallet; only this pricing is per-chain.
 	pub const StoreTxParams: ValidTransactionParams = ValidTransactionParams::new(
-		"TransactionStorageStore",
+		STORE_TAG_PREFIX,
 		TransactionPriority::MAX / 4,
 		crate::DAYS as TransactionLongevity,
 	);
 	pub const RenewTxParams: ValidTransactionParams = ValidTransactionParams::new(
-		"TransactionStorageRenew",
+		RENEW_TAG_PREFIX,
 		TransactionPriority::MAX / 4,
 		crate::DAYS as TransactionLongevity,
 	);
@@ -50,19 +50,19 @@ parameter_types! {
 	);
 	pub const RemoveExpiredAccountAuthorizationTxParams: ValidTransactionParams =
 		ValidTransactionParams::new(
-			"TransactionStorageRemoveExpiredAccountAuthorization",
+			REMOVE_EXPIRED_ACCOUNT_AUTHORIZATION_TAG_PREFIX,
 			TransactionPriority::MAX,
 			crate::DAYS as TransactionLongevity,
 		);
 	pub const RemoveExpiredPreimageAuthorizationTxParams: ValidTransactionParams =
 		ValidTransactionParams::new(
-			"TransactionStorageRemoveExpiredPreimageAuthorization",
+			REMOVE_EXPIRED_PREIMAGE_AUTHORIZATION_TAG_PREFIX,
 			TransactionPriority::MAX,
 			crate::DAYS as TransactionLongevity,
 		);
 	pub const RemoveExhaustedAuthorizerTxParams: ValidTransactionParams =
 		ValidTransactionParams::new(
-			"TransactionStorageRemoveExhaustedAuthorizer",
+			REMOVE_EXHAUSTED_AUTHORIZER_TAG_PREFIX,
 			TransactionPriority::MAX,
 			crate::DAYS as TransactionLongevity,
 		);

--- a/runtimes/bulletin-paseo/src/storage.rs
+++ b/runtimes/bulletin-paseo/src/storage.rs
@@ -13,8 +13,8 @@ use frame_support::{
 	traits::{Contains, EitherOf},
 };
 use pallet_bulletin_transaction_storage::{
-	AsAuthorizer, CallInspector, EnsureAllowedAuthorizers, DEFAULT_MAX_BLOCK_TRANSACTIONS,
-	DEFAULT_MAX_TRANSACTION_SIZE,
+	AsAuthorizer, CallInspector, EnsureAllowedAuthorizers, ValidTransactionParams,
+	DEFAULT_MAX_BLOCK_TRANSACTIONS, DEFAULT_MAX_TRANSACTION_SIZE,
 };
 use pallet_xcm::EnsureXcm;
 use sp_runtime::transaction_validity::{TransactionLongevity, TransactionPriority};
@@ -28,17 +28,44 @@ parameter_types! {
 
 parameter_types! {
 	pub const AuthorizationPeriod: crate::BlockNumber = 14 * crate::DAYS;
-	// Priorities and longevities used by the transaction storage pallet extrinsics.
-	//
-	// `RemoveExpiredAuthorization` (permissionless cleanup) sits at the top so it always
-	// runs before stores compete for blockspace.
-	pub const RemoveExpiredAuthorizationPriority: TransactionPriority = TransactionPriority::MAX;
-	pub const RemoveExpiredAuthorizationLongevity: TransactionLongevity = crate::DAYS as TransactionLongevity;
-	// Base priority for `store` / `renew`. Picked well below `TransactionPriority::MAX` so
-	// `AllowanceBasedPriority` can add its boost without saturating `u64`, while still
-	// leaving plenty of headroom above generic transactions.
-	pub const StoreRenewPriority: TransactionPriority = TransactionPriority::MAX / 4;
-	pub const StoreRenewLongevity: TransactionLongevity = crate::DAYS as TransactionLongevity;
+	// Pool params per family. Cleanup sits at `MAX` so it always runs before stores
+	// compete for blockspace; store and renew sit well below it so
+	// `AllowanceBasedPriority` can add its boost without saturating `u64`. Renew prices
+	// separately from store, equal for now. Distinct prefixes keep the two from deduping
+	// against each other.
+	pub const StoreTxParams: ValidTransactionParams = ValidTransactionParams::new(
+		"TransactionStorageStore",
+		TransactionPriority::MAX / 4,
+		crate::DAYS as TransactionLongevity,
+	);
+	pub const RenewTxParams: ValidTransactionParams = ValidTransactionParams::new(
+		"TransactionStorageRenew",
+		TransactionPriority::MAX / 4,
+		crate::DAYS as TransactionLongevity,
+	);
+	pub const AuthorizeTxParams: ValidTransactionParams = ValidTransactionParams::new(
+		"TransactionStorageAuthorize",
+		TransactionPriority::MAX / 4,
+		crate::DAYS as TransactionLongevity,
+	);
+	pub const RemoveExpiredAccountAuthorizationTxParams: ValidTransactionParams =
+		ValidTransactionParams::new(
+			"TransactionStorageRemoveExpiredAccountAuthorization",
+			TransactionPriority::MAX,
+			crate::DAYS as TransactionLongevity,
+		);
+	pub const RemoveExpiredPreimageAuthorizationTxParams: ValidTransactionParams =
+		ValidTransactionParams::new(
+			"TransactionStorageRemoveExpiredPreimageAuthorization",
+			TransactionPriority::MAX,
+			crate::DAYS as TransactionLongevity,
+		);
+	pub const RemoveExhaustedAuthorizerTxParams: ValidTransactionParams =
+		ValidTransactionParams::new(
+			"TransactionStorageRemoveExhaustedAuthorizer",
+			TransactionPriority::MAX,
+			crate::DAYS as TransactionLongevity,
+		);
 }
 
 /// Tells [`pallet_bulletin_transaction_storage::extension::ValidateStorageCalls`] how to find
@@ -98,10 +125,12 @@ impl pallet_bulletin_transaction_storage::Config for Runtime {
 		// `add_authorizer` / `remove_authorizer`).
 		EnsureAllowedAuthorizers<Runtime>,
 	>;
-	type StoreRenewPriority = StoreRenewPriority;
-	type StoreRenewLongevity = StoreRenewLongevity;
-	type RemoveExpiredAuthorizationPriority = RemoveExpiredAuthorizationPriority;
-	type RemoveExpiredAuthorizationLongevity = RemoveExpiredAuthorizationLongevity;
+	type StoreTxParams = StoreTxParams;
+	type RenewTxParams = RenewTxParams;
+	type AuthorizeTxParams = AuthorizeTxParams;
+	type RemoveExpiredAccountAuthorizationTxParams = RemoveExpiredAccountAuthorizationTxParams;
+	type RemoveExpiredPreimageAuthorizationTxParams = RemoveExpiredPreimageAuthorizationTxParams;
+	type RemoveExhaustedAuthorizerTxParams = RemoveExhaustedAuthorizerTxParams;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper =
 		pallet_bulletin_transaction_storage::benchmarking::DefaultCheckProofHelper;
@@ -111,9 +140,13 @@ parameter_types! {
 	/// Maximum allowable skew between the user's submit timestamp and the on-chain
 	/// time when validating a HOP promotion: 48 hours, in milliseconds.
 	pub const SubmitTimestampTolerance: u64 = 48 * 60 * 60 * 1000;
+	// Lowest priority: promotion only fills blockspace stores would not have used.
+	pub const PromoteTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("HopPromotion", 0, 5);
 }
 
 impl pallet_bulletin_hop_promotion::Config for Runtime {
 	type SubmitTimestampTolerance = SubmitTimestampTolerance;
+	type PromoteTxParams = PromoteTxParams;
 	type WeightInfo = crate::weights::pallet_bulletin_hop_promotion::WeightInfo<Runtime>;
 }

--- a/runtimes/bulletin-westend/src/storage.rs
+++ b/runtimes/bulletin-westend/src/storage.rs
@@ -17,6 +17,8 @@ use frame_system::EnsureSignedBy;
 use pallet_bulletin_transaction_storage::{
 	AsAuthorizer, CallInspector, EnsureAllowedAuthorizers, ValidTransactionParams,
 	DEFAULT_MAX_BLOCK_TRANSACTIONS, DEFAULT_MAX_TRANSACTION_SIZE,
+	REMOVE_EXHAUSTED_AUTHORIZER_TAG_PREFIX, REMOVE_EXPIRED_ACCOUNT_AUTHORIZATION_TAG_PREFIX,
+	REMOVE_EXPIRED_PREIMAGE_AUTHORIZATION_TAG_PREFIX, RENEW_TAG_PREFIX, STORE_TAG_PREFIX,
 };
 use pallet_xcm::EnsureXcm;
 use sp_keyring::Sr25519Keyring;
@@ -44,18 +46,16 @@ impl SortedMembers<AccountId> for TestAccounts {
 
 parameter_types! {
 	pub const AuthorizationPeriod: crate::BlockNumber = 14 * crate::DAYS;
-	// Pool params per family. Cleanup sits at `MAX` so it always runs before stores
-	// compete for blockspace; store and renew sit well below it so
-	// `AllowanceBasedPriority` can add its boost without saturating `u64`. Renew prices
-	// separately from store, equal for now. Distinct prefixes keep the two from deduping
-	// against each other.
+	// Cleanup sits at `MAX` so it always runs before stores compete for blockspace. The
+	// rest sit well below it so `AllowanceBasedPriority` can add its boost without
+	// saturating `u64`. Prefixes come from the pallet; only this pricing is per-chain.
 	pub const StoreTxParams: ValidTransactionParams = ValidTransactionParams::new(
-		"TransactionStorageStore",
+		STORE_TAG_PREFIX,
 		TransactionPriority::MAX / 4,
 		crate::DAYS as TransactionLongevity,
 	);
 	pub const RenewTxParams: ValidTransactionParams = ValidTransactionParams::new(
-		"TransactionStorageRenew",
+		RENEW_TAG_PREFIX,
 		TransactionPriority::MAX / 4,
 		crate::DAYS as TransactionLongevity,
 	);
@@ -66,19 +66,19 @@ parameter_types! {
 	);
 	pub const RemoveExpiredAccountAuthorizationTxParams: ValidTransactionParams =
 		ValidTransactionParams::new(
-			"TransactionStorageRemoveExpiredAccountAuthorization",
+			REMOVE_EXPIRED_ACCOUNT_AUTHORIZATION_TAG_PREFIX,
 			TransactionPriority::MAX,
 			crate::DAYS as TransactionLongevity,
 		);
 	pub const RemoveExpiredPreimageAuthorizationTxParams: ValidTransactionParams =
 		ValidTransactionParams::new(
-			"TransactionStorageRemoveExpiredPreimageAuthorization",
+			REMOVE_EXPIRED_PREIMAGE_AUTHORIZATION_TAG_PREFIX,
 			TransactionPriority::MAX,
 			crate::DAYS as TransactionLongevity,
 		);
 	pub const RemoveExhaustedAuthorizerTxParams: ValidTransactionParams =
 		ValidTransactionParams::new(
-			"TransactionStorageRemoveExhaustedAuthorizer",
+			REMOVE_EXHAUSTED_AUTHORIZER_TAG_PREFIX,
 			TransactionPriority::MAX,
 			crate::DAYS as TransactionLongevity,
 		);

--- a/runtimes/bulletin-westend/src/storage.rs
+++ b/runtimes/bulletin-westend/src/storage.rs
@@ -15,8 +15,8 @@ use frame_support::{
 };
 use frame_system::EnsureSignedBy;
 use pallet_bulletin_transaction_storage::{
-	AsAuthorizer, CallInspector, EnsureAllowedAuthorizers, DEFAULT_MAX_BLOCK_TRANSACTIONS,
-	DEFAULT_MAX_TRANSACTION_SIZE,
+	AsAuthorizer, CallInspector, EnsureAllowedAuthorizers, ValidTransactionParams,
+	DEFAULT_MAX_BLOCK_TRANSACTIONS, DEFAULT_MAX_TRANSACTION_SIZE,
 };
 use pallet_xcm::EnsureXcm;
 use sp_keyring::Sr25519Keyring;
@@ -44,17 +44,44 @@ impl SortedMembers<AccountId> for TestAccounts {
 
 parameter_types! {
 	pub const AuthorizationPeriod: crate::BlockNumber = 14 * crate::DAYS;
-	// Priorities and longevities used by the transaction storage pallet extrinsics.
-	//
-	// `RemoveExpiredAuthorization` (permissionless cleanup) sits at the top so it always
-	// runs before stores compete for blockspace.
-	pub const RemoveExpiredAuthorizationPriority: TransactionPriority = TransactionPriority::MAX;
-	pub const RemoveExpiredAuthorizationLongevity: TransactionLongevity = crate::DAYS as TransactionLongevity;
-	// Base priority for `store` / `renew`. Picked well below `TransactionPriority::MAX` so
-	// `AllowanceBasedPriority` can add its boost without saturating `u64`, while still
-	// leaving plenty of headroom above generic transactions.
-	pub const StoreRenewPriority: TransactionPriority = TransactionPriority::MAX / 4;
-	pub const StoreRenewLongevity: TransactionLongevity = crate::DAYS as TransactionLongevity;
+	// Pool params per family. Cleanup sits at `MAX` so it always runs before stores
+	// compete for blockspace; store and renew sit well below it so
+	// `AllowanceBasedPriority` can add its boost without saturating `u64`. Renew prices
+	// separately from store, equal for now. Distinct prefixes keep the two from deduping
+	// against each other.
+	pub const StoreTxParams: ValidTransactionParams = ValidTransactionParams::new(
+		"TransactionStorageStore",
+		TransactionPriority::MAX / 4,
+		crate::DAYS as TransactionLongevity,
+	);
+	pub const RenewTxParams: ValidTransactionParams = ValidTransactionParams::new(
+		"TransactionStorageRenew",
+		TransactionPriority::MAX / 4,
+		crate::DAYS as TransactionLongevity,
+	);
+	pub const AuthorizeTxParams: ValidTransactionParams = ValidTransactionParams::new(
+		"TransactionStorageAuthorize",
+		TransactionPriority::MAX / 4,
+		crate::DAYS as TransactionLongevity,
+	);
+	pub const RemoveExpiredAccountAuthorizationTxParams: ValidTransactionParams =
+		ValidTransactionParams::new(
+			"TransactionStorageRemoveExpiredAccountAuthorization",
+			TransactionPriority::MAX,
+			crate::DAYS as TransactionLongevity,
+		);
+	pub const RemoveExpiredPreimageAuthorizationTxParams: ValidTransactionParams =
+		ValidTransactionParams::new(
+			"TransactionStorageRemoveExpiredPreimageAuthorization",
+			TransactionPriority::MAX,
+			crate::DAYS as TransactionLongevity,
+		);
+	pub const RemoveExhaustedAuthorizerTxParams: ValidTransactionParams =
+		ValidTransactionParams::new(
+			"TransactionStorageRemoveExhaustedAuthorizer",
+			TransactionPriority::MAX,
+			crate::DAYS as TransactionLongevity,
+		);
 }
 
 /// Tells [`pallet_bulletin_transaction_storage::extension::ValidateStorageCalls`] how to find
@@ -126,10 +153,12 @@ impl pallet_bulletin_transaction_storage::Config for Runtime {
 		// `add_authorizer` / `remove_authorizer`).
 		EnsureAllowedAuthorizers<Runtime>,
 	>;
-	type StoreRenewPriority = StoreRenewPriority;
-	type StoreRenewLongevity = StoreRenewLongevity;
-	type RemoveExpiredAuthorizationPriority = RemoveExpiredAuthorizationPriority;
-	type RemoveExpiredAuthorizationLongevity = RemoveExpiredAuthorizationLongevity;
+	type StoreTxParams = StoreTxParams;
+	type RenewTxParams = RenewTxParams;
+	type AuthorizeTxParams = AuthorizeTxParams;
+	type RemoveExpiredAccountAuthorizationTxParams = RemoveExpiredAccountAuthorizationTxParams;
+	type RemoveExpiredPreimageAuthorizationTxParams = RemoveExpiredPreimageAuthorizationTxParams;
+	type RemoveExhaustedAuthorizerTxParams = RemoveExhaustedAuthorizerTxParams;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper =
 		pallet_bulletin_transaction_storage::benchmarking::DefaultCheckProofHelper;
@@ -139,9 +168,13 @@ parameter_types! {
 	/// Maximum allowable skew between the user's submit timestamp and the on-chain
 	/// time when validating a HOP promotion: 48 hours, in milliseconds.
 	pub const SubmitTimestampTolerance: u64 = 48 * 60 * 60 * 1000;
+	// Lowest priority: promotion only fills blockspace stores would not have used.
+	pub const PromoteTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("HopPromotion", 0, 5);
 }
 
 impl pallet_bulletin_hop_promotion::Config for Runtime {
 	type SubmitTimestampTolerance = SubmitTimestampTolerance;
+	type PromoteTxParams = PromoteTxParams;
 	type WeightInfo = crate::weights::pallet_bulletin_hop_promotion::WeightInfo<Runtime>;
 }

--- a/runtimes/bulletin-westend/src/storage.rs
+++ b/runtimes/bulletin-westend/src/storage.rs
@@ -17,8 +17,6 @@ use frame_system::EnsureSignedBy;
 use pallet_bulletin_transaction_storage::{
 	AsAuthorizer, CallInspector, EnsureAllowedAuthorizers, ValidTransactionParams,
 	DEFAULT_MAX_BLOCK_TRANSACTIONS, DEFAULT_MAX_TRANSACTION_SIZE,
-	REMOVE_EXHAUSTED_AUTHORIZER_TAG_PREFIX, REMOVE_EXPIRED_ACCOUNT_AUTHORIZATION_TAG_PREFIX,
-	REMOVE_EXPIRED_PREIMAGE_AUTHORIZATION_TAG_PREFIX, RENEW_TAG_PREFIX, STORE_TAG_PREFIX,
 };
 use pallet_xcm::EnsureXcm;
 use sp_keyring::Sr25519Keyring;
@@ -44,43 +42,37 @@ impl SortedMembers<AccountId> for TestAccounts {
 	}
 }
 
+/// Cleanup runs before stores compete for blockspace.
+const CLEANUP_PRIORITY: TransactionPriority = TransactionPriority::MAX;
+/// Below `MAX` so `AllowanceBasedPriority` can add its boost without saturating `u64`.
+const STORE_PRIORITY: TransactionPriority = TransactionPriority::MAX / 4;
+const TX_LONGEVITY: TransactionLongevity = crate::DAYS as TransactionLongevity;
+
 parameter_types! {
 	pub const AuthorizationPeriod: crate::BlockNumber = 14 * crate::DAYS;
-	// Cleanup sits at `MAX` so it always runs before stores compete for blockspace. The
-	// rest sit well below it so `AllowanceBasedPriority` can add its boost without
-	// saturating `u64`. Prefixes come from the pallet; only this pricing is per-chain.
-	pub const StoreTxParams: ValidTransactionParams = ValidTransactionParams::new(
-		STORE_TAG_PREFIX,
-		TransactionPriority::MAX / 4,
-		crate::DAYS as TransactionLongevity,
-	);
-	pub const RenewTxParams: ValidTransactionParams = ValidTransactionParams::new(
-		RENEW_TAG_PREFIX,
-		TransactionPriority::MAX / 4,
-		crate::DAYS as TransactionLongevity,
-	);
-	pub const AuthorizeTxParams: ValidTransactionParams = ValidTransactionParams::new(
-		"TransactionStorageAuthorize",
-		TransactionPriority::MAX / 4,
-		crate::DAYS as TransactionLongevity,
-	);
+	pub const StoreTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("TransactionStorageStore", STORE_PRIORITY, TX_LONGEVITY);
+	pub const RenewTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("TransactionStorageRenew", STORE_PRIORITY, TX_LONGEVITY);
+	pub const AuthorizeTxParams: ValidTransactionParams =
+		ValidTransactionParams::new("TransactionStorageAuthorize", STORE_PRIORITY, TX_LONGEVITY);
 	pub const RemoveExpiredAccountAuthorizationTxParams: ValidTransactionParams =
 		ValidTransactionParams::new(
-			REMOVE_EXPIRED_ACCOUNT_AUTHORIZATION_TAG_PREFIX,
-			TransactionPriority::MAX,
-			crate::DAYS as TransactionLongevity,
+			"TransactionStorageRemoveExpiredAccountAuthorization",
+			CLEANUP_PRIORITY,
+			TX_LONGEVITY,
 		);
 	pub const RemoveExpiredPreimageAuthorizationTxParams: ValidTransactionParams =
 		ValidTransactionParams::new(
-			REMOVE_EXPIRED_PREIMAGE_AUTHORIZATION_TAG_PREFIX,
-			TransactionPriority::MAX,
-			crate::DAYS as TransactionLongevity,
+			"TransactionStorageRemoveExpiredPreimageAuthorization",
+			CLEANUP_PRIORITY,
+			TX_LONGEVITY,
 		);
 	pub const RemoveExhaustedAuthorizerTxParams: ValidTransactionParams =
 		ValidTransactionParams::new(
-			REMOVE_EXHAUSTED_AUTHORIZER_TAG_PREFIX,
-			TransactionPriority::MAX,
-			crate::DAYS as TransactionLongevity,
+			"TransactionStorageRemoveExhaustedAuthorizer",
+			CLEANUP_PRIORITY,
+			TX_LONGEVITY,
 		);
 }
 

--- a/stress-test/src/scenarios/throughput.rs
+++ b/stress-test/src/scenarios/throughput.rs
@@ -565,7 +565,7 @@ pub async fn run_sequential_upload(
 	let ws_owned: Vec<String> = ws_urls.iter().map(|s| s.to_string()).collect();
 	let futures: Vec<_> = signers
 		.iter()
-		.zip(all_payloads.into_iter())
+		.zip(all_payloads)
 		.enumerate()
 		.map(|(i, (signer, payloads))| {
 			let ws = ws_owned.clone();

--- a/stress-test/src/store.rs
+++ b/stress-test/src/store.rs
@@ -1094,7 +1094,7 @@ pub async fn submit_sequential_wave(
 				},
 				Err(e) => {
 					let msg = format!("{e}");
-					let class = classify_tx_error(&anyhow::anyhow!("{}", &msg));
+					let class = classify_tx_error(&anyhow::anyhow!("{}", msg));
 					// Keep first 5 raw errors for log output.
 					{
 						let mut errs = raw_errs.lock().unwrap();

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -168,17 +168,17 @@ async fn spawn_shared_harness(
 }
 
 fn get_para_node_args_with_pruning(blocks_pruning: u32) -> Vec<String> {
-	// Extends NODE_LOG_CONFIG with pruning-side targets so a "bitswap still has data after
-	// pruning should have fired" failure has the corresponding node events to read:
-	//   - `db=debug`: `Removing block #N` from sc-client-db::prune_block (the
-	//     pruning-actually-fired confirmation)
+	// A pruning-focused log config, NOT the full `NODE_LOG_CONFIG` firehose. The libp2p/sync
+	// trace targets (`litep2p`, `sub-libp2p`, `sync`, `request-response`) generate ~10 MB per
+	// node in a few minutes, which overwhelms the shared-network log files and gets truncated
+	// long before the failing test runs — so a pruning-eviction failure ships un-diagnosable
+	// logs. Keep only what a "bitswap still serves data after pruning" failure needs:
+	//   - `db=debug`: `Removing block #N` from sc-client-db::prune_block (pruning fired)
 	//   - `state-db=debug` / `state-db::pin=debug`: canonicalization + pin/unpin
+	//   - `transaction-storage=trace` / `bitswap=trace`: col11 indexing + the served block
 	// (Node uses RocksDB — `parity-db` target would never fire.)
-	let log_targets = format!(
-		"{},db=debug,state-db=debug,state-db::pin=debug",
-		// Strip the leading "-l" so we can append more comma-separated targets.
-		NODE_LOG_CONFIG.strip_prefix("-l").unwrap_or(NODE_LOG_CONFIG)
-	);
+	let log_targets =
+		"transaction-storage=trace,bitswap=trace,db=debug,state-db=debug,state-db::pin=debug";
 	vec![
 		"--ipfs-server".into(),
 		format!("--blocks-pruning={}", blocks_pruning),
@@ -883,6 +883,25 @@ async fn parachain_auto_renew_vs_no_renew_eviction_test() -> Result<()> {
 		 original store block was pruned",
 	)?;
 	tracing::info!("✓ data_renewed still served via bitswap");
+
+	// `data_not_renewed` was stored a few blocks after `data_renewed`, so its store block
+	// crosses the `--blocks-pruning` boundary later than the `wait_until` above (which is
+	// anchored to `data_renewed`). Wait for FINALIZED to pass it before asserting eviction,
+	// otherwise the DONT_HAVE poll also has to absorb the finality-lag gap and races under
+	// slower finalization.
+	let not_renewed_pruned_finalized =
+		data_not_renewed_block + BLOCKS_PRUNING_GREATER_THAN_RETENTION as u64 + 1;
+	tracing::info!(
+		"Waiting for FINALIZED block {} so data_not_renewed's store block {} is past the pruning boundary",
+		not_renewed_pruned_finalized,
+		data_not_renewed_block
+	);
+	wait_for_finalized_height(
+		collator1,
+		not_renewed_pruned_finalized,
+		BLOCK_PRODUCTION_TIMEOUT_SECS,
+	)
+	.await?;
 
 	expect_bitswap_dont_have(
 		collator1,

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -19,7 +19,7 @@ use crate::{
 		verify_parachain_binaries, wait_for_block_height, wait_for_finalized_height,
 		wait_for_finalized_quiescence, wait_for_session_change_on_node, AuthorizationOverride,
 		BLOCK_PRODUCTION_TIMEOUT_SECS, NETWORK_READY_TIMEOUT_SECS, NODE_LOG_CONFIG,
-		PARACHAIN_TEST_DATA_PATTERN, TEST_DATA_SIZE,
+		PARACHAIN_TEST_DATA_PATTERN, PRUNING_NODE_LOG_CONFIG, TEST_DATA_SIZE,
 	},
 };
 use anyhow::{Context, Result};
@@ -167,17 +167,24 @@ async fn spawn_shared_harness(
 	Ok(std::sync::Arc::new(SharedHarness { _network: network, collator1 }))
 }
 
+/// Wait for the FINALIZED head to clear `block`'s `--blocks-pruning` boundary. Pruning
+/// fires off the finalized head, not the best head, so waiting on best-block plus a fudge
+/// is flaky under finality lag.
+async fn wait_past_pruning_boundary(
+	node: &zombienet_sdk::NetworkNode,
+	block: u64,
+	what: &str,
+) -> Result<()> {
+	let target = block + BLOCKS_PRUNING_GREATER_THAN_RETENTION as u64 + 1;
+	tracing::info!("Waiting for FINALIZED block {target} so {what} ({block}) is past pruning");
+	wait_for_finalized_height(node, target, BLOCK_PRODUCTION_TIMEOUT_SECS).await
+}
+
 fn get_para_node_args_with_pruning(blocks_pruning: u32) -> Vec<String> {
-	// Deliberately not `NODE_LOG_CONFIG`: its libp2p/sync trace targets emit ~10 MB per node
-	// in minutes, truncating the shared-network log files long before the failing test runs.
-	// These are what a "bitswap still serves data after pruning" failure needs to be
-	// diagnosable. (Node uses RocksDB, so a `parity-db` target would never fire.)
-	let log_targets =
-		"transaction-storage=trace,bitswap=trace,db=debug,state-db=debug,state-db::pin=debug";
 	vec![
 		"--ipfs-server".into(),
 		format!("--blocks-pruning={}", blocks_pruning),
-		format!("-l{}", log_targets),
+		PRUNING_NODE_LOG_CONFIG.into(),
 		"--".into(),
 		"--network-backend=libp2p".into(),
 	]
@@ -583,20 +590,7 @@ async fn parachain_renew_twice_within_block_with_pruning_test() -> Result<()> {
 
 	verify_node_bitswap(collator1, &data, BITSWAP_TIMEOUT_SECS, "Collator-1 (post-renew)").await?;
 
-	// `--blocks-pruning=N` prunes blocks N behind FINALIZED head, not best head. Waiting
-	// on best-block + fudge is flaky under finality lag.
-	let after_renew_pruned_finalized =
-		renew_block + BLOCKS_PRUNING_GREATER_THAN_RETENTION as u64 + 1;
-	tracing::info!(
-		"Waiting for FINALIZED block {} so both store and renew blocks are past the pruning boundary",
-		after_renew_pruned_finalized
-	);
-	wait_for_finalized_height(
-		collator1,
-		after_renew_pruned_finalized,
-		BLOCK_PRODUCTION_TIMEOUT_SECS,
-	)
-	.await?;
+	wait_past_pruning_boundary(collator1, renew_block, "the renew block").await?;
 
 	expect_bitswap_dont_have(
 		collator1,
@@ -711,20 +705,14 @@ async fn parachain_auto_renew_with_concurrent_store_test() -> Result<()> {
 	verify_node_bitswap(collator1, &data1, BITSWAP_TIMEOUT_SECS, "Collator-1 / data1").await?;
 	verify_node_bitswap(collator1, &data2, BITSWAP_TIMEOUT_SECS, "Collator-1 / data2").await?;
 
-	// Pruning fires off FINALIZED head — wait on finalized to cross the boundary directly.
-	// Use the later of the two refcounted blocks (renewal_block holds data1's renewed entry,
-	// data2_block holds data2). Both must be past the pruning window for col11 cleanup.
-	let last_refcounted_block = renewal_block.max(data2_block);
-	let after_pruning_finalized =
-		last_refcounted_block + BLOCKS_PRUNING_GREATER_THAN_RETENTION as u64 + 1;
-	tracing::info!(
-		"Waiting for FINALIZED block {} so renewal_block={} and data2_block={} are past pruning",
-		after_pruning_finalized,
-		renewal_block,
-		data2_block
-	);
-	wait_for_finalized_height(collator1, after_pruning_finalized, BLOCK_PRODUCTION_TIMEOUT_SECS)
-		.await?;
+	// The later of the two refcounted blocks: renewal_block holds data1's renewed entry,
+	// data2_block holds data2. Both must clear the window for col11 cleanup.
+	wait_past_pruning_boundary(
+		collator1,
+		renewal_block.max(data2_block),
+		"the last refcounted block",
+	)
+	.await?;
 
 	// Proof for data2's stored block fires at `data2_block + RP`. When data2 == renewal_block,
 	// this is also the proof block for data1's renewed entry (same block).
@@ -880,21 +868,10 @@ async fn parachain_auto_renew_vs_no_renew_eviction_test() -> Result<()> {
 	tracing::info!("✓ data_renewed still served via bitswap");
 
 	// The `wait_until` above is anchored to `data_renewed`, but `data_not_renewed` was stored
-	// a few blocks later, so it crosses the pruning boundary later. Without this the DONT_HAVE
-	// poll also has to absorb the finality-lag gap, and races under slow finalization.
-	let not_renewed_pruned_finalized =
-		data_not_renewed_block + BLOCKS_PRUNING_GREATER_THAN_RETENTION as u64 + 1;
-	tracing::info!(
-		"Waiting for FINALIZED block {} so data_not_renewed's store block {} is past the pruning boundary",
-		not_renewed_pruned_finalized,
-		data_not_renewed_block
-	);
-	wait_for_finalized_height(
-		collator1,
-		not_renewed_pruned_finalized,
-		BLOCK_PRODUCTION_TIMEOUT_SECS,
-	)
-	.await?;
+	// a few blocks later. Without this the DONT_HAVE poll also has to absorb the finality-lag
+	// gap, and races under slow finalization.
+	wait_past_pruning_boundary(collator1, data_not_renewed_block, "data_not_renewed's store block")
+		.await?;
 
 	expect_bitswap_dont_have(
 		collator1,

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -168,15 +168,10 @@ async fn spawn_shared_harness(
 }
 
 fn get_para_node_args_with_pruning(blocks_pruning: u32) -> Vec<String> {
-	// A pruning-focused log config, NOT the full `NODE_LOG_CONFIG` firehose. The libp2p/sync
-	// trace targets (`litep2p`, `sub-libp2p`, `sync`, `request-response`) generate ~10 MB per
-	// node in a few minutes, which overwhelms the shared-network log files and gets truncated
-	// long before the failing test runs — so a pruning-eviction failure ships un-diagnosable
-	// logs. Keep only what a "bitswap still serves data after pruning" failure needs:
-	//   - `db=debug`: `Removing block #N` from sc-client-db::prune_block (pruning fired)
-	//   - `state-db=debug` / `state-db::pin=debug`: canonicalization + pin/unpin
-	//   - `transaction-storage=trace` / `bitswap=trace`: col11 indexing + the served block
-	// (Node uses RocksDB — `parity-db` target would never fire.)
+	// Deliberately not `NODE_LOG_CONFIG`: its libp2p/sync trace targets emit ~10 MB per node
+	// in minutes, truncating the shared-network log files long before the failing test runs.
+	// These are what a "bitswap still serves data after pruning" failure needs to be
+	// diagnosable. (Node uses RocksDB, so a `parity-db` target would never fire.)
 	let log_targets =
 		"transaction-storage=trace,bitswap=trace,db=debug,state-db=debug,state-db::pin=debug";
 	vec![
@@ -884,11 +879,9 @@ async fn parachain_auto_renew_vs_no_renew_eviction_test() -> Result<()> {
 	)?;
 	tracing::info!("✓ data_renewed still served via bitswap");
 
-	// `data_not_renewed` was stored a few blocks after `data_renewed`, so its store block
-	// crosses the `--blocks-pruning` boundary later than the `wait_until` above (which is
-	// anchored to `data_renewed`). Wait for FINALIZED to pass it before asserting eviction,
-	// otherwise the DONT_HAVE poll also has to absorb the finality-lag gap and races under
-	// slower finalization.
+	// The `wait_until` above is anchored to `data_renewed`, but `data_not_renewed` was stored
+	// a few blocks later, so it crosses the pruning boundary later. Without this the DONT_HAVE
+	// poll also has to absorb the finality-lag gap, and races under slow finalization.
 	let not_renewed_pruned_finalized =
 		data_not_renewed_block + BLOCKS_PRUNING_GREATER_THAN_RETENTION as u64 + 1;
 	tracing::info!(

--- a/zombienet-sdk-tests/tests/utils/config.rs
+++ b/zombienet-sdk-tests/tests/utils/config.rs
@@ -35,6 +35,12 @@ pub const LOG_ERROR_TIMEOUT_SECS: u64 = 10;
 pub const TEST_DATA_SIZE: usize = 2048;
 pub const TRANSACTION_STORAGE_COLUMN: &str = "col11";
 pub const NODE_LOG_CONFIG: &str = "-lsync=trace,sub-libp2p=trace,litep2p=trace,request-response=trace,transaction-storage=trace,bitswap=trace";
+/// For pruning-eviction tests. Deliberately omits `NODE_LOG_CONFIG`'s libp2p/sync trace
+/// targets: they emit ~10 MB per node in minutes, truncating the shared-network log files
+/// long before the failing test runs. The `db`/`state-db` targets are what shows whether
+/// pruning actually fired. (Node uses RocksDB, so a `parity-db` target would never fire.)
+pub const PRUNING_NODE_LOG_CONFIG: &str =
+	"-ltransaction-storage=trace,bitswap=trace,db=debug,state-db=debug,state-db::pin=debug";
 
 // Parachain network topology (configurable via env vars)
 pub const RELAY_CHAIN_ENV: &str = "RELAY_CHAIN";


### PR DESCRIPTION
### What

Extracts the fixes and refactors that ride along in #571 (the renewal pallet split) but do not depend on it, so they can land on their own and #571 shrinks to the split itself.

**Pool params.** One runtime-supplied `ValidTransactionParams { tag_prefix, priority, longevity }` per call family, replacing the `StoreRenew{Priority,Longevity}` and `RemoveExpiredAuthorization{Priority,Longevity}` pairs and the `ValidTransaction` builder chain spelled out at each construction site. Prefixes must be pairwise distinct, which `integrity_test` now checks for every family — including `authorize_*`, whose prefix is unread today (it validates untagged) but would otherwise be an exception the check had to omit.

**A pool conflict fixed.** Preimage-authorized `store` and `force_renew` both tagged `("TransactionStorageStoreRenew", content_hash)`, so a renew evicted a pending store of the same blob. They now sit on distinct prefixes, as the signed path already did.

**hop-promotion.** `PromoteTxParams` comes from the runtime, and `integrity_test` asserts `promote < store` priority directly instead of a test that stored, renewed and compared emitted priorities. `authorize_promote` also reported a bad blob size as `InvalidTransaction::Custom(0)` — which is `IMPOSSIBLE`, "implies a bug" — so an empty or oversized HOP blob told the submitter the node had hit an internal error. It reports `BAD_DATA_SIZE` now; two tests had pinned the wrong value.

**try-state direction.** `do_try_state` errored on any drift between `PermanentStorageUsed` and `Σ renewed + Σ prepaid`. Both directions are reachable on live state through history this pallet did not create — pre-counter `Renew` entries were never charged (under-count), and Root dropping a prepaid registration never decrements (over-count) — so it fails on real chains and would fire in the check-migration jobs. The equality is now enforced under `cfg(test)`, where state is built from nothing, and logged on a live chain. `used <= MaxPermanentStorageSize` stays a hard error. The drift test covered only the over-count direction; it now covers both.

**Docs.** `cargo doc --no-deps` went from ten warnings to zero.

**Tests and CI.** The pruning test ran the full `NODE_LOG_CONFIG` firehose, whose libp2p/sync trace targets truncated the log files before the failing test ran; `parachain_auto_renew_vs_no_renew_eviction_test` anchored its finality wait to the wrong blob and raced under slower finalization; zombienet log artifacts carried the RocksDB `db/` noise; two clippy nits in stress-test.

### Behaviour vs `main`

No consensus change. Nothing touches `pallet::storage`, `pallet::call_index`, `pallet::weight`, `pallet::event`, `pallet::error` or any dispatch body; `extension.rs`, `benchmarking.rs` and `weights.rs` are untouched. Every functional hunk is in pool validation, `integrity_test`, or `do_try_state`. Priorities and longevities are byte-identical to `main` (store/renew/authorize `MAX/4`, cleanup `MAX`, all `DAYS`).

Four observable differences:

1. Pool tag prefixes on the preimage path change — the deliberate fix above. Pool tags are node-local, not consensus, so no upgrade coordination.
2. `promote`'s rejection code for a bad blob size goes from `Custom(0)` to `Custom(1)`.
3. The four old pool constants are renamed and reshaped in metadata (see below).
4. try-runtime `try_state` warns instead of erroring on counter drift — off-chain tooling only, and a deliberate loosening.

`integrity_test` gains a new panic path for a mis-wired runtime (shared prefix, or `promote` priority not below `store`). Both runtimes pass, as the `construct_runtime`-generated integrity test covers.

### Metadata

All seven pool-param items are `#[pallet::constant]`, so pool pricing stays readable from metadata. (`#[pallet::constant]` needs only `TypeInfo + Encode`, not `Decode` or `MaxEncodedLen`, and `&'static str` has both via blanket impls.) The old names are still gone, though — a consumer reading `StoreRenewPriority` breaks and must read `StoreTxParams` instead, whose value encodes as compact-length prefix, prefix bytes, then two `u64`s.

### Left in #571

Split scaffolding: the `LeafValidator` / `ValidateAuthorizedCalls` rework, `TransactionInfo<Meta>` / `AuthorizationExtent<Extra>` genericization, the relocation migration, the regenerated `sdk/metadata.scale`, and the `DataRenewal` fallbacks in console-ui and the SDKs.

### Release impact

Breaking for `pallet-bulletin-transaction-storage` and `pallet-bulletin-hop-promotion` (`Config` changes). `bulletin-transaction-storage-primitives` is purely additive, so a caret-compatible bump keeps `pallet-bulletin-transaction-storage-runtime-api` and `bulletin-pallets-common` out of the release.

### Known, not addressed here

The try-state equality only becomes unconditional once its two drift causes are retired: `disable_auto_renew`'s Root arm drops a `paid` registration without decrementing `PermanentStorageUsed`, and legacy pre-counter `Renew` entries need a migration that recomputes the counter. Both are consensus changes, out of scope for a port. Separately, the nine `parachain_sync_storage.rs` call sites still use the truncating `NODE_LOG_CONFIG`.
