### PR TITLE
Follow-ups to #571 review comments

### DIFF
--- a/examples/check_auto_renew_chopsticks.js
+++ b/examples/check_auto_renew_chopsticks.js
@@ -14,16 +14,14 @@
  *  6. Advances to the expiry block. There `TransactionStorage::on_initialize`
  *     ages the data out and queues it into `DataRenewal.PendingAutoRenewals`
  *     for the same block's `process_pending_renewals` mandatory inherent.
- *  7. Injects the `DataRenewal.process_pending_renewals` inherent into that
- *     block via `dev_newBlock({ transactions })` and verifies the drain:
+ *  7. Builds the expiry block and verifies the drain:
  *       - PendingAutoRenewals is emptied (taken by the inherent)
  *       - TransactionByContentHash now points at the expiry block (renewed)
  *       - the recurring registration survives with `paid = false`
  *
- * Chopsticks does not natively synthesize custom pallet inherents (see
- * AcalaNetwork/chopsticks#1037 — it only learned the storage-pallet proof
- * inherent). This test therefore injects the mandatory renewal inherent
- * explicitly, which exercises the exact on-chain code path a collator runs.
+ * Chopsticks synthesizes the mandatory `DataRenewal.process_pending_renewals`
+ * inherent itself (AcalaNetwork/chopsticks#1064), so plain `dev_newBlock()`
+ * exercises the exact on-chain code path a collator runs.
  *
  * Usage:
  *   node check_auto_renew_chopsticks.js [endpoint] [wasm_path]
@@ -46,17 +44,10 @@ import {
   Bytes,
   Vector,
   Tuple,
-  decAnyMetadata,
-  unifyMetadata,
 } from "@polkadot-api/substrate-bindings";
 
 const endpoint = process.argv[2] || "wss://westend-bulletin-rpc.polkadot.io";
 const runtimeWasm = process.argv[3] || null;
-
-// The mandatory drain inherent. Indices come from metadata, not hardcoded: a
-// `construct_runtime` change would otherwise point them at some other call.
-const PALLET_NAME = "DataRenewal";
-const CALL_NAME = "process_pending_renewals";
 
 // ─── PAPI Typed Codecs ────────────────────────────────────────────────────
 //
@@ -130,53 +121,6 @@ function mapKey(pallet, name, keyBytes) {
 /** Encode a value with a PAPI codec and return a 0x-prefixed hex string */
 function encodeHex(codec, value) {
   return "0x" + toHex(codec.enc(value));
-}
-
-/**
- * Encode a bare (unsigned) extrinsic wrapping a nullary call. Bare extrinsics
- * are how inherents reach the runtime: version byte = EXTRINSIC_FORMAT_VERSION
- * (5) with the bare type bits (0), followed by the pallet+call indices, all
- * behind a SCALE compact length prefix.
- */
-function bareInherentExtrinsic(palletIndex, callIndex) {
-  const EXTRINSIC_FORMAT_VERSION = 5;
-  const body = new Uint8Array([EXTRINSIC_FORMAT_VERSION, palletIndex, callIndex]);
-  // Compact length for < 64 bytes is a single byte: len << 2.
-  const prefixed = new Uint8Array([body.length << 2, ...body]);
-  return "0x" + toHex(prefixed);
-}
-
-/** Resolve `pallet.call` to its `(palletIndex, callIndex)` from runtime metadata. */
-async function resolveCallIndices(provider, palletName, callName) {
-  const meta = unifyMetadata(decAnyMetadata(await provider.send("state_getMetadata", [], false)));
-
-  const pallet = meta.pallets.find((p) => p.name === palletName);
-  if (!pallet) {
-    throw new Error(
-      `Pallet ${palletName} is absent from the runtime metadata (found: ${meta.pallets
-        .map((p) => p.name)
-        .join(", ")})`,
-    );
-  }
-  if (pallet.calls === undefined) {
-    throw new Error(`Pallet ${palletName} declares no calls`);
-  }
-
-  const callsType = meta.lookup.find((entry) => entry.id === pallet.calls.type);
-  if (callsType?.def.tag !== "variant") {
-    throw new Error(`Call type ${pallet.calls.type} of ${palletName} is not a variant`);
-  }
-
-  const variant = callsType.def.value.find((v) => v.name === callName);
-  if (!variant) {
-    throw new Error(
-      `${palletName} has no call ${callName} (found: ${callsType.def.value
-        .map((v) => v.name)
-        .join(", ")})`,
-    );
-  }
-
-  return { palletIndex: pallet.index, callIndex: variant.index };
 }
 
 // ─── Logging helpers ──────────────────────────────────────────────────────
@@ -349,15 +293,12 @@ async function main() {
     logOk(`Block #${chain.head.number} produced`);
   }
 
-  // ── Expiry block: on_initialize queues PendingAutoRenewals, and the injected
-  //    process_pending_renewals inherent drains it in the same block. ──
-  logStep(7, "Building the expiry block with the process_pending_renewals inherent injected...");
-  const { palletIndex, callIndex } = await resolveCallIndices(provider, PALLET_NAME, CALL_NAME);
-  logOk(`${PALLET_NAME}.${CALL_NAME} resolved from metadata to (${palletIndex}, ${callIndex})`);
-  const inherent = bareInherentExtrinsic(palletIndex, callIndex);
-  console.log(`  Injecting inherent extrinsic: ${inherent}`);
+  // ── Expiry block: on_initialize queues PendingAutoRenewals, and the
+  //    process_pending_renewals inherent (synthesized by Chopsticks) drains it
+  //    in the same block. ──
+  logStep(7, "Building the expiry block (Chopsticks supplies the process_pending_renewals inherent)...");
   await provider.send("dev_setStorage", [[[proofCheckedKey, "0x01"]]], false);
-  await provider.send("dev_newBlock", [{ transactions: [inherent] }], false);
+  await provider.send("dev_newBlock", [], false);
   if (chain.head.number < expiryBlock) {
     throw new Error(`Expected block #${expiryBlock}, got #${chain.head.number}`);
   }

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-core": "^1.5.0",
+        "@acala-network/chopsticks-core": "^1.5.1",
         "@ipld/dag-pb": "^4.1.3",
         "@polkadot-api/descriptors": "file:.papi/descriptors",
         "@polkadot-api/substrate-bindings": "^0.20.2",
@@ -40,12 +40,12 @@
       }
     },
     "node_modules/@acala-network/chopsticks-core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.5.0.tgz",
-      "integrity": "sha512-DnWoga/1/Tiqyb4rSk62iZO6yR8/GdwBOmMDaAIxmxLsh6EEEFozhnw3wzcC9LeDX0uo/6YCejyiOcTTY+MT4w==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.5.1.tgz",
+      "integrity": "sha512-o0ZywjKIKPOuB5eCtHWAeGpfDfWUaAG0yJ5vvdkLepeHcxN7m88IoCoAiyDiit+A2SNZmnGy3ql79Xj4/QaFdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-executor": "1.5.0",
+        "@acala-network/chopsticks-executor": "1.5.1",
         "@polkadot/rpc-provider": "^16.4.1",
         "@polkadot/types": "^16.4.1",
         "@polkadot/types-codec": "^16.4.1",
@@ -66,9 +66,9 @@
       }
     },
     "node_modules/@acala-network/chopsticks-executor": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.5.0.tgz",
-      "integrity": "sha512-rT+dOIdXGNJeZ19L7eKK8k3xvkRdaxLlu47NKTNTNxANzSl9Gs5FMx0a7hwWo6DIPuTj9SLBW9JK+8L4AnrGqA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.5.1.tgz",
+      "integrity": "sha512-0dxkDaWdweAxhodfvYOQt8KzCxs5Jpo5xZ5N3YhGc/lMeIvDd6kEAxdpyLMgyiWjqyKdHph65a4CCHYc5jAqcg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/util": "^14.0.1",

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,7 +8,7 @@
     "papi:update": "papi"
   },
   "dependencies": {
-    "@acala-network/chopsticks-core": "^1.5.0",
+    "@acala-network/chopsticks-core": "^1.5.1",
     "@ipld/dag-pb": "^4.1.3",
     "@polkadot-api/descriptors": "file:.papi/descriptors",
     "@polkadot-api/substrate-bindings": "^0.20.2",

--- a/pallets/data-renewal/src/benchmarking.rs
+++ b/pallets/data-renewal/src/benchmarking.rs
@@ -260,7 +260,7 @@ mod benchmarks {
 					cid_codec: RAW_CODEC,
 					extrinsic_index: 0,
 					block_chunks: 0,
-					meta: EntryKind::Store,
+					meta: Default::default(),
 				};
 				let renewal_data = RenewalData { account: caller, recurring: true, paid: false };
 				pending

--- a/pallets/data-renewal/src/lib.rs
+++ b/pallets/data-renewal/src/lib.rs
@@ -32,7 +32,7 @@
 //! ## Cross-pallet contract
 //!
 //! The storage pallet has no renewal vocabulary; this pallet owns all of it through
-//! two opaque payloads the runtime wires ([`EntryKind`] as `EntryMeta`,
+//! two opaque payloads the runtime wires (an `EntryMeta` implementing [`RenewMeta`],
 //! [`PermanentExtent`] as `AuthorizationExtra`):
 //!
 //! - **Down → storage:** dispatchables use the storage pallet's public API; the per-account renew
@@ -67,7 +67,7 @@ mod mock;
 mod tests;
 
 pub use pallet::*;
-pub use types::{EntryKind, PermanentExtent, RenewalData};
+pub use types::{PermanentExtent, RenewMeta, RenewalData};
 pub use weights::WeightInfo;
 
 use bulletin_transaction_storage_primitives::ContentHash;
@@ -117,7 +117,7 @@ pub mod pallet {
 	pub trait Config:
 		frame_system::Config
 		+ pallet_bulletin_transaction_storage::Config<
-			EntryMeta = EntryKind,
+			EntryMeta: RenewMeta,
 			AuthorizationExtra = PermanentExtent,
 		>
 	{
@@ -481,7 +481,7 @@ impl<T: Config> Pallet<T> {
 		let extrinsic_index =
 			<frame_system::Pallet<T>>::extrinsic_index().ok_or(Error::<T>::BadContext)?;
 		pallet_bulletin_transaction_storage::Pallet::<T>::with_block_transactions(|entries| {
-			entries.renew(&info, extrinsic_index, EntryKind::Renew)
+			entries.renew(&info, extrinsic_index, T::EntryMeta::renew())
 		})
 		.ok_or(Error::<T>::TooManyTransactions)
 	}
@@ -528,7 +528,7 @@ impl<T: Config> Pallet<T> {
 				let charged =
 					was_paid || Self::check_renew_authorization(&scope, tx_info.size, true).is_ok();
 				let new_index = if charged {
-					entries.renew(&tx_info, extrinsic_index, EntryKind::Renew)
+					entries.renew(&tx_info, extrinsic_index, T::EntryMeta::renew())
 				} else {
 					None
 				};
@@ -742,7 +742,7 @@ impl<T: Config> Pallet<T> {
 			|acc, (_, entries)| {
 				entries
 					.iter()
-					.filter(|t| t.meta == EntryKind::Renew)
+					.filter(|t| t.meta.is_renew())
 					.fold(acc, |inner, t| inner.saturating_add(t.size as u64))
 			},
 		);
@@ -797,14 +797,14 @@ impl<T: Config> Pallet<T> {
 /// Obsolete-block sweep callback: decrements the chain-wide counter for aged-out
 /// `Renew` entries and queues `is_latest` entries with a [`Renewals`] registration
 /// into [`PendingAutoRenewals`] for the same block's inherent.
-impl<T: Config> OnObsoleteTransactions<BlockNumberFor<T>, EntryKind> for Pallet<T> {
+impl<T: Config> OnObsoleteTransactions<BlockNumberFor<T>, T::EntryMeta> for Pallet<T> {
 	fn handle_obsolete(_obsolete: BlockNumberFor<T>, items: &[(TransactionInfoFor<T>, bool)]) {
 		// Renewed bytes leaving the retention window free up permanent capacity.
 		// Stale shadows (`is_latest == false`) count too: their sizes were charged
 		// when their renew was consumed.
 		let renewed_sum: u64 = items
 			.iter()
-			.filter(|(tx_info, _)| tx_info.meta == EntryKind::Renew)
+			.filter(|(tx_info, _)| tx_info.meta.is_renew())
 			.fold(0u64, |acc, (tx_info, _)| acc.saturating_add(tx_info.size as u64));
 		if renewed_sum > 0 {
 			Self::update_permanent_storage_used(|used| used.saturating_sub(renewed_sum));
@@ -888,7 +888,7 @@ impl<T: Config> txs_benchmarking::BenchmarkHelper<T> for RenewalBenchmarkHelper 
 	}
 
 	fn worst_case_entry_meta() -> T::EntryMeta {
-		EntryKind::Renew
+		T::EntryMeta::renew()
 	}
 
 	fn register_worst_case_entry(content_hash: ContentHash) {

--- a/pallets/data-renewal/src/lib.rs
+++ b/pallets/data-renewal/src/lib.rs
@@ -126,7 +126,7 @@ pub mod pallet {
 		/// Weight info for renewal dispatchables.
 		type WeightInfo: WeightInfo;
 		/// Cap, in bytes, on total permanent storage (via `renew`) committed across
-		/// all authorizations. Tracks chain-wide capacity for permanent data.
+		/// all authorizations.
 		#[pallet::constant]
 		type MaxPermanentStorageSize: Get<u64>;
 		/// Pool params for every renewal call. One prefix, so at most one of `renew`,
@@ -794,7 +794,7 @@ impl<T: Config> Pallet<T> {
 	}
 }
 
-/// Obsolete-block sweep callback: decrements the chain-wide counter for aged-out
+/// Obsolete-block sweep callback: decrements [`PermanentStorageUsed`] for aged-out
 /// `Renew` entries and queues `is_latest` entries with a [`Renewals`] registration
 /// into [`PendingAutoRenewals`] for the same block's inherent.
 impl<T: Config> OnObsoleteTransactions<BlockNumberFor<T>, T::EntryMeta> for Pallet<T> {

--- a/pallets/data-renewal/src/mock.rs
+++ b/pallets/data-renewal/src/mock.rs
@@ -40,37 +40,6 @@ type Block = MockBlock<Test>;
 const PRIORITY: TransactionPriority = TransactionPriority::MAX;
 const LONGEVITY: TransactionLongevity = 10;
 
-/// Local stand-in for the runtime-composed `EntryMeta` enum.
-#[derive(
-	Copy,
-	Clone,
-	Debug,
-	PartialEq,
-	Eq,
-	Default,
-	codec::Encode,
-	codec::Decode,
-	codec::MaxEncodedLen,
-	scale_info::TypeInfo,
-)]
-pub enum EntryKind {
-	#[default]
-	#[codec(index = 0)]
-	Store,
-	#[codec(index = 1)]
-	Renew,
-}
-
-impl crate::RenewMeta for EntryKind {
-	fn renew() -> Self {
-		Self::Renew
-	}
-
-	fn is_renew(&self) -> bool {
-		matches!(self, Self::Renew)
-	}
-}
-
 #[frame_support::runtime]
 mod runtime {
 	#[runtime::runtime]
@@ -151,7 +120,7 @@ impl pallet_bulletin_transaction_storage::Config for Test {
 	type RemoveExpiredAccountAuthorizationTxParams = RemoveExpiredAccountAuthorizationTxParams;
 	type RemoveExpiredPreimageAuthorizationTxParams = RemoveExpiredPreimageAuthorizationTxParams;
 	type RemoveExhaustedAuthorizerTxParams = RemoveExhaustedAuthorizerTxParams;
-	type EntryMeta = EntryKind;
+	type EntryMeta = bulletin_transaction_storage_primitives::EntryKind;
 	type AuthorizationExtra = crate::PermanentExtent;
 	type OnObsoleteTransactions = DataRenewal;
 	// The runtimes wire this, so the benchmark tests exercise it too.

--- a/pallets/data-renewal/src/mock.rs
+++ b/pallets/data-renewal/src/mock.rs
@@ -40,6 +40,37 @@ type Block = MockBlock<Test>;
 const PRIORITY: TransactionPriority = TransactionPriority::MAX;
 const LONGEVITY: TransactionLongevity = 10;
 
+/// Local stand-in for the runtime-composed `EntryMeta` enum.
+#[derive(
+	Copy,
+	Clone,
+	Debug,
+	PartialEq,
+	Eq,
+	Default,
+	codec::Encode,
+	codec::Decode,
+	codec::MaxEncodedLen,
+	scale_info::TypeInfo,
+)]
+pub enum EntryKind {
+	#[default]
+	#[codec(index = 0)]
+	Store,
+	#[codec(index = 1)]
+	Renew,
+}
+
+impl crate::RenewMeta for EntryKind {
+	fn renew() -> Self {
+		Self::Renew
+	}
+
+	fn is_renew(&self) -> bool {
+		matches!(self, Self::Renew)
+	}
+}
+
 #[frame_support::runtime]
 mod runtime {
 	#[runtime::runtime]
@@ -120,7 +151,7 @@ impl pallet_bulletin_transaction_storage::Config for Test {
 	type RemoveExpiredAccountAuthorizationTxParams = RemoveExpiredAccountAuthorizationTxParams;
 	type RemoveExpiredPreimageAuthorizationTxParams = RemoveExpiredPreimageAuthorizationTxParams;
 	type RemoveExhaustedAuthorizerTxParams = RemoveExhaustedAuthorizerTxParams;
-	type EntryMeta = crate::EntryKind;
+	type EntryMeta = EntryKind;
 	type AuthorizationExtra = crate::PermanentExtent;
 	type OnObsoleteTransactions = DataRenewal;
 	// The runtimes wire this, so the benchmark tests exercise it too.

--- a/pallets/data-renewal/src/tests.rs
+++ b/pallets/data-renewal/src/tests.rs
@@ -20,8 +20,11 @@
 #![allow(deprecated)]
 
 use crate::{mock::*, PendingAutoRenewals, PermanentExtent, RenewalData, Renewals};
-use bulletin_transaction_storage_primitives::cids::{CidConfig, HashingAlgorithm};
-use codec::Encode;
+use bulletin_transaction_storage_primitives::{
+	cids::{CidConfig, HashingAlgorithm},
+	EntryKind,
+};
+use codec::{Decode, Encode};
 use pallet_bulletin_transaction_storage::{
 	self as txs, pallet::Origin, AuthorizationExtent, AuthorizationScope, TransactionInfo,
 	TransactionRef,
@@ -1904,8 +1907,8 @@ fn renew_bumps_permanent_used_and_records_kind() {
 }
 
 /// `renew` rejects with [`crate::PERMANENT_ALLOWANCE_EXCEEDED`] when the per-account hard cap is
-/// reached: `bytes_permanent + size > bytes_allowance`. The chain-wide counter must remain
-/// untouched.
+/// reached: `bytes_permanent + size > bytes_allowance`. [`crate::PermanentStorageUsed`] must
+/// remain untouched.
 #[test]
 fn renew_rejects_when_per_account_allowance_exceeded() {
 	new_test_ext().execute_with(|| {
@@ -2110,8 +2113,49 @@ fn obsolete_sweep_emits_single_used_updated_event_per_block() {
 	});
 }
 
+/// Live `Transactions` entries carry this exact layout (1-byte `kind` tail) and must
+/// decode through `TransactionInfo<EntryKind>` as-is; the enum's byte values are
+/// pinned in the primitives' `entry_kind_encoding_is_frozen`.
+#[test]
+fn transaction_info_encoding_matches_pre_split_layout() {
+	use crate::RenewMeta;
+	use polkadot_sdk_frame::deps::sp_runtime::traits::{BlakeTwo256, Hash};
+
+	// This pallet's writes must hit the frozen `Renew` byte.
+	assert_eq!(EntryKind::renew(), EntryKind::Renew);
+
+	// The layout live entries were encoded with.
+	#[derive(Encode)]
+	struct FrozenTransactionInfo {
+		chunk_root: <BlakeTwo256 as Hash>::Output,
+		content_hash: [u8; 32],
+		hashing: HashingAlgorithm,
+		cid_codec: u64,
+		size: u32,
+		extrinsic_index: u32,
+		block_chunks: u32,
+		kind: u8, // EntryKind::Renew
+	}
+	let frozen = FrozenTransactionInfo {
+		chunk_root: BlakeTwo256::hash(b"root"),
+		content_hash: [7u8; 32],
+		hashing: HashingAlgorithm::Blake2b256,
+		cid_codec: 0x55,
+		size: 2000,
+		extrinsic_index: 42,
+		block_chunks: 8,
+		kind: 1,
+	};
+	let decoded =
+		TransactionInfo::<EntryKind>::decode(&mut &frozen.encode()[..]).expect("must decode");
+	assert_eq!(decoded.content_hash, [7u8; 32]);
+	assert_eq!(decoded.size, 2000);
+	assert_eq!(decoded.extrinsic_index, 42);
+	assert_eq!(decoded.meta, EntryKind::Renew);
+}
+
 /// Renew emits `PermanentStorageUsedUpdated { used }` so off-chain capacity-planning
-/// dashboards can track the chain-wide counter without polling storage.
+/// dashboards can track [`crate::PermanentStorageUsed`] without polling storage.
 #[test]
 fn renew_emits_permanent_storage_used_updated() {
 	new_test_ext().execute_with(|| {
@@ -2341,7 +2385,7 @@ fn auto_renewal_fails_on_chain_wide_permanent_cap() {
 		assert_ok!(enable_auto_renew_via_extension(who, content_hash));
 		assert_eq!(crate::PermanentStorageUsed::<Test>::get(), 2000);
 
-		// Cycle 1 (prepaid) fires free at block 12 — chain-wide counter is not bumped.
+		// Cycle 1 (prepaid) fires free at block 12 — PermanentStorageUsed is not bumped.
 		init_block(12);
 		assert_ok!(TransactionStorage::authorize_account(
 			RuntimeOrigin::root(),

--- a/pallets/data-renewal/src/tests.rs
+++ b/pallets/data-renewal/src/tests.rs
@@ -19,9 +19,9 @@
 
 #![allow(deprecated)]
 
-use crate::{mock::*, EntryKind, PendingAutoRenewals, PermanentExtent, RenewalData, Renewals};
+use crate::{mock::*, PendingAutoRenewals, PermanentExtent, RenewalData, Renewals};
 use bulletin_transaction_storage_primitives::cids::{CidConfig, HashingAlgorithm};
-use codec::{Decode, Encode};
+use codec::Encode;
 use pallet_bulletin_transaction_storage::{
 	self as txs, pallet::Origin, AuthorizationExtent, AuthorizationScope, TransactionInfo,
 	TransactionRef,
@@ -2108,49 +2108,6 @@ fn obsolete_sweep_emits_single_used_updated_event_per_block() {
 			.count();
 		assert_eq!(count, 1, "exactly one used-updated event per cleanup, not per entry");
 	});
-}
-
-/// `EntryKind` must keep the retired `TransactionKind`'s exact encoding (1 byte;
-/// `Store = 0`, `Renew = 1`): live `Transactions` entries written before the split
-/// decode through `TransactionInfo<EntryKind>` without a storage migration.
-#[test]
-fn entry_kind_encoding_is_frozen() {
-	use polkadot_sdk_frame::deps::sp_runtime::traits::{BlakeTwo256, Hash};
-
-	assert_eq!(EntryKind::Store.encode(), vec![0u8]);
-	assert_eq!(EntryKind::Renew.encode(), vec![1u8]);
-	assert_eq!(EntryKind::default(), EntryKind::Store);
-
-	// Frozen copy of the pre-split `TransactionInfo` layout (tail field was
-	// `kind: TransactionKind`). Bytes written by the old runtime must decode
-	// as the new generic type.
-	#[derive(Encode)]
-	struct FrozenTransactionInfo {
-		chunk_root: <BlakeTwo256 as Hash>::Output,
-		content_hash: [u8; 32],
-		hashing: HashingAlgorithm,
-		cid_codec: u64,
-		size: u32,
-		extrinsic_index: u32,
-		block_chunks: u32,
-		kind: u8, // TransactionKind::Renew
-	}
-	let frozen = FrozenTransactionInfo {
-		chunk_root: BlakeTwo256::hash(b"root"),
-		content_hash: [7u8; 32],
-		hashing: HashingAlgorithm::Blake2b256,
-		cid_codec: 0x55,
-		size: 2000,
-		extrinsic_index: 42,
-		block_chunks: 8,
-		kind: 1,
-	};
-	let decoded =
-		TransactionInfo::<EntryKind>::decode(&mut &frozen.encode()[..]).expect("must decode");
-	assert_eq!(decoded.content_hash, [7u8; 32]);
-	assert_eq!(decoded.size, 2000);
-	assert_eq!(decoded.extrinsic_index, 42);
-	assert_eq!(decoded.meta, EntryKind::Renew);
 }
 
 /// Renew emits `PermanentStorageUsedUpdated { used }` so off-chain capacity-planning

--- a/pallets/data-renewal/src/types.rs
+++ b/pallets/data-renewal/src/types.rs
@@ -17,15 +17,25 @@
 
 //! Type definitions for the data-renewal pallet.
 
+use bulletin_transaction_storage_primitives::EntryKind;
 use codec::{Decode, Encode, MaxEncodedLen};
 
-/// Capability this pallet requires of the runtime-wired `EntryMeta`: contribute the
-/// "renewed" variant and recognize it back. The enum itself belongs to the runtime,
-/// so other pallets can contribute further variants.
+/// Required of the runtime-wired `EntryMeta`: construct the value this pallet writes
+/// on renewed entries, and recognize it. [`EntryKind`] is the stock implementor.
 pub trait RenewMeta {
-	/// Marks an entry appended by `renew`/auto-renewal.
+	/// The value written on entries appended by `renew`/auto-renewal.
 	fn renew() -> Self;
 	fn is_renew(&self) -> bool;
+}
+
+impl RenewMeta for EntryKind {
+	fn renew() -> Self {
+		Self::Renew
+	}
+
+	fn is_renew(&self) -> bool {
+		matches!(self, Self::Renew)
+	}
 }
 
 /// Per-authorization `AuthorizationExtra` wired into the storage pallet: the

--- a/pallets/data-renewal/src/types.rs
+++ b/pallets/data-renewal/src/types.rs
@@ -19,23 +19,13 @@
 
 use codec::{Decode, Encode, MaxEncodedLen};
 
-/// Per-entry `EntryMeta` wired into the storage pallet; `handle_obsolete` decrements
-/// the chain-wide counter for aged-out [`EntryKind::Renew`] entries.
-///
-/// INVARIANT: identical (names and 1-byte encoding) to the retired `TransactionKind`,
-/// so pre-split `Transactions` entries decode without migration. Locked by the
-/// `entry_kind_encoding_is_frozen` test.
-#[derive(
-	Copy, Clone, Debug, PartialEq, Eq, Default, Encode, Decode, scale_info::TypeInfo, MaxEncodedLen,
-)]
-pub enum EntryKind {
-	/// Created by `store`; ages out silently.
-	#[default]
-	#[codec(index = 0)]
-	Store,
-	/// Created by `renew`/auto-renewal; counted in the chain-wide counter.
-	#[codec(index = 1)]
-	Renew,
+/// Capability this pallet requires of the runtime-wired `EntryMeta`: contribute the
+/// "renewed" variant and recognize it back. The enum itself belongs to the runtime,
+/// so other pallets can contribute further variants.
+pub trait RenewMeta {
+	/// Marks an entry appended by `renew`/auto-renewal.
+	fn renew() -> Self;
+	fn is_renew(&self) -> bool;
 }
 
 /// Per-authorization `AuthorizationExtra` wired into the storage pallet: the

--- a/pallets/transaction-storage/primitives/src/lib.rs
+++ b/pallets/transaction-storage/primitives/src/lib.rs
@@ -30,6 +30,24 @@ pub mod cids;
 /// 32-byte hash of a stored blob of data.
 pub type ContentHash = [u8; 32];
 
+/// Stock `EntryMeta` for runtimes wiring the renewal pallet; each variant is written
+/// by exactly one pallet. A runtime needing more variants wires its own enum
+/// implementing the same consumer traits.
+///
+/// INVARIANT: live `Transactions` entries store these exact bytes; do not reorder or
+/// renumber variants. Locked by `entry_kind_encoding_is_frozen`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub enum EntryKind {
+	/// Written by the storage pallet's `store` calls, as the `Default` value.
+	#[default]
+	#[codec(index = 0)]
+	Store,
+	/// Written by the renewal pallet's `renew`/`force_renew`/auto-renewal, via its
+	/// `RenewMeta` impl.
+	#[codec(index = 1)]
+	Renew,
+}
+
 /// A [`ValidTransaction`] minus its `provides` payload. Families that must not evict each
 /// other in the pool need distinct `tag_prefix`es.
 #[derive(Clone, Copy, Encode, TypeInfo)]
@@ -127,5 +145,14 @@ mod tests {
 	#[should_panic(expected = "A and A_AGAIN must not share the tag prefix `a`")]
 	fn shared_tag_prefix_panics() {
 		assert_distinct_tag_prefixes(&[("A", A), ("B", B), ("A_AGAIN", A_AGAIN)]);
+	}
+
+	/// The containing `TransactionInfo` layout is pinned by the renewal pallet's
+	/// `transaction_info_encoding_matches_pre_split_layout`.
+	#[test]
+	fn entry_kind_encoding_is_frozen() {
+		assert_eq!(EntryKind::Store.encode(), vec![0u8]);
+		assert_eq!(EntryKind::Renew.encode(), vec![1u8]);
+		assert_eq!(EntryKind::default(), EntryKind::Store);
 	}
 }

--- a/pallets/transaction-storage/src/benchmarking.rs
+++ b/pallets/transaction-storage/src/benchmarking.rs
@@ -41,20 +41,19 @@ pub trait BenchmarkHelper<T: Config> {
 	/// `OnObsoleteTransactions` callback do its worst-case work. Runtimes wiring the
 	/// renewal pallet should return its permanent variant so the benchmark exercises
 	/// the renewed-byte counter decrement.
-	fn worst_case_entry_meta() -> T::EntryMeta {
-		Default::default()
-	}
+	fn worst_case_entry_meta() -> T::EntryMeta;
 
 	/// Give `content_hash` the consumer-pallet state that makes
 	/// [`Config::OnObsoleteTransactions`] take its most expensive path. Without it the expiry
 	/// sweep is benchmarked with no registration to find, so the lookup and the queueing it
 	/// leads to go uncharged.
-	fn register_worst_case_entry(_content_hash: ContentHash) {}
+	fn register_worst_case_entry(content_hash: ContentHash);
 }
 
 /// Default [`BenchmarkHelper`] for runtimes using [`DEFAULT_MAX_TRANSACTION_SIZE`] and
 /// [`DEFAULT_MAX_BLOCK_TRANSACTIONS`]. Regenerate with `gen_default_check_proof` test if these
-/// change.
+/// change. Its worst-case entry hooks are no-ops, for runtimes with
+/// `OnObsoleteTransactions = ()`.
 pub struct DefaultCheckProofHelper;
 
 /// Hex-encoded [`TransactionStorageProof`] for the default configuration
@@ -107,6 +106,12 @@ impl<T: Config> BenchmarkHelper<T> for DefaultCheckProofHelper {
 		);
 		array_bytes::hex2bytes_unchecked(DEFAULT_CHECK_PROOF)
 	}
+
+	fn worst_case_entry_meta() -> T::EntryMeta {
+		Default::default()
+	}
+
+	fn register_worst_case_entry(_content_hash: ContentHash) {}
 }
 
 type RuntimeCallOf<T> = <T as frame_system::Config>::RuntimeCall;

--- a/pallets/transaction-storage/src/extension.rs
+++ b/pallets/transaction-storage/src/extension.rs
@@ -147,6 +147,8 @@ impl<T: Config> LeafValidator<T> for Tuple {
 		Ok(false)
 	}
 
+	// The binding is the `for_tuples!` accumulator; clippy's "return directly" would drop it.
+	#[allow(clippy::let_and_return)]
 	fn leaf_weight(call: &RuntimeCallOf<T>) -> Weight {
 		let mut weight = Weight::zero();
 		for_tuples!( #( weight = weight.saturating_add(Tuple::leaf_weight(call)); )* );

--- a/pallets/transaction-storage/src/lib.rs
+++ b/pallets/transaction-storage/src/lib.rs
@@ -170,8 +170,8 @@ pub mod pallet {
 		type RemoveExhaustedAuthorizerTxParams: Get<ValidTransactionParams>;
 		/// Opaque per-entry payload on [`TransactionInfo`], never interpreted here:
 		/// `store` writes `Default::default()`, expiry hands it back through
-		/// [`Config::OnObsoleteTransactions`]. Wire `()` or the renewal pallet's
-		/// `EntryKind`.
+		/// [`Config::OnObsoleteTransactions`]. Wire `()` or a runtime-composed enum
+		/// satisfying its consumers' bounds (e.g. the renewal pallet's `RenewMeta`).
 		type EntryMeta: Member + codec::FullCodec + MaxEncodedLen + scale_info::TypeInfo + Default;
 		/// Opaque per-authorization payload inside [`AuthorizationExtent`], never
 		/// interpreted here: reset with the other counters, mutated only through

--- a/pallets/transaction-storage/src/lib.rs
+++ b/pallets/transaction-storage/src/lib.rs
@@ -170,8 +170,8 @@ pub mod pallet {
 		type RemoveExhaustedAuthorizerTxParams: Get<ValidTransactionParams>;
 		/// Opaque per-entry payload on [`TransactionInfo`], never interpreted here:
 		/// `store` writes `Default::default()`, expiry hands it back through
-		/// [`Config::OnObsoleteTransactions`]. Wire `()` or a runtime-composed enum
-		/// satisfying its consumers' bounds (e.g. the renewal pallet's `RenewMeta`).
+		/// [`Config::OnObsoleteTransactions`]. Wire `()` or the primitives'
+		/// [`EntryKind`](bulletin_transaction_storage_primitives::EntryKind).
 		type EntryMeta: Member + codec::FullCodec + MaxEncodedLen + scale_info::TypeInfo + Default;
 		/// Opaque per-authorization payload inside [`AuthorizationExtent`], never
 		/// interpreted here: reset with the other counters, mutated only through
@@ -1172,9 +1172,9 @@ pub mod pallet {
 		/// Authorize data storage for a scope. Behaviour for an existing entry:
 		/// - **Expired-but-present**: re-grant the caps and reset **all** consumed counters
 		///   (`bytes`, `transactions`, and the opaque `extra`) to their defaults. The new window is
-		///   fully independent of the old one. Pre-existing renewed bytes from the old window are
-		///   tracked by the renewal pallet's chain-wide counter and aged out when their
-		///   `Transactions` block becomes obsolete; they do not spend the new window's quota.
+		///   fully independent of the old one. Pre-existing renewed bytes from the old window stay
+		///   in the renewal pallet's `PermanentStorageUsed` until their `Transactions` block
+		///   becomes obsolete; they do not spend the new window's quota.
 		/// - **Unexpired Account**: caps are additive — `claim_long_term_storage` (and similar
 		///   flows on caller chains) calls this once per claim and expects each to extend the caps.
 		///   Consumed counters (`bytes`, `bytes_permanent`, `transactions`) are preserved. Expiry

--- a/pallets/transaction-storage/src/types.rs
+++ b/pallets/transaction-storage/src/types.rs
@@ -210,7 +210,8 @@ pub struct TransactionInfo<Meta> {
 
 	/// Opaque per-entry payload ([`crate::Config::EntryMeta`]), stored verbatim and
 	/// handed back through [`OnObsoleteTransactions::handle_obsolete`] at expiry.
-	/// Tail field; the wired type must keep `TransactionKind`'s 1-byte encoding.
+	/// Tail field; live entries store one byte here, so the wired type must keep a
+	/// 1-byte encoding.
 	pub meta: Meta,
 }
 

--- a/runtimes/bulletin-paseo/Cargo.toml
+++ b/runtimes/bulletin-paseo/Cargo.toml
@@ -46,6 +46,7 @@ pallet-bulletin-transaction-storage = { workspace = true }
 pallet-bulletin-transaction-storage-runtime-api = { workspace = true }
 pallet-bulletin-hop-promotion = { workspace = true }
 bulletin-pallets-common = { workspace = true }
+bulletin-transaction-storage-primitives = { workspace = true }
 sp-api = { workspace = true }
 sp-block-builder = { workspace = true }
 sp-consensus-aura = { workspace = true }
@@ -90,7 +91,6 @@ parachains-common = { workspace = true }
 [dev-dependencies]
 parachains-runtimes-test-utils = { workspace = true, default-features = true }
 sp-io = { workspace = true }
-bulletin-transaction-storage-primitives = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true, default-features = true }

--- a/runtimes/bulletin-paseo/src/storage.rs
+++ b/runtimes/bulletin-paseo/src/storage.rs
@@ -121,51 +121,11 @@ impl pallet_bulletin_transaction_storage::Config for Runtime {
 	type RemoveExpiredAccountAuthorizationTxParams = RemoveExpiredAccountAuthorizationTxParams;
 	type RemoveExpiredPreimageAuthorizationTxParams = RemoveExpiredPreimageAuthorizationTxParams;
 	type RemoveExhaustedAuthorizerTxParams = RemoveExhaustedAuthorizerTxParams;
-	type EntryMeta = EntryKind;
+	type EntryMeta = bulletin_transaction_storage_primitives::EntryKind;
 	type AuthorizationExtra = pallet_bulletin_data_renewal::PermanentExtent;
 	type OnObsoleteTransactions = crate::DataRenewal;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = pallet_bulletin_data_renewal::RenewalBenchmarkHelper;
-}
-
-/// Per-entry `EntryMeta` composed by this runtime: `Store` is the storage pallet's
-/// `Default` contribution, `Renew` the renewal pallet's (via
-/// [`RenewMeta`](pallet_bulletin_data_renewal::RenewMeta)). Future pallets add their
-/// variants here.
-///
-/// INVARIANT: identical (names and 1-byte encoding) to the retired `TransactionKind`,
-/// so pre-split `Transactions` entries decode without migration. Locked by the
-/// `entry_kind_encoding_is_frozen` test.
-#[derive(
-	Copy,
-	Clone,
-	Debug,
-	PartialEq,
-	Eq,
-	Default,
-	codec::Encode,
-	codec::Decode,
-	codec::MaxEncodedLen,
-	scale_info::TypeInfo,
-)]
-pub enum EntryKind {
-	/// Created by `store`; ages out silently.
-	#[default]
-	#[codec(index = 0)]
-	Store,
-	/// Created by `renew`/auto-renewal; counted in the chain-wide counter.
-	#[codec(index = 1)]
-	Renew,
-}
-
-impl pallet_bulletin_data_renewal::RenewMeta for EntryKind {
-	fn renew() -> Self {
-		Self::Renew
-	}
-
-	fn is_renew(&self) -> bool {
-		matches!(self, Self::Renew)
-	}
 }
 
 impl pallet_bulletin_data_renewal::Config for Runtime {
@@ -188,54 +148,4 @@ impl pallet_bulletin_hop_promotion::Config for Runtime {
 	type SubmitTimestampTolerance = SubmitTimestampTolerance;
 	type PromoteTxParams = PromoteTxParams;
 	type WeightInfo = crate::weights::pallet_bulletin_hop_promotion::WeightInfo<Runtime>;
-}
-
-#[cfg(test)]
-mod tests {
-	use super::EntryKind;
-	use bulletin_transaction_storage_primitives::cids::HashingAlgorithm;
-	use codec::{Decode, Encode};
-	use pallet_bulletin_transaction_storage::TransactionInfo;
-	use sp_runtime::traits::{BlakeTwo256, Hash};
-
-	/// `EntryKind` must keep the retired `TransactionKind`'s exact encoding (1 byte;
-	/// `Store = 0`, `Renew = 1`): live `Transactions` entries written before the split
-	/// decode through `TransactionInfo<EntryKind>` without a storage migration.
-	#[test]
-	fn entry_kind_encoding_is_frozen() {
-		assert_eq!(EntryKind::Store.encode(), vec![0u8]);
-		assert_eq!(EntryKind::Renew.encode(), vec![1u8]);
-		assert_eq!(EntryKind::default(), EntryKind::Store);
-
-		// Frozen copy of the pre-split `TransactionInfo` layout (tail field was
-		// `kind: TransactionKind`). Bytes written by the old runtime must decode
-		// as the new generic type.
-		#[derive(Encode)]
-		struct FrozenTransactionInfo {
-			chunk_root: <BlakeTwo256 as Hash>::Output,
-			content_hash: [u8; 32],
-			hashing: HashingAlgorithm,
-			cid_codec: u64,
-			size: u32,
-			extrinsic_index: u32,
-			block_chunks: u32,
-			kind: u8, // TransactionKind::Renew
-		}
-		let frozen = FrozenTransactionInfo {
-			chunk_root: BlakeTwo256::hash(b"root"),
-			content_hash: [7u8; 32],
-			hashing: HashingAlgorithm::Blake2b256,
-			cid_codec: 0x55,
-			size: 2000,
-			extrinsic_index: 42,
-			block_chunks: 8,
-			kind: 1,
-		};
-		let decoded =
-			TransactionInfo::<EntryKind>::decode(&mut &frozen.encode()[..]).expect("must decode");
-		assert_eq!(decoded.content_hash, [7u8; 32]);
-		assert_eq!(decoded.size, 2000);
-		assert_eq!(decoded.extrinsic_index, 42);
-		assert_eq!(decoded.meta, EntryKind::Renew);
-	}
 }

--- a/runtimes/bulletin-paseo/src/storage.rs
+++ b/runtimes/bulletin-paseo/src/storage.rs
@@ -121,11 +121,51 @@ impl pallet_bulletin_transaction_storage::Config for Runtime {
 	type RemoveExpiredAccountAuthorizationTxParams = RemoveExpiredAccountAuthorizationTxParams;
 	type RemoveExpiredPreimageAuthorizationTxParams = RemoveExpiredPreimageAuthorizationTxParams;
 	type RemoveExhaustedAuthorizerTxParams = RemoveExhaustedAuthorizerTxParams;
-	type EntryMeta = pallet_bulletin_data_renewal::EntryKind;
+	type EntryMeta = EntryKind;
 	type AuthorizationExtra = pallet_bulletin_data_renewal::PermanentExtent;
 	type OnObsoleteTransactions = crate::DataRenewal;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = pallet_bulletin_data_renewal::RenewalBenchmarkHelper;
+}
+
+/// Per-entry `EntryMeta` composed by this runtime: `Store` is the storage pallet's
+/// `Default` contribution, `Renew` the renewal pallet's (via
+/// [`RenewMeta`](pallet_bulletin_data_renewal::RenewMeta)). Future pallets add their
+/// variants here.
+///
+/// INVARIANT: identical (names and 1-byte encoding) to the retired `TransactionKind`,
+/// so pre-split `Transactions` entries decode without migration. Locked by the
+/// `entry_kind_encoding_is_frozen` test.
+#[derive(
+	Copy,
+	Clone,
+	Debug,
+	PartialEq,
+	Eq,
+	Default,
+	codec::Encode,
+	codec::Decode,
+	codec::MaxEncodedLen,
+	scale_info::TypeInfo,
+)]
+pub enum EntryKind {
+	/// Created by `store`; ages out silently.
+	#[default]
+	#[codec(index = 0)]
+	Store,
+	/// Created by `renew`/auto-renewal; counted in the chain-wide counter.
+	#[codec(index = 1)]
+	Renew,
+}
+
+impl pallet_bulletin_data_renewal::RenewMeta for EntryKind {
+	fn renew() -> Self {
+		Self::Renew
+	}
+
+	fn is_renew(&self) -> bool {
+		matches!(self, Self::Renew)
+	}
 }
 
 impl pallet_bulletin_data_renewal::Config for Runtime {
@@ -148,4 +188,54 @@ impl pallet_bulletin_hop_promotion::Config for Runtime {
 	type SubmitTimestampTolerance = SubmitTimestampTolerance;
 	type PromoteTxParams = PromoteTxParams;
 	type WeightInfo = crate::weights::pallet_bulletin_hop_promotion::WeightInfo<Runtime>;
+}
+
+#[cfg(test)]
+mod tests {
+	use super::EntryKind;
+	use bulletin_transaction_storage_primitives::cids::HashingAlgorithm;
+	use codec::{Decode, Encode};
+	use pallet_bulletin_transaction_storage::TransactionInfo;
+	use sp_runtime::traits::{BlakeTwo256, Hash};
+
+	/// `EntryKind` must keep the retired `TransactionKind`'s exact encoding (1 byte;
+	/// `Store = 0`, `Renew = 1`): live `Transactions` entries written before the split
+	/// decode through `TransactionInfo<EntryKind>` without a storage migration.
+	#[test]
+	fn entry_kind_encoding_is_frozen() {
+		assert_eq!(EntryKind::Store.encode(), vec![0u8]);
+		assert_eq!(EntryKind::Renew.encode(), vec![1u8]);
+		assert_eq!(EntryKind::default(), EntryKind::Store);
+
+		// Frozen copy of the pre-split `TransactionInfo` layout (tail field was
+		// `kind: TransactionKind`). Bytes written by the old runtime must decode
+		// as the new generic type.
+		#[derive(Encode)]
+		struct FrozenTransactionInfo {
+			chunk_root: <BlakeTwo256 as Hash>::Output,
+			content_hash: [u8; 32],
+			hashing: HashingAlgorithm,
+			cid_codec: u64,
+			size: u32,
+			extrinsic_index: u32,
+			block_chunks: u32,
+			kind: u8, // TransactionKind::Renew
+		}
+		let frozen = FrozenTransactionInfo {
+			chunk_root: BlakeTwo256::hash(b"root"),
+			content_hash: [7u8; 32],
+			hashing: HashingAlgorithm::Blake2b256,
+			cid_codec: 0x55,
+			size: 2000,
+			extrinsic_index: 42,
+			block_chunks: 8,
+			kind: 1,
+		};
+		let decoded =
+			TransactionInfo::<EntryKind>::decode(&mut &frozen.encode()[..]).expect("must decode");
+		assert_eq!(decoded.content_hash, [7u8; 32]);
+		assert_eq!(decoded.size, 2000);
+		assert_eq!(decoded.extrinsic_index, 42);
+		assert_eq!(decoded.meta, EntryKind::Renew);
+	}
 }

--- a/runtimes/bulletin-westend/Cargo.toml
+++ b/runtimes/bulletin-westend/Cargo.toml
@@ -45,6 +45,7 @@ pallet-bulletin-data-renewal = { workspace = true }
 pallet-bulletin-transaction-storage = { workspace = true }
 pallet-bulletin-transaction-storage-runtime-api = { workspace = true }
 bulletin-pallets-common = { workspace = true }
+bulletin-transaction-storage-primitives = { workspace = true }
 sp-api = { workspace = true }
 sp-block-builder = { workspace = true }
 sp-consensus-aura = { workspace = true }
@@ -91,7 +92,6 @@ testnet-parachains-constants = { features = ["westend"], workspace = true }
 [dev-dependencies]
 parachains-runtimes-test-utils = { workspace = true, default-features = true }
 sp-io = { workspace = true }
-bulletin-transaction-storage-primitives = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true, default-features = true }

--- a/runtimes/bulletin-westend/src/storage.rs
+++ b/runtimes/bulletin-westend/src/storage.rs
@@ -149,51 +149,11 @@ impl pallet_bulletin_transaction_storage::Config for Runtime {
 	type RemoveExpiredAccountAuthorizationTxParams = RemoveExpiredAccountAuthorizationTxParams;
 	type RemoveExpiredPreimageAuthorizationTxParams = RemoveExpiredPreimageAuthorizationTxParams;
 	type RemoveExhaustedAuthorizerTxParams = RemoveExhaustedAuthorizerTxParams;
-	type EntryMeta = EntryKind;
+	type EntryMeta = bulletin_transaction_storage_primitives::EntryKind;
 	type AuthorizationExtra = pallet_bulletin_data_renewal::PermanentExtent;
 	type OnObsoleteTransactions = crate::DataRenewal;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = pallet_bulletin_data_renewal::RenewalBenchmarkHelper;
-}
-
-/// Per-entry `EntryMeta` composed by this runtime: `Store` is the storage pallet's
-/// `Default` contribution, `Renew` the renewal pallet's (via
-/// [`RenewMeta`](pallet_bulletin_data_renewal::RenewMeta)). Future pallets add their
-/// variants here.
-///
-/// INVARIANT: identical (names and 1-byte encoding) to the retired `TransactionKind`,
-/// so pre-split `Transactions` entries decode without migration. Locked by the
-/// `entry_kind_encoding_is_frozen` test.
-#[derive(
-	Copy,
-	Clone,
-	Debug,
-	PartialEq,
-	Eq,
-	Default,
-	codec::Encode,
-	codec::Decode,
-	codec::MaxEncodedLen,
-	scale_info::TypeInfo,
-)]
-pub enum EntryKind {
-	/// Created by `store`; ages out silently.
-	#[default]
-	#[codec(index = 0)]
-	Store,
-	/// Created by `renew`/auto-renewal; counted in the chain-wide counter.
-	#[codec(index = 1)]
-	Renew,
-}
-
-impl pallet_bulletin_data_renewal::RenewMeta for EntryKind {
-	fn renew() -> Self {
-		Self::Renew
-	}
-
-	fn is_renew(&self) -> bool {
-		matches!(self, Self::Renew)
-	}
 }
 
 impl pallet_bulletin_data_renewal::Config for Runtime {
@@ -216,54 +176,4 @@ impl pallet_bulletin_hop_promotion::Config for Runtime {
 	type SubmitTimestampTolerance = SubmitTimestampTolerance;
 	type PromoteTxParams = PromoteTxParams;
 	type WeightInfo = crate::weights::pallet_bulletin_hop_promotion::WeightInfo<Runtime>;
-}
-
-#[cfg(test)]
-mod tests {
-	use super::EntryKind;
-	use bulletin_transaction_storage_primitives::cids::HashingAlgorithm;
-	use codec::{Decode, Encode};
-	use pallet_bulletin_transaction_storage::TransactionInfo;
-	use sp_runtime::traits::{BlakeTwo256, Hash};
-
-	/// `EntryKind` must keep the retired `TransactionKind`'s exact encoding (1 byte;
-	/// `Store = 0`, `Renew = 1`): live `Transactions` entries written before the split
-	/// decode through `TransactionInfo<EntryKind>` without a storage migration.
-	#[test]
-	fn entry_kind_encoding_is_frozen() {
-		assert_eq!(EntryKind::Store.encode(), vec![0u8]);
-		assert_eq!(EntryKind::Renew.encode(), vec![1u8]);
-		assert_eq!(EntryKind::default(), EntryKind::Store);
-
-		// Frozen copy of the pre-split `TransactionInfo` layout (tail field was
-		// `kind: TransactionKind`). Bytes written by the old runtime must decode
-		// as the new generic type.
-		#[derive(Encode)]
-		struct FrozenTransactionInfo {
-			chunk_root: <BlakeTwo256 as Hash>::Output,
-			content_hash: [u8; 32],
-			hashing: HashingAlgorithm,
-			cid_codec: u64,
-			size: u32,
-			extrinsic_index: u32,
-			block_chunks: u32,
-			kind: u8, // TransactionKind::Renew
-		}
-		let frozen = FrozenTransactionInfo {
-			chunk_root: BlakeTwo256::hash(b"root"),
-			content_hash: [7u8; 32],
-			hashing: HashingAlgorithm::Blake2b256,
-			cid_codec: 0x55,
-			size: 2000,
-			extrinsic_index: 42,
-			block_chunks: 8,
-			kind: 1,
-		};
-		let decoded =
-			TransactionInfo::<EntryKind>::decode(&mut &frozen.encode()[..]).expect("must decode");
-		assert_eq!(decoded.content_hash, [7u8; 32]);
-		assert_eq!(decoded.size, 2000);
-		assert_eq!(decoded.extrinsic_index, 42);
-		assert_eq!(decoded.meta, EntryKind::Renew);
-	}
 }

--- a/runtimes/bulletin-westend/src/storage.rs
+++ b/runtimes/bulletin-westend/src/storage.rs
@@ -149,11 +149,51 @@ impl pallet_bulletin_transaction_storage::Config for Runtime {
 	type RemoveExpiredAccountAuthorizationTxParams = RemoveExpiredAccountAuthorizationTxParams;
 	type RemoveExpiredPreimageAuthorizationTxParams = RemoveExpiredPreimageAuthorizationTxParams;
 	type RemoveExhaustedAuthorizerTxParams = RemoveExhaustedAuthorizerTxParams;
-	type EntryMeta = pallet_bulletin_data_renewal::EntryKind;
+	type EntryMeta = EntryKind;
 	type AuthorizationExtra = pallet_bulletin_data_renewal::PermanentExtent;
 	type OnObsoleteTransactions = crate::DataRenewal;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = pallet_bulletin_data_renewal::RenewalBenchmarkHelper;
+}
+
+/// Per-entry `EntryMeta` composed by this runtime: `Store` is the storage pallet's
+/// `Default` contribution, `Renew` the renewal pallet's (via
+/// [`RenewMeta`](pallet_bulletin_data_renewal::RenewMeta)). Future pallets add their
+/// variants here.
+///
+/// INVARIANT: identical (names and 1-byte encoding) to the retired `TransactionKind`,
+/// so pre-split `Transactions` entries decode without migration. Locked by the
+/// `entry_kind_encoding_is_frozen` test.
+#[derive(
+	Copy,
+	Clone,
+	Debug,
+	PartialEq,
+	Eq,
+	Default,
+	codec::Encode,
+	codec::Decode,
+	codec::MaxEncodedLen,
+	scale_info::TypeInfo,
+)]
+pub enum EntryKind {
+	/// Created by `store`; ages out silently.
+	#[default]
+	#[codec(index = 0)]
+	Store,
+	/// Created by `renew`/auto-renewal; counted in the chain-wide counter.
+	#[codec(index = 1)]
+	Renew,
+}
+
+impl pallet_bulletin_data_renewal::RenewMeta for EntryKind {
+	fn renew() -> Self {
+		Self::Renew
+	}
+
+	fn is_renew(&self) -> bool {
+		matches!(self, Self::Renew)
+	}
 }
 
 impl pallet_bulletin_data_renewal::Config for Runtime {
@@ -176,4 +216,54 @@ impl pallet_bulletin_hop_promotion::Config for Runtime {
 	type SubmitTimestampTolerance = SubmitTimestampTolerance;
 	type PromoteTxParams = PromoteTxParams;
 	type WeightInfo = crate::weights::pallet_bulletin_hop_promotion::WeightInfo<Runtime>;
+}
+
+#[cfg(test)]
+mod tests {
+	use super::EntryKind;
+	use bulletin_transaction_storage_primitives::cids::HashingAlgorithm;
+	use codec::{Decode, Encode};
+	use pallet_bulletin_transaction_storage::TransactionInfo;
+	use sp_runtime::traits::{BlakeTwo256, Hash};
+
+	/// `EntryKind` must keep the retired `TransactionKind`'s exact encoding (1 byte;
+	/// `Store = 0`, `Renew = 1`): live `Transactions` entries written before the split
+	/// decode through `TransactionInfo<EntryKind>` without a storage migration.
+	#[test]
+	fn entry_kind_encoding_is_frozen() {
+		assert_eq!(EntryKind::Store.encode(), vec![0u8]);
+		assert_eq!(EntryKind::Renew.encode(), vec![1u8]);
+		assert_eq!(EntryKind::default(), EntryKind::Store);
+
+		// Frozen copy of the pre-split `TransactionInfo` layout (tail field was
+		// `kind: TransactionKind`). Bytes written by the old runtime must decode
+		// as the new generic type.
+		#[derive(Encode)]
+		struct FrozenTransactionInfo {
+			chunk_root: <BlakeTwo256 as Hash>::Output,
+			content_hash: [u8; 32],
+			hashing: HashingAlgorithm,
+			cid_codec: u64,
+			size: u32,
+			extrinsic_index: u32,
+			block_chunks: u32,
+			kind: u8, // TransactionKind::Renew
+		}
+		let frozen = FrozenTransactionInfo {
+			chunk_root: BlakeTwo256::hash(b"root"),
+			content_hash: [7u8; 32],
+			hashing: HashingAlgorithm::Blake2b256,
+			cid_codec: 0x55,
+			size: 2000,
+			extrinsic_index: 42,
+			block_chunks: 8,
+			kind: 1,
+		};
+		let decoded =
+			TransactionInfo::<EntryKind>::decode(&mut &frozen.encode()[..]).expect("must decode");
+		assert_eq!(decoded.content_hash, [7u8; 32]);
+		assert_eq!(decoded.size, 2000);
+		assert_eq!(decoded.extrinsic_index, 42);
+		assert_eq!(decoded.meta, EntryKind::Renew);
+	}
 }


### PR DESCRIPTION
- `BenchmarkHelper`: `worst_case_entry_meta` / `register_worst_case_entry` are now required; no-op defaults
  moved to `DefaultCheckProofHelper` ([comment](https://github.com/paritytech/polkadot-bulletin-chain/pull/571#discussion_r3710081896), [comment](https://github.com/paritytech/polkadot-bulletin-chain/pull/571#discussion_r3710083064))
 - `check_auto_renew_chopsticks.js`: drop the manual `process_pending_renewals` injection — Chopsticks builds
  the inherent since AcalaNetwork/chopsticks#1064; `chopsticks-core` bumped to `^1.5.1` ([comment](https://github.com/paritytech/polkadot-bulletin-chain/pull/571#discussion_r3715291969))
