### PR TITLE
rename: drop Auto from shared renewal names

### DIFF
--- a/docs/authorizations.md
+++ b/docs/authorizations.md
@@ -126,11 +126,9 @@ That obsolete-block cleanup is the only path that ever decrements `PermanentStor
 
 ## Why renewed bytes can't grow unboundedly
 
-Stated up front: at any block `n`, total renewed bytes on chain are bounded by `MaxPermanentStorageSize` (chain-wide cap) and a single account's renewed bytes are bounded by `(K + 1) × bytes_allowance` where `K = RetentionPeriod / AuthorizationPeriod` (so `2 × bytes_allowance` for the aligned Westend / Paseo configs where `K = 1`).
+At any block `n`, total renewed bytes on chain are bounded by `MaxPermanentStorageSize` (chain-wide cap) and a single account's renewed bytes are bounded by `(K + 1) × bytes_allowance` where `K = RetentionPeriod / AuthorizationPeriod` (so `2 × bytes_allowance` for the aligned Westend / Paseo configs where `K = 1`).
 
 Why: every renewed byte ages out exactly `RetentionPeriod` blocks after its renew block (the obsolete-block cleanup in `on_initialize`). New renews are gated by the chain-wide cap, so the counter can only enter the in-bounds region. As old data ages out, the cap recovers.
-
-The examples below trace the counters block-by-block to make the bound visible.
 
 ### Example 1 — single user, single window
 
@@ -161,7 +159,7 @@ From here Alice's path branches:
 - **PoP re-authorizes** (`authorize_account` on the expired-but-present path) — the caps are re-granted and **all** consumed counters (`bytes`, `bytes_permanent`, `transactions`) reset to `0`. Alice gets a fresh window and can `store` / `force_renew` again. Repeating the pattern every window gives steady-state on-chain footprint = `bytes_allowance` per account (= 10 MiB).
 - **PoP does not re-authorize** — the authorization sits expired-but-present until anyone calls `remove_expired_account_authorization`. Alice cannot `store` or `force_renew`. Her renewed data has already aged out.
 
-Two things worth noting:
+Two consequences:
 
 1. `bytes_permanent` is **not** decremented when the renewed data ages out — that is the chain-wide `PermanentStorageUsed`'s job. The per-account counter only resets on re-authorize (expired-but-present path). While the authorization is expired, `check_authorization` rejects on the expiration check before reading `bytes_permanent`, so the staleness is unobservable.
 2. `Transactions` is the source of truth for on-chain renewed bytes. The chain-wide counter mirrors that same total via increments at renew time and decrements at obsolete-block cleanup; the per-account counter does not need to.
@@ -190,7 +188,7 @@ Peak on-chain bytes per account: `2 × bytes_allowance`. Generalising, with `Ret
 | n+k | further renews would exceed 1.7 TiB | 1.7 TiB | `ChainPermanentCapReached` rejects new renews |
 | n+k+RetentionPeriod | obsolete cleanup decrements as old renewals age out | < 1.7 TiB | new renews accepted again |
 
-The chain-wide cap is a hard ceiling on `PermanentStorageUsed`; the on-chain renewed bytes equal the counter (modulo a transient lag inside `on_initialize`). The system self-corrects: as soon as the counter falls below the cap, renewals resume.
+The chain-wide cap is a hard ceiling on `PermanentStorageUsed`, and the on-chain renewed bytes equal the counter (modulo a transient lag inside `on_initialize`). Renewals resume as soon as the counter falls back below the cap.
 
 ### Example 5 — adversarial single-user renew spam
 
@@ -211,9 +209,9 @@ When `PermanentStorageNearCap` fires governance can either:
 
 ## Auto-renewal
 
-Auto-renewal reuses the manual renew code path so the [Hard limit on renewed storage](#hard-limit-on-renewed-storage) accounting fires consistently — per-account `bytes_permanent` increment, chain-wide `PermanentStorageUsed` cap check, `kind = Renew` stamp in `Transactions`, obsolete-cleanup decrement. Hard-cap checks live in `check_authorization` (called by the extension's `check_signed` for the manual flow and by `do_process_pending_renewals` for the auto flow); the unified renewal mechanics live in `do_renew_in_memory` (called by `do_renew` and by the auto-renewal drain loop).
+Auto-renewal reuses the manual renew code path so the [Hard limit on renewed storage](#hard-limit-on-renewed-storage) accounting fires consistently — per-account `bytes_permanent` increment, chain-wide `PermanentStorageUsed` cap check, `kind = Renew` stamp in `Transactions`, obsolete-cleanup decrement. Hard-cap checks live in `check_authorization`, called by the extension's `check_signed` for the manual flow and by `do_process_pending_renewals` for the auto flow. The shared renewal mechanics live in `do_renew_in_memory`, called by `do_renew` and by the drain loop.
 
-Behaviour on auto-renewal failure (per-account quota or chain-wide cap rejected at cycle time, or `MaxBlockTransactions` reached): the registration is dropped from `AutoRenewals`, `Event::RenewalFailed` is emitted, and the data expires normally. If the slot cap rejects a cycle after the charge has been applied, `do_process_pending_renewals` refunds the chain-wide `PermanentStorageUsed` bump so the cap does not leak; the per-account `bytes_permanent` / `transactions` increments are left in place — slot-cap rejection at inherent time is pathological (the inherent runs before user txs and `len(pending) <= MaxBlockTransactions`), so the simpler accounting is preferred over a per-auth refund that would silently apply across roll-overs.
+Behaviour on auto-renewal failure (per-account quota or chain-wide cap rejected at cycle time, or `MaxBlockTransactions` reached): the registration is dropped from `AutoRenewals`, `Event::RenewalFailed` is emitted, and the data expires normally. If the slot cap rejects a cycle after the charge has been applied, `do_process_pending_renewals` refunds the chain-wide `PermanentStorageUsed` bump so the cap does not leak; the per-account `bytes_permanent` / `transactions` increments are left in place. Slot-cap rejection at inherent time is pathological — the inherent runs before user txs and `len(pending) <= MaxBlockTransactions` — so the simpler accounting is preferred over a per-auth refund that would silently apply across roll-overs.
 
 The latest-entry guard in `on_initialize` skips an obsolete entry when `TransactionByContentHash[hash]` points to a later block — a manual `force_renew` may have moved the latest reference forward; the renewal cycle then fires from the new entry's expiry, not the original.
 

--- a/docs/authorizations.md
+++ b/docs/authorizations.md
@@ -31,7 +31,7 @@ Without bounds, at sustained-peak block usage one window of fresh `store` data a
 ## Storage types
 
 - **Temporary storage** — happens through the `store` call. Lives on chain for one `RetentionPeriod` from its `store` block.
-- **Renewed storage** — happens through `force_renew` (sync, at dispatch time) or via the auto-renewal cycle (`enable_auto_renew` + `do_process_auto_renewals`). The renewed entry itself also lives one `RetentionPeriod` (from its renewal block); the original `Transactions` entry it pointed at ages out on its own clock.
+- **Renewed storage** — happens through `force_renew` (sync, at dispatch time) or via the auto-renewal cycle (`enable_auto_renew` + `do_process_pending_renewals`). The renewed entry itself also lives one `RetentionPeriod` (from its renewal block); the original `Transactions` entry it pointed at ages out on its own clock.
 
 The renew-family extrinsics:
 
@@ -55,7 +55,7 @@ PoP grants two numbers per account: `bytes_allowance` (size budget) and `transac
 
 - One `AuthorizationExtent` per scope is kept in `Authorizations`, keyed by `AuthorizationScope::{Account, Preimage}`.
 - `AuthorizationExtent { transactions, transactions_allowance, bytes, bytes_permanent, bytes_allowance }` holds the soft-side counters (`bytes`, `transactions`), the per-window renew quota (`bytes_permanent`), and the caps.
-- `bytes` and `transactions` bump on `store` / `store_with_cid_config`. `bytes_permanent` bumps on `force_renew`, on the `renew` one-shot scheduler at registration, on `enable_auto_renew`'s registration (prepayment for the first cycle), and on each cycle-2-onward recurring cycle in `do_process_auto_renewals`. The `transactions` axis bumps on all of those.
+- `bytes` and `transactions` bump on `store` / `store_with_cid_config`. `bytes_permanent` bumps on `force_renew`, on the `renew` one-shot scheduler at registration, on `enable_auto_renew`'s registration (prepayment for the first cycle), and on each cycle-2-onward recurring cycle in `do_process_pending_renewals`. The `transactions` axis bumps on all of those.
 
 ### `authorize_account` semantics
 
@@ -91,7 +91,7 @@ The hard cap is enforced at two levels, and a renewal that would breach **either
 
 "Renew" here means any path that consumes the per-window renew quota: `force_renew`,
 the `renew` one-shot scheduler at registration, `enable_auto_renew`'s registration
-(prepaying the first cycle), and each per-cycle charge in `do_process_auto_renewals`
+(prepaying the first cycle), and each per-cycle charge in `do_process_pending_renewals`
 (cycle 2 onward for recurring registrations; the prepaid first cycle does not
 re-consume).
 
@@ -200,7 +200,7 @@ A user across many accounts (Sybil-like) is bounded by the chain-wide cap (Examp
 
 ## Migration
 
-`STORAGE_VERSION = 5`. Migrations are only relevant for the Paseo/Westend testnets carrying pre-existing on-chain state forward; see the `pallet_bulletin_transaction_storage::migrations::{v1, v2, v3, v4, v5}` modules for the wiring. The v4 step re-encodes each `AutoRenewals` entry from `{ account }` to `{ account, recurring, paid }`. All pre-existing entries were written by the old non-prepaying `enable_auto_renew`, so they migrate as `{ recurring: true, paid: false }` — their next `do_process_auto_renewals` cycle charges per-cycle, preserving their on-chain behaviour across the upgrade. The v5 step re-encodes each `AllowedAuthorizers` entry's `AuthorizerBudget` (dropping `authorization_period`, adding `feeless: true`) and bumps the authorizer's System provider reference.
+`STORAGE_VERSION = 5`. Migrations are only relevant for the Paseo/Westend testnets carrying pre-existing on-chain state forward; see the `pallet_bulletin_transaction_storage::migrations::{v1, v2, v3, v4, v5}` modules for the wiring. The v4 step re-encodes each `AutoRenewals` entry from `{ account }` to `{ account, recurring, paid }`. All pre-existing entries were written by the old non-prepaying `enable_auto_renew`, so they migrate as `{ recurring: true, paid: false }` — their next `do_process_pending_renewals` cycle charges per-cycle, preserving their on-chain behaviour across the upgrade. The v5 step re-encodes each `AllowedAuthorizers` entry's `AuthorizerBudget` (dropping `authorization_period`, adding `feeless: true`) and bumps the authorizer's System provider reference.
 
 ## Capacity planning operational steps
 
@@ -211,14 +211,14 @@ When `PermanentStorageNearCap` fires governance can either:
 
 ## Auto-renewal
 
-Auto-renewal reuses the manual renew code path so the [Hard limit on renewed storage](#hard-limit-on-renewed-storage) accounting fires consistently — per-account `bytes_permanent` increment, chain-wide `PermanentStorageUsed` cap check, `kind = Renew` stamp in `Transactions`, obsolete-cleanup decrement. Hard-cap checks live in `check_authorization` (called by the extension's `check_signed` for the manual flow and by `do_process_auto_renewals` for the auto flow); the unified renewal mechanics live in `do_renew_in_memory` (called by `do_renew` and by the auto-renewal drain loop).
+Auto-renewal reuses the manual renew code path so the [Hard limit on renewed storage](#hard-limit-on-renewed-storage) accounting fires consistently — per-account `bytes_permanent` increment, chain-wide `PermanentStorageUsed` cap check, `kind = Renew` stamp in `Transactions`, obsolete-cleanup decrement. Hard-cap checks live in `check_authorization` (called by the extension's `check_signed` for the manual flow and by `do_process_pending_renewals` for the auto flow); the unified renewal mechanics live in `do_renew_in_memory` (called by `do_renew` and by the auto-renewal drain loop).
 
-Behaviour on auto-renewal failure (per-account quota or chain-wide cap rejected at cycle time, or `MaxBlockTransactions` reached): the registration is dropped from `AutoRenewals`, `Event::AutoRenewalFailed` is emitted, and the data expires normally. If the slot cap rejects a cycle after the charge has been applied, `do_process_auto_renewals` refunds the chain-wide `PermanentStorageUsed` bump so the cap does not leak; the per-account `bytes_permanent` / `transactions` increments are left in place — slot-cap rejection at inherent time is pathological (the inherent runs before user txs and `len(pending) <= MaxBlockTransactions`), so the simpler accounting is preferred over a per-auth refund that would silently apply across roll-overs.
+Behaviour on auto-renewal failure (per-account quota or chain-wide cap rejected at cycle time, or `MaxBlockTransactions` reached): the registration is dropped from `AutoRenewals`, `Event::RenewalFailed` is emitted, and the data expires normally. If the slot cap rejects a cycle after the charge has been applied, `do_process_pending_renewals` refunds the chain-wide `PermanentStorageUsed` bump so the cap does not leak; the per-account `bytes_permanent` / `transactions` increments are left in place — slot-cap rejection at inherent time is pathological (the inherent runs before user txs and `len(pending) <= MaxBlockTransactions`), so the simpler accounting is preferred over a per-auth refund that would silently apply across roll-overs.
 
 The latest-entry guard in `on_initialize` skips an obsolete entry when `TransactionByContentHash[hash]` points to a later block — a manual `force_renew` may have moved the latest reference forward; the renewal cycle then fires from the new entry's expiry, not the original.
 
 ## TODO
 
-- **Reserve block-transaction slots for user txs.** `do_process_auto_renewals` is mandatory and pushes into the same `BlockTransactions` slot as user `store` / `force_renew`. Cap auto-renewals to a fraction of `MaxBlockTransactions` or partition the slot budget.
+- **Reserve block-transaction slots for user txs.** `do_process_pending_renewals` is mandatory and pushes into the same `BlockTransactions` slot as user `store` / `force_renew`. Cap auto-renewals to a fraction of `MaxBlockTransactions` or partition the slot budget.
 - **Per-content dedup of re-renewals (nice-to-have).** On a renew of `X`, look up the previous `(block, idx)` for `X` via `TransactionByContentHash` and cancel its pending decrement — drops the per-content double-count when the same content is renewed in multiple consecutive windows.
 

--- a/docs/book/src/concepts/renewal.md
+++ b/docs/book/src/concepts/renewal.md
@@ -11,15 +11,13 @@ Renewal extrinsics identify the data with a `TransactionRef` (`entry`). It has t
 
 ## Renewal Extrinsics
 
-The pallet exposes three distinct renewal operations. They behave differently — pick the one that matches your needs.
+Three renewal operations, with different behaviour:
 
 ### `renew(entry)` — one-shot scheduled renewal
 
-Schedules a **single** auto-renewal that fires once when the data reaches its retention boundary. After that one renewal the registration is removed and the data is no longer renewed.
+Schedules a **single** renewal that fires when the data reaches its retention boundary. The registration is then removed.
 
-- Does **not** renew synchronously at dispatch time.
-- Emits `RenewalEnabled { content_hash, who, recurring: false }`.
-- Does **not** emit `Renewed`.
+- Emits `RenewalEnabled { content_hash, who, recurring: false }` — not `Renewed`, since nothing is renewed at dispatch time.
 - Rejects with `RenewalAlreadyEnabled` if a renewal is already registered for this content hash.
 
 ### `force_renew(entry)` — immediate synchronous renewal
@@ -31,7 +29,7 @@ Renews the data **immediately** at dispatch time, extending its retention from t
 
 ### `enable_auto_renew(content_hash)` — continuous renewal
 
-Registers the data (identified by content hash, not a `TransactionRef`) for **recurring** auto-renewal. The chain renews it automatically at each retention cycle until disabled.
+Registers the data — by content hash, not a `TransactionRef` — for **recurring** renewal at each retention cycle until disabled.
 
 - Emits `RenewalEnabled { content_hash, who, recurring: true }`.
 - Emits `DataRenewed { index, content_hash, account }` at each cycle.
@@ -90,29 +88,15 @@ api.tx.TransactionStorage.enable_auto_renew({ content_hash: contentHashHex });
 
 ## When to Renew
 
-**Renew when you need:**
-- Guaranteed on-chain availability beyond the retention period
-- Validators to continue providing storage proofs
-- Chain-level data guarantees for your application
-
-**You don't need to renew if:**
-- The data only needs to exist temporarily
-- You've replicated the data to external storage
-- The retention period is sufficient for your use case
+Renew if you need on-chain availability — and validator storage proofs — beyond the retention period. If the retention period covers your use case, or you keep a copy in external storage, you don't.
 
 ## Authorization
 
-Like `store`, renewal requires **authorization**:
-- The account must have sufficient authorized bytes/transactions
-- Authorization is consumed based on the data size
-- Pre-authorize enough capacity if you plan multiple renewals
+Like `store`, renewal consumes **authorization** based on the data size, so pre-authorize enough capacity for the renewals you plan.
 
 ## Data Availability After Expiration
 
-Even after data expires on-chain:
-- Validator nodes may still have the data cached temporarily
-- The CID remains valid; only on-chain storage guarantees expire
-- Consider replicating critical data to external storage as backup
+Only the on-chain guarantee expires: the CID stays valid, and validators may still serve the data from cache for a while. Replicate critical data externally.
 
 ## SDK Support
 
@@ -122,7 +106,5 @@ Both SDKs provide a `renew` helper:
 
 ## Next Steps
 
-- [Rust SDK: Renewal](../rust/renewal.md) - SDK-specific implementation
-- [TypeScript SDK: Renewal](../typescript/renewal.md) - SDK-specific implementation
 - [Storage Model](./storage.md) - How data is stored
 - [Data Retrieval](./retrieval.md) - Fetching from validator nodes

--- a/docs/book/src/concepts/renewal.md
+++ b/docs/book/src/concepts/renewal.md
@@ -20,7 +20,7 @@ Schedules a **single** auto-renewal that fires once when the data reaches its re
 - Does **not** renew synchronously at dispatch time.
 - Emits `RenewalEnabled { content_hash, who, recurring: false }`.
 - Does **not** emit `Renewed`.
-- Rejects with `AutoRenewalAlreadyEnabled` if a renewal is already registered for this content hash.
+- Rejects with `RenewalAlreadyEnabled` if a renewal is already registered for this content hash.
 
 ### `force_renew(entry)` — immediate synchronous renewal
 
@@ -34,7 +34,7 @@ Renews the data **immediately** at dispatch time, extending its retention from t
 Registers the data (identified by content hash, not a `TransactionRef`) for **recurring** auto-renewal. The chain renews it automatically at each retention cycle until disabled.
 
 - Emits `RenewalEnabled { content_hash, who, recurring: true }`.
-- Emits `DataAutoRenewed { index, content_hash, account }` at each cycle.
+- Emits `DataRenewed { index, content_hash, account }` at each cycle.
 
 Use `disable_auto_renew(content_hash)` to stop recurring renewal. It emits `AutoRenewalDisabled { content_hash, who }`. While the registration is still prepaid it is refused with `CannotDisablePrepaidAutoRenewal` — disabling becomes possible after the first cycle has fired.
 

--- a/docs/book/src/rust/renewal.md
+++ b/docs/book/src/rust/renewal.md
@@ -1,10 +1,10 @@
 # Renewal
 
-This guide shows how to renew stored data using the Rust SDK to extend the retention period.
+Extending the retention of stored data with the Rust SDK.
 
 > **Prerequisites**: Read [Data Renewal Concepts](../concepts/renewal.md) first to understand the renewal flow.
 
-> **Note**: `TransactionClient::renew` schedules a one-shot renewal — it fires once when the data reaches its retention boundary. For immediate renewal use `TransactionClient::force_renew` (same arguments). Recurring `enable_auto_renew` is not exposed by the SDK; call it via subxt against the live runtime if you need it (see [concepts](../concepts/renewal.md)).
+> **Note**: `TransactionClient::renew` schedules a one-shot renewal that fires at the retention boundary; `TransactionClient::force_renew` (same arguments) renews immediately. Recurring `enable_auto_renew` is not exposed by the SDK — call it via subxt (see [concepts](../concepts/renewal.md)).
 
 ## Two Clients
 

--- a/docs/book/src/rust/renewal.md
+++ b/docs/book/src/rust/renewal.md
@@ -69,7 +69,7 @@ let storage_ref = StorageRef::new(block_number, index);
 
 ## Using RenewalTracker
 
-For applications managing multiple stored items, use `RenewalTracker` to know when to renew. `renew` registers at most one scheduled renewal per content hash — submitting again before the boundary rejects with `AutoRenewalAlreadyEnabled`:
+For applications managing multiple stored items, use `RenewalTracker` to know when to renew. `renew` registers at most one scheduled renewal per content hash — submitting again before the boundary rejects with `RenewalAlreadyEnabled`:
 
 ```rust
 let mut tracker = RenewalTracker::new();
@@ -158,7 +158,7 @@ fn restore_entries(entries: Vec<PersistedEntry>) -> RenewalTracker {
 
 ## Error Handling
 
-`prepare_renew` rejects invalid input (e.g. block 0) with `Error::RenewalFailed`; submission errors surface the same variant, including on-chain rejections such as `AutoRenewalAlreadyEnabled` (a renewal is already scheduled for the content hash):
+`prepare_renew` rejects invalid input (e.g. block 0) with `Error::RenewalFailed`; submission errors surface the same variant, including on-chain rejections such as `RenewalAlreadyEnabled` (a renewal is already scheduled for the content hash):
 
 ```rust
 match client.prepare_renew(storage_ref) {

--- a/docs/book/src/typescript/renewal.md
+++ b/docs/book/src/typescript/renewal.md
@@ -1,10 +1,12 @@
 # Renewal
 
-This guide shows how to renew stored data using the TypeScript SDK to extend the retention period.
+Extending the retention of stored data with the TypeScript SDK.
 
 > **Prerequisites**: Read [Data Renewal Concepts](../concepts/renewal.md) first to understand the renewal flow.
 
-> **Note**: `client.renew(ref)` takes either a `{ block, index }` position or a 32-byte content hash (`Uint8Array`) — the SDK infers the on-chain `TransactionRef` variant from the shape. It schedules a one-shot renewal that fires once when the data reaches its retention boundary; for immediate renewal use `client.forceRenew(ref)`. On chains still running the pre-`TransactionRef` runtime, positions fall back to the legacy `renew` extrinsic (which renews immediately); content hashes and `forceRenew` error there. Recurring `enable_auto_renew` is not exposed by the SDK; call it via a raw PAPI transaction against the live runtime if you need it (see [Raw Runtime Renewal](#raw-runtime-renewal)).
+> **Note**: `client.renew(ref)` takes a `{ block, index }` position or a 32-byte content hash (`Uint8Array`) — the SDK infers the `TransactionRef` variant from the shape. It schedules a one-shot renewal that fires at the retention boundary; `client.forceRenew(ref)` renews immediately. Recurring `enable_auto_renew` is not exposed by the SDK — use a [raw PAPI transaction](#raw-runtime-renewal).
+>
+> On chains still running the pre-`TransactionRef` runtime, positions fall back to the legacy `renew` extrinsic (which renews immediately); content hashes and `forceRenew` error there.
 
 ## Using the SDK Client
 
@@ -86,7 +88,7 @@ for (const item of await tracker.getItemsNeedingRenewal(api)) {
 
 ## Raw Runtime Renewal
 
-Bypassing the SDK client, a raw PAPI transaction targets the **current** runtime, where `renew`/`force_renew` take an `entry: TransactionRef` and `enable_auto_renew` takes a `content_hash`:
+Against the **current** runtime, bypassing the SDK client: `renew` / `force_renew` take an `entry: TransactionRef`, `enable_auto_renew` a `content_hash`:
 
 ```typescript
 // One-shot scheduled renewal
@@ -119,7 +121,7 @@ api.tx.TransactionStorage.store_with_cid_config({
 
 ## Authorization for Renewal
 
-Renewal is accounted differently from storing. A store only consumes the soft boost budget (going over just lowers priority), but a renewal charges the data's byte size against `bytes_permanent` — the account's renew quota — plus one transaction unit, and also counts against the chain-wide permanent-storage **hard cap**. Unlike stores, renewals **are rejected** when either limit is exceeded (see [Authorization](./authorization.md)).
+Renewal is accounted differently from storing. Going over budget on a store only lowers its priority; a renewal charges the data size against `bytes_permanent` (the account's renew quota) plus one transaction unit, and against the chain-wide permanent-storage **hard cap**. Exceeding either limit **rejects** the renewal (see [Authorization](./authorization.md)).
 
 ## Error Handling
 

--- a/docs/book/src/typescript/renewal.md
+++ b/docs/book/src/typescript/renewal.md
@@ -49,7 +49,7 @@ console.log(`Data expires at block ${expiresAtBlock} (${blocksRemaining} blocks 
 
 ## Building a Renewal Tracker
 
-For applications managing multiple stored items, track them and renew before expiry. `renew` registers at most one scheduled renewal per content hash — a second call before it fires rejects with `AutoRenewalAlreadyEnabled`, so drop entries once scheduled:
+For applications managing multiple stored items, track them and renew before expiry. `renew` registers at most one scheduled renewal per content hash — a second call before it fires rejects with `RenewalAlreadyEnabled`, so drop entries once scheduled:
 
 ```typescript
 interface StoredItem {
@@ -129,7 +129,7 @@ try {
 } catch (error) {
   if (error.message.includes("RenewedNotFound")) {
     console.log("Data not found - may have been pruned");
-  } else if (error.message.includes("AutoRenewalAlreadyEnabled")) {
+  } else if (error.message.includes("RenewalAlreadyEnabled")) {
     console.log("A renewal is already scheduled for this data");
   } else if (error.message.includes("AuthorizationNotFound")) {
     console.log("Insufficient authorization - request more via Faucet");

--- a/examples/check_auto_renew_chopsticks.js
+++ b/examples/check_auto_renew_chopsticks.js
@@ -12,10 +12,10 @@
  *  4. Tests disable_auto_renew: removes the entry, verifies it's cleared
  *  5. Re-enables auto-renewal for the expiry test
  *  6. Advances to the expiry block. There `TransactionStorage::on_initialize`
- *     ages the data out and queues it into `DataRenewal.PendingAutoRenewals`
+ *     ages the data out and queues it into `DataRenewal.PendingRenewals`
  *     for the same block's `process_pending_renewals` mandatory inherent.
  *  7. Builds the expiry block and verifies the drain:
- *       - PendingAutoRenewals is emptied (taken by the inherent)
+ *       - PendingRenewals is emptied (taken by the inherent)
  *       - TransactionByContentHash now points at the expiry block (renewed)
  *       - the recurring registration survives with `paid = false`
  *
@@ -180,7 +180,7 @@ async function main() {
   const testData = new Uint8Array(2000).fill(42);
   const contentHash = blake2AsU8a(testData, 256);
   const renewalsKey = mapKey("DataRenewal", "Renewals", contentHash);
-  const pendingKey = storageKey("DataRenewal", "PendingAutoRenewals");
+  const pendingKey = storageKey("DataRenewal", "PendingRenewals");
   const contentHashKey = mapKey("TransactionStorage", "TransactionByContentHash", contentHash);
   console.log(`  Content hash: 0x${toHex(contentHash).slice(0, 16)}...`);
 
@@ -293,7 +293,7 @@ async function main() {
     logOk(`Block #${chain.head.number} produced`);
   }
 
-  // ── Expiry block: on_initialize queues PendingAutoRenewals, and the
+  // ── Expiry block: on_initialize queues PendingRenewals, and the
   //    process_pending_renewals inherent (synthesized by Chopsticks) drains it
   //    in the same block. ──
   logStep(7, "Building the expiry block (Chopsticks supplies the process_pending_renewals inherent)...");
@@ -305,14 +305,14 @@ async function main() {
   logOk(`Block #${chain.head.number} produced (on_finalize did not panic)`);
 
   // ── Verify the drain results ──
-  logStep(8, "Verifying the inherent drained PendingAutoRenewals and renewed the data...");
+  logStep(8, "Verifying the inherent drained PendingRenewals and renewed the data...");
 
   const pendingAfter = await provider.send("state_getStorage", [pendingKey], false);
   if (!pendingAfter || pendingAfter === "0x00") {
-    logOk("PendingAutoRenewals is empty (drained by the inherent)");
+    logOk("PendingRenewals is empty (drained by the inherent)");
   } else {
-    logFail(`PendingAutoRenewals not drained: ${pendingAfter}`);
-    throw new Error("process_pending_renewals did not drain PendingAutoRenewals");
+    logFail(`PendingRenewals not drained: ${pendingAfter}`);
+    throw new Error("process_pending_renewals did not drain PendingRenewals");
   }
 
   const contentHashAfter = await provider.send("state_getStorage", [contentHashKey], false);
@@ -348,7 +348,7 @@ async function main() {
   console.log("  Verified:");
   console.log("  - enable_auto_renew: DataRenewal.Renewals entry created");
   console.log("  - disable_auto_renew: DataRenewal.Renewals entry removed");
-  console.log("  - on_initialize queues expiring data into PendingAutoRenewals");
+  console.log("  - on_initialize queues expiring data into PendingRenewals");
   console.log("  - process_pending_renewals inherent drains it and renews the data");
   console.log("  - recurring registration survives with the prepayment consumed");
   console.log("");

--- a/pallets/data-renewal/README.md
+++ b/pallets/data-renewal/README.md
@@ -12,7 +12,7 @@ Extends the retention of data stored in `pallet-bulletin-transaction-storage`, m
 
 ## Overview
 
-Stored data is removed once its `RetentionPeriod` elapses. This pallet is the renewal layer on top of the storage pallet: the storage pallet has no renewal vocabulary of its own, and instead exposes two opaque payloads (`EntryMeta`, `AuthorizationExtra`) that the runtime wires to this pallet's `EntryKind` and `PermanentExtent`.
+Stored data is removed once its `RetentionPeriod` elapses. This pallet is the renewal layer on top of the storage pallet, which has no renewal vocabulary of its own: it exposes two opaque payloads (`EntryMeta`, `AuthorizationExtra`) that the runtime wires to this pallet's `EntryKind` and `PermanentExtent`.
 
 Dispatchables:
 - `renew(entry)` — register a one-shot renewal for an entry, identified by `Position { block, index }` or `ContentHash(hash)`

--- a/pallets/data-renewal/README.md
+++ b/pallets/data-renewal/README.md
@@ -20,7 +20,7 @@ Dispatchables:
 - `force_renew(entry)` — renew synchronously, during block execution
 - `process_pending_renewals` — mandatory inherent that drains the current block's renewal queue
 
-Renewals fire at the retention boundary: the storage pallet's `handle_obsolete` hook queues registered entries into `PendingAutoRenewals`, and the inherent renews them in the same block.
+Renewals fire at the retention boundary: the storage pallet's `handle_obsolete` hook queues registered entries into `PendingRenewals`, and the inherent renews them in the same block.
 
 `renew` and `enable_auto_renew` are feeless. The transaction extension charges one transaction slot plus `size` bytes at registration, which prepays the first cycle; recurring registrations are charged per cycle thereafter.
 

--- a/pallets/data-renewal/src/benchmarking.rs
+++ b/pallets/data-renewal/src/benchmarking.rs
@@ -236,7 +236,7 @@ mod benchmarks {
 		System::<T>::set_extrinsic_index(0);
 
 		if n > 0 {
-			let mut pending = PendingAutoRenewals::<T>::get();
+			let mut pending = PendingRenewals::<T>::get();
 			for i in 0..n {
 				// Unique caller per item so each `check_authorization` hits a distinct
 				// `Authorizations` key.
@@ -267,13 +267,13 @@ mod benchmarks {
 					.try_push((content_hash, tx_info, renewal_data))
 					.map_err(|_| BenchmarkError::Stop("unable to push pending renewal"))?;
 			}
-			PendingAutoRenewals::<T>::put(&pending);
+			PendingRenewals::<T>::put(&pending);
 		}
 
 		#[extrinsic_call]
 		_(RawOrigin::None);
 
-		assert!(PendingAutoRenewals::<T>::get().is_empty());
+		assert!(PendingRenewals::<T>::get().is_empty());
 		assert_eq!(pallet_bulletin_transaction_storage::Pallet::<T>::block_transactions_count(), n);
 		Ok(())
 	}

--- a/pallets/data-renewal/src/extension.rs
+++ b/pallets/data-renewal/src/extension.rs
@@ -127,7 +127,7 @@ impl<T: Config> Pallet<T> {
 				let info = txs::Pallet::<T>::resolve_transaction_ref(entry)
 					.map_err(|_| crate::RENEWED_NOT_FOUND)?;
 				if crate::Renewals::<T>::contains_key(info.content_hash) {
-					return Err(crate::AUTO_RENEWAL_ALREADY_ENABLED.into());
+					return Err(crate::RENEWAL_ALREADY_ENABLED.into());
 				}
 				Pallet::<T>::check_renew_authorization(
 					&AuthorizationScope::Account(who.clone()),
@@ -163,7 +163,7 @@ impl<T: Config> Pallet<T> {
 			},
 			Call::enable_auto_renew { content_hash } => {
 				if crate::Renewals::<T>::contains_key(*content_hash) {
-					return Err(crate::AUTO_RENEWAL_ALREADY_ENABLED.into());
+					return Err(crate::RENEWAL_ALREADY_ENABLED.into());
 				}
 				let (block, index) = txs::Pallet::<T>::lookup_by_content_hash(*content_hash)
 					.ok_or(crate::RENEWED_NOT_FOUND)?;

--- a/pallets/data-renewal/src/lib.rs
+++ b/pallets/data-renewal/src/lib.rs
@@ -25,7 +25,7 @@
 //! - **Dispatchables:** `force_renew` (synchronous), `renew` (one-shot scheduler),
 //!   `enable_auto_renew` / `disable_auto_renew` (recurring), `process_pending_renewals` (mandatory
 //!   drain inherent).
-//! - **Storage:** [`Renewals`] (per-content-hash registration), [`PendingAutoRenewals`] (per-block
+//! - **Storage:** [`Renewals`] (per-content-hash registration), [`PendingRenewals`] (per-block
 //!   scratch queue, drained by the inherent), and [`PermanentStorageUsed`] (chain-wide renewed-byte
 //!   counter, capped by `MaxPermanentStorageSize`).
 //!
@@ -39,7 +39,7 @@
 //!   quota is mutated atomically through `try_mutate_active_authorization`.
 //! - **Up ← storage:** [`OnObsoleteTransactions::handle_obsolete`] fires at the `RetentionPeriod`
 //!   boundary — it decrements [`PermanentStorageUsed`] for aged-out `Renew` entries and queues
-//!   registered entries into [`PendingAutoRenewals`] for the same block's inherent.
+//!   registered entries into [`PendingRenewals`] for the same block's inherent.
 //! - **Per-cycle accounting** is charged by `Pallet::check_renew_authorization`.
 //!
 //! ## Prepayment model
@@ -48,7 +48,7 @@
 //! transaction-extension's `pre_dispatch` charges one tx slot + `size` bytes
 //! up front. The first cycle then fires free (`paid = true` on the inserted
 //! [`RenewalData`]), and every subsequent recurring cycle charges per-cycle in
-//! `Pallet::do_process_auto_renewals`.
+//! `Pallet::do_process_pending_renewals`.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -96,8 +96,8 @@ pub const CHAIN_PERMANENT_CAP_REACHED: InvalidTransaction = InvalidTransaction::
 pub const AUTO_RENEWAL_NOT_ENABLED: InvalidTransaction = InvalidTransaction::Custom(9);
 /// `disable_auto_renew`: caller is not the account that registered the auto-renewal.
 pub const NOT_AUTO_RENEWAL_OWNER: InvalidTransaction = InvalidTransaction::Custom(10);
-/// `enable_auto_renew`: an auto-renewal is already registered for this content hash.
-pub const AUTO_RENEWAL_ALREADY_ENABLED: InvalidTransaction = InvalidTransaction::Custom(11);
+/// `renew` / `enable_auto_renew`: a renewal is already registered for this content hash.
+pub const RENEWAL_ALREADY_ENABLED: InvalidTransaction = InvalidTransaction::Custom(11);
 /// `disable_auto_renew`: the registration has been prepaid for its next cycle and
 /// cannot be disabled by the owner until the cycle fires and consumes the prepayment.
 /// Root can still disable for governance cleanup.
@@ -144,8 +144,8 @@ pub mod pallet {
 		RenewedNotFound,
 		/// Block already contains the maximum number of transactions.
 		TooManyTransactions,
-		/// Auto-renewal is already enabled for this content hash.
-		AutoRenewalAlreadyEnabled,
+		/// A renewal is already registered for this content hash.
+		RenewalAlreadyEnabled,
 		/// Auto-renewal is not enabled for this content hash.
 		AutoRenewalNotEnabled,
 		/// Caller is not the owner of the auto-renewal registration.
@@ -170,13 +170,12 @@ pub mod pallet {
 	pub type Renewals<T: Config> =
 		StorageMap<_, Blake2_128Concat, ContentHash, RenewalData<T::AccountId>, OptionQuery>;
 
-	/// Transactions that must be auto-renewed in the current block.
+	/// Transactions to renew in the current block.
 	///
-	/// Populated by [`OnObsoleteTransactions::handle_obsolete`] when a block's data is
-	/// about to expire. Cleared by the [`Pallet::process_pending_renewals`] mandatory
-	/// inherent executed in the same block.
+	/// Filled by [`OnObsoleteTransactions::handle_obsolete`] at the retention boundary,
+	/// drained by the [`Pallet::process_pending_renewals`] inherent in the same block.
 	#[pallet::storage]
-	pub type PendingAutoRenewals<T: Config> = StorageValue<
+	pub type PendingRenewals<T: Config> = StorageValue<
 		_,
 		BoundedVec<
 			(ContentHash, TransactionInfoFor<T>, RenewalData<T::AccountId>),
@@ -206,10 +205,11 @@ pub mod pallet {
 		/// Auto-renewal disabled for `content_hash`. `who` is the registration's owner
 		/// (not the caller when Root issued the disable).
 		AutoRenewalDisabled { content_hash: ContentHash, who: T::AccountId },
-		/// Data was automatically renewed at `index` with `content_hash` for `account`.
-		DataAutoRenewed { index: u32, content_hash: ContentHash, account: T::AccountId },
-		/// Auto-renewal failed for `content_hash` (insufficient authorization for `account`).
-		AutoRenewalFailed { content_hash: ContentHash, account: T::AccountId },
+		/// A registered renewal fired, re-storing the data at `index`.
+		DataRenewed { index: u32, content_hash: ContentHash, account: T::AccountId },
+		/// A registered renewal failed on `account`'s authorization; the registration is
+		/// dropped and the data expires.
+		RenewalFailed { content_hash: ContentHash, account: T::AccountId },
 		/// `PermanentStorageUsed` changed (a `renew` bumped it, or the obsolete sweep
 		/// decremented it). Off-chain capacity-planning consumers can drive their dashboards
 		/// from these.
@@ -223,21 +223,21 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_finalize(_: BlockNumberFor<T>) {
-			// All pending auto-renewals must have been processed by the
+			// All pending renewals must have been processed by the
 			// `process_pending_renewals` inherent.
 			#[cfg(feature = "try-runtime")]
-			if !PendingAutoRenewals::<T>::get().is_empty() {
+			if !PendingRenewals::<T>::get().is_empty() {
 				tracing::warn!(
 					target: LOG_TARGET,
-					"Pending auto-renewals were not processed (expected during try-runtime)"
+					"Pending renewals were not processed (expected during try-runtime)"
 				);
-				PendingAutoRenewals::<T>::kill();
+				PendingRenewals::<T>::kill();
 			}
 
 			#[cfg(not(feature = "try-runtime"))]
 			assert!(
-				PendingAutoRenewals::<T>::get().is_empty(),
-				"All pending auto-renewals must be processed by process_pending_renewals"
+				PendingRenewals::<T>::get().is_empty(),
+				"All pending renewals must be processed by process_pending_renewals"
 			);
 		}
 
@@ -281,10 +281,7 @@ pub mod pallet {
 					.map_err(|_| Error::<T>::RenewedNotFound)?;
 			let content_hash = info.content_hash;
 
-			ensure!(
-				!Renewals::<T>::contains_key(content_hash),
-				Error::<T>::AutoRenewalAlreadyEnabled
-			);
+			ensure!(!Renewals::<T>::contains_key(content_hash), Error::<T>::RenewalAlreadyEnabled);
 
 			Renewals::<T>::insert(
 				content_hash,
@@ -322,9 +319,9 @@ pub mod pallet {
 
 		/// Register recurring auto-renewal for `content_hash`. First cycle is
 		/// prepaid at registration (`paid = true`); subsequent cycles charge
-		/// the owner's authorization in `do_process_auto_renewals` and
+		/// the owner's authorization in `do_process_pending_renewals` and
 		/// drop the registration on quota exhaustion with
-		/// [`Event::AutoRenewalFailed`].
+		/// [`Event::RenewalFailed`].
 		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::enable_auto_renew())]
 		#[pallet::feeless_if(|_origin: &OriginFor<T>, _content_hash: &ContentHash| -> bool { true })]
@@ -338,10 +335,7 @@ pub mod pallet {
 				return Err(DispatchError::BadOrigin);
 			};
 
-			ensure!(
-				!Renewals::<T>::contains_key(content_hash),
-				Error::<T>::AutoRenewalAlreadyEnabled
-			);
+			ensure!(!Renewals::<T>::contains_key(content_hash), Error::<T>::RenewalAlreadyEnabled);
 
 			// Defensive content-hash existence check. The hard-cap accounting
 			// (`bytes_permanent`, `PermanentStorageUsed`, one tx slot) is performed by
@@ -396,7 +390,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Mandatory inherent: drain [`PendingAutoRenewals`] for the current
+		/// Mandatory inherent: drain [`PendingRenewals`] for the current
 		/// block. Refunds to the actually-drained count via `PostDispatchInfo`.
 		#[pallet::call_index(4)]
 		#[pallet::weight((
@@ -407,7 +401,7 @@ pub mod pallet {
 		))]
 		pub fn process_pending_renewals(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			ensure_none(origin)?;
-			let n_actual = Self::do_process_auto_renewals();
+			let n_actual = Self::do_process_pending_renewals();
 			Ok(Some(<T as Config>::WeightInfo::process_pending_renewals(n_actual)).into())
 		}
 	}
@@ -419,7 +413,7 @@ pub mod pallet {
 		const INHERENT_IDENTIFIER: InherentIdentifier = *b"datarenw";
 
 		fn create_inherent(_data: &InherentData) -> Option<Self::Call> {
-			if PendingAutoRenewals::<T>::get().is_empty() {
+			if PendingRenewals::<T>::get().is_empty() {
 				return None;
 			}
 			Some(Call::process_pending_renewals {})
@@ -485,18 +479,18 @@ impl<T: Config> Pallet<T> {
 		.ok_or(Error::<T>::TooManyTransactions)
 	}
 
-	/// Drain [`PendingAutoRenewals`], returning the count drained. One
+	/// Drain [`PendingRenewals`], returning the count drained. One
 	/// `BlockTransactions` read/write for all entries. Per-cycle charges
 	/// (recurring cycles past the prepaid one) go through `check_authorization`;
 	/// the prepaid bump is refunded when a paid cycle is rejected by the
 	/// per-block slot cap.
 	///
 	/// On any failure (auth, caps, slot cap) the registration is removed and
-	/// `AutoRenewalFailed` emitted — the data is gone, since the obsolete
+	/// `RenewalFailed` emitted — the data is gone, since the obsolete
 	/// `Transactions` entry was already taken by storage pallet's
 	/// `on_initialize`.
-	pub(crate) fn do_process_auto_renewals() -> u32 {
-		let pending = PendingAutoRenewals::<T>::take();
+	pub(crate) fn do_process_pending_renewals() -> u32 {
+		let pending = PendingRenewals::<T>::take();
 		let n_actual = pending.len() as u32;
 		if n_actual == 0 {
 			return 0;
@@ -509,7 +503,7 @@ impl<T: Config> Pallet<T> {
 			None => {
 				for (content_hash, _, renewal_data) in pending.into_iter() {
 					Renewals::<T>::remove(content_hash);
-					Self::deposit_event(Event::AutoRenewalFailed {
+					Self::deposit_event(Event::RenewalFailed {
 						content_hash,
 						account: renewal_data.account,
 					});
@@ -546,7 +540,7 @@ impl<T: Config> Pallet<T> {
 							}
 						});
 					}
-					Self::deposit_event(Event::DataAutoRenewed {
+					Self::deposit_event(Event::DataRenewed {
 						index: new_index,
 						content_hash,
 						account: renewal_data.account,
@@ -562,7 +556,7 @@ impl<T: Config> Pallet<T> {
 						Self::update_permanent_storage_used(|used| used.saturating_sub(size_u64));
 					}
 					Renewals::<T>::remove(content_hash);
-					Self::deposit_event(Event::AutoRenewalFailed {
+					Self::deposit_event(Event::RenewalFailed {
 						content_hash,
 						account: renewal_data.account,
 					});
@@ -753,7 +747,7 @@ impl<T: Config> Pallet<T> {
 		#[cfg(test)]
 		ensure!(
 			used == expected,
-			"PermanentStorageUsed != Σ renewed sizes + Σ paid auto-renewal sizes",
+			"PermanentStorageUsed != Σ renewed sizes + Σ paid registration sizes",
 		);
 		#[cfg(all(feature = "try-runtime", not(test)))]
 		if used != expected {
@@ -761,7 +755,7 @@ impl<T: Config> Pallet<T> {
 				target: LOG_TARGET,
 				used,
 				expected,
-				"PermanentStorageUsed drifts from Σ renewed + Σ paid auto-renewal sizes",
+				"PermanentStorageUsed drifts from Σ renewed + Σ paid registration sizes",
 			);
 		}
 
@@ -776,7 +770,7 @@ impl<T: Config> Pallet<T> {
 
 /// Obsolete-block sweep callback: decrements [`PermanentStorageUsed`] for aged-out
 /// `Renew` entries and queues `is_latest` entries with a [`Renewals`] registration
-/// into [`PendingAutoRenewals`] for the same block's inherent.
+/// into [`PendingRenewals`] for the same block's inherent.
 impl<T: Config> OnObsoleteTransactions<BlockNumberFor<T>, T::EntryMeta> for Pallet<T> {
 	fn handle_obsolete(_obsolete: BlockNumberFor<T>, items: &[(TransactionInfoFor<T>, bool)]) {
 		// Renewed bytes leaving the retention window free up permanent capacity.
@@ -793,7 +787,7 @@ impl<T: Config> OnObsoleteTransactions<BlockNumberFor<T>, T::EntryMeta> for Pall
 		// One read, one write — `try_push` cannot overflow under
 		// `items.len() <= MaxBlockTransactions` plus the `on_finalize`
 		// empty-pending invariant.
-		let mut pending = PendingAutoRenewals::<T>::get();
+		let mut pending = PendingRenewals::<T>::get();
 		for (tx_info, is_latest) in items.iter() {
 			if !is_latest {
 				continue;
@@ -804,7 +798,7 @@ impl<T: Config> OnObsoleteTransactions<BlockNumberFor<T>, T::EntryMeta> for Pall
 			}
 		}
 		if !pending.is_empty() {
-			PendingAutoRenewals::<T>::put(&pending);
+			PendingRenewals::<T>::put(&pending);
 		}
 	}
 }

--- a/pallets/data-renewal/src/migrations.rs
+++ b/pallets/data-renewal/src/migrations.rs
@@ -121,12 +121,13 @@ impl<T: Config> OnRuntimeUpgrade for RelocateFromTransactionStorage<T> {
 		// Number of `StorageValue`s actually relocated below; each costs a set + a clear.
 		let mut values_moved: u64 = 0;
 
-		// `PendingAutoRenewals` (StorageValue): transient per-block scratch. The pre-split
-		// `on_finalize` asserts it is drained every block, so it is always absent here —
-		// the move is belt-and-braces, kept so the relocation is complete by construction
-		// rather than by relying on an invariant in the pallet being split apart.
+		// `PendingAutoRenewals` (StorageValue, now [`crate::PendingRenewals`]): transient
+		// per-block scratch. The pre-split `on_finalize` asserts it is drained every block,
+		// so it is always absent here — the move is belt-and-braces, kept so the relocation
+		// is complete by construction rather than by relying on an invariant in the pallet
+		// being split apart.
 		let old_pending_key = old_prefix::<T>(b"PendingAutoRenewals");
-		let new_pending_key = crate::PendingAutoRenewals::<T>::hashed_key();
+		let new_pending_key = crate::PendingRenewals::<T>::hashed_key();
 		if let Some(raw) = sp_io::storage::get(&old_pending_key) {
 			sp_io::storage::set(&new_pending_key, &raw);
 			sp_io::storage::clear(&old_pending_key);
@@ -246,10 +247,9 @@ impl<T: Config> OnRuntimeUpgrade for RelocateFromTransactionStorage<T> {
 		// Compared as raw bytes so a value present only at the wrong prefix is caught even
 		// though `ValueQuery` would read it back as an empty vec either way.
 		ensure!(
-			sp_io::storage::get(&crate::PendingAutoRenewals::<T>::hashed_key())
-				.map(|raw| raw.to_vec()) ==
+			sp_io::storage::get(&crate::PendingRenewals::<T>::hashed_key()).map(|raw| raw.to_vec()) ==
 				pre.pending,
-			"PendingAutoRenewals not relocated byte-exactly"
+			"PendingRenewals not relocated byte-exactly"
 		);
 		ensure!(
 			sp_io::storage::get(&old_prefix::<T>(b"PendingAutoRenewals")).is_none(),

--- a/pallets/data-renewal/src/mock.rs
+++ b/pallets/data-renewal/src/mock.rs
@@ -154,7 +154,7 @@ pub fn new_test_ext() -> TestExternalities {
 
 /// Run to block `n`, calling `apply_block_inherents` (proof inherent) and the
 /// renewal-pallet drain inherent before each `on_finalize`. Mirrors the runtime's
-/// block-author behaviour so the per-block `ProofChecked` and `PendingAutoRenewals`
+/// block-author behaviour so the per-block `ProofChecked` and `PendingRenewals`
 /// invariants are satisfied.
 pub fn run_to_block(
 	n: u64,
@@ -165,7 +165,7 @@ pub fn run_to_block(
 		RunToBlockHooks::default().before_finalize(move |_| {
 			let proof = f();
 			TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), proof).unwrap();
-			if !crate::PendingAutoRenewals::<Test>::get().is_empty() {
+			if !crate::PendingRenewals::<Test>::get().is_empty() {
 				DataRenewal::process_pending_renewals(RuntimeOrigin::none()).unwrap();
 			}
 		}),
@@ -182,7 +182,7 @@ pub fn apply_block_inherents_full(
 	TransactionStorage::apply_block_inherents(RuntimeOrigin::none(), proof)
 		.map(|_| ())
 		.map_err(|e| e.error)?;
-	if !crate::PendingAutoRenewals::<Test>::get().is_empty() {
+	if !crate::PendingRenewals::<Test>::get().is_empty() {
 		DataRenewal::process_pending_renewals(RuntimeOrigin::none())
 			.map(|_| ())
 			.map_err(|e| e.error)?;

--- a/pallets/data-renewal/src/tests.rs
+++ b/pallets/data-renewal/src/tests.rs
@@ -19,7 +19,7 @@
 
 #![allow(deprecated)]
 
-use crate::{mock::*, PendingAutoRenewals, PermanentExtent, RenewalData, Renewals};
+use crate::{mock::*, PendingRenewals, PermanentExtent, RenewalData, Renewals};
 use bulletin_transaction_storage_primitives::{
 	cids::{CidConfig, HashingAlgorithm},
 	EntryKind,
@@ -48,7 +48,7 @@ use sp_transaction_storage_proof::{num_chunks, registration::build_proof};
 fn pallet_compiles_and_storage_is_separate_from_transaction_storage() {
 	new_test_ext().execute_with(|| {
 		assert!(Renewals::<Test>::iter().next().is_none());
-		assert!(PendingAutoRenewals::<Test>::get().is_empty());
+		assert!(PendingRenewals::<Test>::get().is_empty());
 		use polkadot_sdk_frame::deps::frame_support::traits::GetStorageVersion;
 		assert_eq!(
 			crate::Pallet::<Test>::on_chain_storage_version(),
@@ -83,7 +83,7 @@ fn on_obsolete_callback_queues_pending_renewals_for_is_latest_entries_with_regis
 		let items = [(info, true)];
 		<crate::Pallet<Test> as OnObsoleteTransactions<u64, EntryKind>>::handle_obsolete(1, &items);
 
-		let pending = PendingAutoRenewals::<Test>::get();
+		let pending = PendingRenewals::<Test>::get();
 		assert_eq!(pending.len(), 1);
 		assert_eq!(pending[0].0, content_hash);
 	});
@@ -114,7 +114,7 @@ fn on_obsolete_callback_skips_stale_shadow_entries() {
 		};
 		let items = [(info, false)];
 		<crate::Pallet<Test> as OnObsoleteTransactions<u64, EntryKind>>::handle_obsolete(1, &items);
-		assert!(PendingAutoRenewals::<Test>::get().is_empty());
+		assert!(PendingRenewals::<Test>::get().is_empty());
 	});
 }
 
@@ -196,12 +196,12 @@ fn relocation_migration_moves_permanent_storage_used() {
 	});
 }
 
-/// `PendingAutoRenewals` is relocated byte-exactly to the key the pallet reads.
+/// `PendingRenewals` is relocated byte-exactly to the key the pallet reads.
 ///
 /// The value is produced by encoding through the storage item itself and then moved to the
 /// legacy prefix, so the test never has to name the (`Config`-dependent) value type.
 #[test]
-fn relocation_migration_moves_pending_auto_renewals() {
+fn relocation_migration_moves_pending_renewals() {
 	use bulletin_transaction_storage_primitives::ContentHash;
 	use polkadot_sdk_frame::deps::{
 		frame_support::traits::StorageVersion,
@@ -219,7 +219,7 @@ fn relocation_migration_moves_pending_auto_renewals() {
 			block_chunks: 1,
 			meta: EntryKind::Renew,
 		};
-		PendingAutoRenewals::<Test>::mutate(|pending| {
+		PendingRenewals::<Test>::mutate(|pending| {
 			pending
 				.try_push((
 					content_hash,
@@ -231,7 +231,7 @@ fn relocation_migration_moves_pending_auto_renewals() {
 
 		// Relocate the encoded value back to the legacy prefix to build the pre-migration
 		// state, then reset the version gate.
-		let new_key = PendingAutoRenewals::<Test>::hashed_key();
+		let new_key = PendingRenewals::<Test>::hashed_key();
 		let raw = sp_io::storage::get(&new_key).expect("just written").to_vec();
 		sp_io::storage::clear(&new_key);
 		let old_key = storage_prefix(b"TransactionStorage", b"PendingAutoRenewals");
@@ -240,7 +240,7 @@ fn relocation_migration_moves_pending_auto_renewals() {
 
 		let _ = crate::migrations::RelocateFromTransactionStorage::<Test>::on_runtime_upgrade();
 
-		let pending = PendingAutoRenewals::<Test>::get();
+		let pending = PendingRenewals::<Test>::get();
 		assert_eq!(pending.len(), 1, "pending entry must be readable through the storage item");
 		assert_eq!(pending[0].0, content_hash);
 		assert!(sp_io::storage::get(&old_key).is_none(), "old key must be cleared");
@@ -267,7 +267,7 @@ fn relocation_migration_try_runtime_checks_pass() {
 			&RenewalData::<u64> { account: 3, recurring: false, paid: true }.encode(),
 		);
 
-		// Both relocated `StorageValue`s. `PendingAutoRenewals` is left absent, which is
+		// Both relocated `StorageValue`s. `PendingRenewals` is left absent, which is
 		// the real-world case the `on_finalize` drain invariant guarantees.
 		sp_io::storage::set(
 			&storage_prefix(b"TransactionStorage", b"PermanentStorageUsed"),
@@ -378,7 +378,7 @@ fn enable_auto_renew_works() {
 		let call = crate::Call::<Test>::enable_auto_renew { content_hash };
 		assert_eq!(
 			DataRenewal::validate_renewal_signed(&who, &call).map(|_| ()),
-			Err(crate::AUTO_RENEWAL_ALREADY_ENABLED.into()),
+			Err(crate::RENEWAL_ALREADY_ENABLED.into()),
 		);
 	});
 }
@@ -526,7 +526,7 @@ fn pending_auto_renewals_populated_only_for_registered_items() {
 		let items = [(info_a, true), (info_b, true)];
 		<crate::Pallet<Test> as OnObsoleteTransactions<u64, EntryKind>>::handle_obsolete(1, &items);
 
-		let pending = PendingAutoRenewals::<Test>::get();
+		let pending = PendingRenewals::<Test>::get();
 		assert_eq!(pending.len(), 1, "only the registered item should be queued");
 		assert_eq!(pending[0].0, hash_a);
 	});
@@ -553,7 +553,7 @@ fn process_auto_renewals_rejects_signed_origin() {
 fn process_auto_renewals_noop_when_empty() {
 	new_test_ext().execute_with(|| {
 		run_to_block(1, || None);
-		assert!(PendingAutoRenewals::<Test>::get().is_empty());
+		assert!(PendingRenewals::<Test>::get().is_empty());
 		assert_ok!(DataRenewal::process_pending_renewals(RuntimeOrigin::none()));
 	});
 }
@@ -1201,11 +1201,11 @@ fn auto_renewal_lifecycle() {
 		run_to_block(11, proof_provider);
 
 		// Block 12: on_initialize takes `Transactions[1]` and schedules the
-		// auto-renewal into `PendingAutoRenewals`.
+		// auto-renewal into `PendingRenewals`.
 		init_block(12);
 
-		// Verify PendingAutoRenewals was populated
-		let pending = crate::PendingAutoRenewals::<Test>::get();
+		// Verify PendingRenewals was populated
+		let pending = crate::PendingRenewals::<Test>::get();
 		assert_eq!(pending.len(), 1);
 		assert_eq!(pending[0].0, content_hash);
 
@@ -1215,8 +1215,8 @@ fn auto_renewal_lifecycle() {
 
 		assert_ok!(apply_block_inherents_full(None));
 
-		// Verify PendingAutoRenewals is now empty
-		assert!(crate::PendingAutoRenewals::<Test>::get().is_empty());
+		// Verify PendingRenewals is now empty
+		assert!(crate::PendingRenewals::<Test>::get().is_empty());
 
 		// Data was renewed into the current block.
 		assert_eq!(
@@ -1227,7 +1227,7 @@ fn auto_renewal_lifecycle() {
 		);
 
 		// Verify event
-		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataAutoRenewed {
+		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataRenewed {
 			index: 0,
 			content_hash,
 			account: who,
@@ -1347,13 +1347,13 @@ fn auto_renewal_fails_when_authorization_exhausted() {
 		// headroom — `bytes_permanent + size > bytes_allowance` fires.
 		init_block(23);
 		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 1, 1000));
-		let pending = crate::PendingAutoRenewals::<Test>::get();
+		let pending = crate::PendingRenewals::<Test>::get();
 		assert_eq!(pending.len(), 1, "Should have pending renewal");
 
 		assert_ok!(apply_block_inherents_full(None));
 
 		// Should have failed — event emitted and auto-renewal removed.
-		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::AutoRenewalFailed {
+		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::RenewalFailed {
 			content_hash,
 			account: who,
 		}));
@@ -1481,8 +1481,8 @@ fn process_auto_renewals_continues_on_per_item_failure() {
 			100_000_000
 		));
 
-		// Verify PendingAutoRenewals was populated with 3 items
-		let pending = crate::PendingAutoRenewals::<Test>::get();
+		// Verify PendingRenewals was populated with 3 items
+		let pending = crate::PendingRenewals::<Test>::get();
 		assert_eq!(pending.len(), 3);
 
 		// Fill block with (max - 1) dummy transactions so only 1 renewal fits
@@ -1494,23 +1494,23 @@ fn process_auto_renewals_continues_on_per_item_failure() {
 		// Process auto-renewals — should NOT return an error even though 2 of 3 fail
 		assert_ok!(apply_block_inherents_full(None));
 
-		// PendingAutoRenewals should be fully consumed
-		assert!(crate::PendingAutoRenewals::<Test>::get().is_empty());
+		// PendingRenewals should be fully consumed
+		assert!(crate::PendingRenewals::<Test>::get().is_empty());
 
-		// First item should have succeeded (DataAutoRenewed event).
+		// First item should have succeeded (DataRenewed event).
 		// Index is max_txns - 1 because the block already has max_txns - 1 items (0-indexed).
-		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataAutoRenewed {
+		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataRenewed {
 			index: max_txns - 1,
 			content_hash: hashes[0],
 			account: who,
 		}));
 
-		// Remaining items should have failed (AutoRenewalFailed events)
-		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::AutoRenewalFailed {
+		// Remaining items should have failed (RenewalFailed events)
+		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::RenewalFailed {
 			content_hash: hashes[1],
 			account: who,
 		}));
-		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::AutoRenewalFailed {
+		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::RenewalFailed {
 			content_hash: hashes[2],
 			account: who,
 		}));
@@ -1523,7 +1523,7 @@ fn process_auto_renewals_continues_on_per_item_failure() {
 
 /// `paid = true` cycle rejected by the per-block slot cap refunds chain-wide
 /// `PermanentStorageUsed`. Per-account `bytes_permanent` / `transactions` are
-/// intentionally left burned — see the inline rationale in `do_process_auto_renewals`.
+/// intentionally left burned — see the inline rationale in `do_process_pending_renewals`.
 #[test]
 fn paid_cycle_refunds_on_block_slot_cap() {
 	new_test_ext().execute_with(|| {
@@ -1546,7 +1546,7 @@ fn paid_cycle_refunds_on_block_slot_cap() {
 		let transactions_before = auth.extent.transactions;
 
 		init_block(12);
-		assert_eq!(crate::PendingAutoRenewals::<Test>::get().len(), 1);
+		assert_eq!(crate::PendingRenewals::<Test>::get().len(), 1);
 
 		// Fill `BlockTransactions` so the paid drain has no slot to land in.
 		let max_txns =
@@ -1557,7 +1557,7 @@ fn paid_cycle_refunds_on_block_slot_cap() {
 
 		assert_ok!(apply_block_inherents_full(None));
 
-		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::AutoRenewalFailed {
+		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::RenewalFailed {
 			content_hash,
 			account: who,
 		}));
@@ -1595,8 +1595,8 @@ fn one_shot_fires_once_then_unregisters() {
 		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 10, 100_000));
 		assert_ok!(apply_block_inherents_full(None));
 
-		// DataAutoRenewed fired AND the registration was consumed.
-		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataAutoRenewed {
+		// DataRenewed fired AND the registration was consumed.
+		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataRenewed {
 			index: 0,
 			content_hash,
 			account: who,
@@ -1679,7 +1679,7 @@ fn one_shot_cycle_does_not_recharge_auth() {
 		init_block(12);
 		assert_ok!(apply_block_inherents_full(None));
 
-		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataAutoRenewed {
+		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataRenewed {
 			index: 0,
 			content_hash,
 			account: who,
@@ -1714,7 +1714,7 @@ fn renew_and_enable_auto_renew_conflict() {
 			crate::Call::<Test>::renew { entry: TransactionRef::Position { block: 1, index: 0 } };
 		assert_eq!(
 			DataRenewal::validate_renewal_signed(&who, &dup_call).map(|_| ()),
-			Err(crate::AUTO_RENEWAL_ALREADY_ENABLED.into()),
+			Err(crate::RENEWAL_ALREADY_ENABLED.into()),
 		);
 		assert_eq!(crate::PermanentStorageUsed::<Test>::get(), permanent_used_before);
 
@@ -1723,13 +1723,13 @@ fn renew_and_enable_auto_renew_conflict() {
 			Origin::<Test>::Authorized { who, scope: AuthorizationScope::Account(who) }.into();
 		assert_noop!(
 			DataRenewal::renew(origin, TransactionRef::Position { block: 1, index: 0 }),
-			crate::Error::<Test>::AutoRenewalAlreadyEnabled,
+			crate::Error::<Test>::RenewalAlreadyEnabled,
 		);
 
 		let call = crate::Call::<Test>::enable_auto_renew { content_hash };
 		assert_eq!(
 			DataRenewal::validate_renewal_signed(&who, &call).map(|_| ()),
-			Err(crate::AUTO_RENEWAL_ALREADY_ENABLED.into()),
+			Err(crate::RENEWAL_ALREADY_ENABLED.into()),
 		);
 	});
 }
@@ -1755,7 +1755,7 @@ fn renew_rejects_unsigned_and_root_origin() {
 
 /// Run a normal block lifecycle past expiry without invoking `apply_block_inherents`.
 ///
-/// `on_initialize` populates `PendingAutoRenewals`; `on_finalize` then enforces that the
+/// `on_initialize` populates `PendingRenewals`; `on_finalize` then enforces that the
 /// inherent ran, asserting that the storage is empty. The mock's `run_to_block` always
 /// invokes the inherent, hiding this safeguard. This test bypasses the helper to confirm
 /// the assert actually fires when an auto-renewal is pending and the inherent is missing.
@@ -1763,9 +1763,7 @@ fn renew_rejects_unsigned_and_root_origin() {
 // catch.
 #[cfg(not(feature = "try-runtime"))]
 #[test]
-#[should_panic(
-	expected = "All pending auto-renewals must be processed by process_pending_renewals"
-)]
+#[should_panic(expected = "All pending renewals must be processed by process_pending_renewals")]
 fn on_finalize_panics_when_inherent_missing() {
 	new_test_ext().execute_with(|| {
 		run_to_block(1, || None);
@@ -1799,28 +1797,28 @@ fn on_finalize_panics_when_inherent_missing() {
 
 		// Run normally up to (and including) block 12 — proofs supplied via the inherent.
 		// The block-1 `Store` entry expires at block 12 but the latest-entry guard
-		// skips it (force-renew at block 2 is the latest), so no PendingAutoRenewals
+		// skips it (force-renew at block 2 is the latest), so no PendingRenewals
 		// build up here. The force-renewed entry ages out at block 13.
 		run_to_block(12, proof_provider);
 
 		// Manually advance to block 13 and run only on_initialize, which populates
-		// PendingAutoRenewals as Transactions(2) expires. We deliberately do NOT call
+		// PendingRenewals as Transactions(2) expires. We deliberately do NOT call
 		// apply_block_inherents, simulating an inherent that was lost or never built.
 		init_block(13);
 		assert_eq!(
-			crate::PendingAutoRenewals::<Test>::get().len(),
+			crate::PendingRenewals::<Test>::get().len(),
 			1,
 			"on_initialize should have populated pending"
 		);
 
-		// on_finalize must panic on the PendingAutoRenewals invariant. The assert
+		// on_finalize must panic on the PendingRenewals invariant. The assert
 		// now lives on the renewal pallet (the inherent moved there in the split).
 		<DataRenewal as polkadot_sdk_frame::traits::Hooks<u64>>::on_finalize(13);
 	});
 }
 
 /// Verify that `ProvideInherent::create_inherent` actually emits the composite inherent call
-/// when `PendingAutoRenewals` is non-empty, even with no storage proof in `InherentData`.
+/// when `PendingRenewals` is non-empty, even with no storage proof in `InherentData`.
 ///
 /// This is the direct test for "the block author will inject the inherent that drains pending
 /// renewals" — if `create_inherent` ever stops returning the call when only renewals (and no
@@ -1851,7 +1849,7 @@ fn create_inherent_emits_call_when_pending_renewals_present() {
 		// The block-1 `Store` is no longer the latest reference after the
 		// force-renew, so the latest-entry guard skips it at block 12. The
 		// force-renewed entry ages out at block 13, populating
-		// `PendingAutoRenewals` then. We need a proof provider because block 12
+		// `PendingRenewals` then. We need a proof provider because block 12
 		// needs a proof for the (still-on-chain) block-2 Renew entry.
 		let proof_provider = move || {
 			let block_num = System::block_number();
@@ -1871,7 +1869,7 @@ fn create_inherent_emits_call_when_pending_renewals_present() {
 		};
 		run_to_block(12, proof_provider);
 		init_block(13);
-		assert_eq!(crate::PendingAutoRenewals::<Test>::get().len(), 1);
+		assert_eq!(crate::PendingRenewals::<Test>::get().len(), 1);
 
 		// `InherentData` carries no proof, but the renewal pallet must still emit its
 		// drain inherent so the pending renewals are processed in this block.
@@ -2206,7 +2204,7 @@ fn renew_emits_permanent_storage_used_updated() {
 }
 
 /// `enable_auto_renew` rejects a second call for the same content hash, even from the
-/// same account, with `AutoRenewalAlreadyEnabled`.
+/// same account, with `RenewalAlreadyEnabled`.
 #[test]
 fn enable_auto_renew_rejects_already_enabled() {
 	new_test_ext().execute_with(|| {
@@ -2224,7 +2222,7 @@ fn enable_auto_renew_rejects_already_enabled() {
 		let call = crate::Call::<Test>::enable_auto_renew { content_hash };
 		assert_eq!(
 			DataRenewal::validate_renewal_signed(&who, &call).map(|_| ()),
-			Err(crate::AUTO_RENEWAL_ALREADY_ENABLED.into()),
+			Err(crate::RENEWAL_ALREADY_ENABLED.into()),
 		);
 	});
 }
@@ -2278,11 +2276,11 @@ fn enable_auto_renew_rejects_insufficient_capacity() {
 }
 
 /// `disable_auto_renew` dispatched in the same block as the renewal does NOT prevent the
-/// renewal. `on_initialize` captures the entry into `PendingAutoRenewals` as a snapshot;
-/// `do_process_auto_renewals` then iterates that vec without re-reading
+/// renewal. `on_initialize` captures the entry into `PendingRenewals` as a snapshot;
+/// `do_process_pending_renewals` then iterates that vec without re-reading
 /// `AutoRenewals[hash]`. So disabling between `on_initialize` and `apply_block_inherents`
 /// in the renewal block is a no-op for the in-flight cycle — the caller still sees one
-/// final `DataAutoRenewed` event. Subsequent cycles are correctly suppressed because
+/// final `DataRenewed` event. Subsequent cycles are correctly suppressed because
 /// `AutoRenewals[hash]` is gone for the next on_initialize sweep.
 ///
 /// This is only reachable once the registration has cleared its prepaid window
@@ -2310,7 +2308,7 @@ fn disable_auto_renew_in_renewal_block_does_not_prevent_renewal() {
 
 		// Cycle 2 block: on_initialize captures the block-12 renewal into pending.
 		init_block(23);
-		assert_eq!(crate::PendingAutoRenewals::<Test>::get().len(), 1);
+		assert_eq!(crate::PendingRenewals::<Test>::get().len(), 1);
 
 		// Refresh authorization for cycle 2 (block-12 grant expired at block 22).
 		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 10, 100_000));
@@ -2324,7 +2322,7 @@ fn disable_auto_renew_in_renewal_block_does_not_prevent_renewal() {
 
 		// The mandatory inherent still iterates the captured pending vec and renews.
 		assert_ok!(apply_block_inherents_full(None));
-		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataAutoRenewed {
+		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataRenewed {
 			index: 0,
 			content_hash,
 			account: who,
@@ -2358,7 +2356,7 @@ fn root_disable_in_prepaid_renewal_block_is_not_undone_by_cycle() {
 
 		// Cycle 1 block: on_initialize captures the prepaid entry into pending.
 		init_block(12);
-		assert_eq!(crate::PendingAutoRenewals::<Test>::get().len(), 1);
+		assert_eq!(crate::PendingRenewals::<Test>::get().len(), 1);
 
 		// Root disables in the normal section — bypasses both the owner check and the
 		// prepaid-window check.
@@ -2371,7 +2369,7 @@ fn root_disable_in_prepaid_renewal_block_is_not_undone_by_cycle() {
 		// Mandatory inherent: the captured pending renewal still fires (the prepayment
 		// honestly delivers one cycle), but the post-cycle flip must not reinsert.
 		assert_ok!(apply_block_inherents_full(None));
-		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataAutoRenewed {
+		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataRenewed {
 			index: 0,
 			content_hash,
 			account: who,
@@ -2383,7 +2381,7 @@ fn root_disable_in_prepaid_renewal_block_is_not_undone_by_cycle() {
 	});
 }
 
-/// `do_process_auto_renewals` emits `AutoRenewalFailed` when `check_authorization`
+/// `do_process_pending_renewals` emits `RenewalFailed` when `check_authorization`
 /// returns `crate::CHAIN_PERMANENT_CAP_REACHED` — i.e. the chain-wide `PermanentStorageUsed`
 /// counter would exceed `MaxPermanentStorageSize` — even if the per-account budget is
 /// fine. The chain-wide gate only applies on cycles that actually charge, so this
@@ -2434,7 +2432,7 @@ fn auto_renewal_fails_on_chain_wide_permanent_cap() {
 
 		assert_ok!(apply_block_inherents_full(None));
 
-		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::AutoRenewalFailed {
+		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::RenewalFailed {
 			content_hash,
 			account: who,
 		}));
@@ -2468,7 +2466,7 @@ fn auto_renew_obeys_updated_retention_period() {
 		// (saturating). Transactions[1] must NOT be pulled.
 		init_block(12);
 		assert!(
-			crate::PendingAutoRenewals::<Test>::get().is_empty(),
+			crate::PendingRenewals::<Test>::get().is_empty(),
 			"RP change should push the obsolete boundary out",
 		);
 		assert!(
@@ -2479,9 +2477,9 @@ fn auto_renew_obeys_updated_retention_period() {
 		// Block 22 is the NEW renewal boundary (`obsolete = 22 - 21 = 1`).
 		init_block(22);
 		assert_ok!(TransactionStorage::authorize_account(RuntimeOrigin::root(), who, 10, 100_000));
-		assert_eq!(crate::PendingAutoRenewals::<Test>::get().len(), 1);
+		assert_eq!(crate::PendingRenewals::<Test>::get().len(), 1);
 		assert_ok!(apply_block_inherents_full(None));
-		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataAutoRenewed {
+		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataRenewed {
 			index: 0,
 			content_hash,
 			account: who,
@@ -2558,7 +2556,7 @@ fn auto_renew_consumes_registrant_authorization_not_storer() {
 			TransactionStorage::account_authorization_extent(bob).extra.bytes_permanent,
 			2000
 		);
-		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataAutoRenewed {
+		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::DataRenewed {
 			index: 0,
 			content_hash,
 			account: bob,
@@ -2624,11 +2622,11 @@ fn refresh_authorization_does_not_reset_counters_for_auto_renew() {
 		);
 
 		// Cycle 2 at block 23 must charge another 2000 against a per-account cap
-		// of 3000 already at 2000 → AutoRenewalFailed on the per-account axis (not
+		// of 3000 already at 2000 → RenewalFailed on the per-account axis (not
 		// on expiration — refresh kept the auth alive).
 		init_block(23);
 		assert_ok!(apply_block_inherents_full(None));
-		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::AutoRenewalFailed {
+		System::assert_has_event(RuntimeEvent::DataRenewal(crate::Event::RenewalFailed {
 			content_hash,
 			account: who,
 		}));
@@ -3115,7 +3113,7 @@ fn try_state_detects_counter_drift() {
 		crate::PermanentStorageUsed::<Test>::put(2000);
 		assert_err!(
 			DataRenewal::do_try_state(System::block_number()),
-			"PermanentStorageUsed != Σ renewed sizes + Σ paid auto-renewal sizes",
+			"PermanentStorageUsed != Σ renewed sizes + Σ paid registration sizes",
 		);
 
 		// Counter below the on-chain renewed sum: under-count, the direction that lets real
@@ -3137,7 +3135,7 @@ fn try_state_detects_counter_drift() {
 		);
 		assert_err!(
 			DataRenewal::do_try_state(System::block_number()),
-			"PermanentStorageUsed != Σ renewed sizes + Σ paid auto-renewal sizes",
+			"PermanentStorageUsed != Σ renewed sizes + Σ paid registration sizes",
 		);
 	});
 }

--- a/pallets/transaction-storage/src/tests.rs
+++ b/pallets/transaction-storage/src/tests.rs
@@ -1280,7 +1280,7 @@ fn genesis_populates_allowed_authorizers() {
 }
 
 /// Verify that `ProvideInherent::create_inherent` actually emits the composite inherent call
-/// when `PendingAutoRenewals` is non-empty, even with no storage proof in `InherentData`.
+/// when `PendingRenewals` is non-empty, even with no storage proof in `InherentData`.
 ///
 /// This is the direct test for "the block author will inject the inherent that drains pending
 /// renewals" — if `create_inherent` ever stops returning the call when only renewals (and no

--- a/runtimes/bulletin-paseo/src/weights/pallet_bulletin_data_renewal.rs
+++ b/runtimes/bulletin-paseo/src/weights/pallet_bulletin_data_renewal.rs
@@ -130,8 +130,8 @@ impl<T: frame_system::Config> pallet_bulletin_data_renewal::WeightInfo for Weigh
 			.saturating_add(T::DbWeight::get().reads(6))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
-	/// Storage: `DataRenewal::PendingAutoRenewals` (r:1 w:1)
-	/// Proof: `DataRenewal::PendingAutoRenewals` (`max_values`: Some(1), `max_size`: Some(77826), added: 78321, mode: `MaxEncodedLen`)
+	/// Storage: `DataRenewal::PendingRenewals` (r:1 w:1)
+	/// Proof: `DataRenewal::PendingRenewals` (`max_values`: Some(1), `max_size`: Some(77826), added: 78321, mode: `MaxEncodedLen`)
 	/// Storage: `TransactionStorage::BlockTransactions` (r:1 w:1)
 	/// Proof: `TransactionStorage::BlockTransactions` (`max_values`: Some(1), `max_size`: Some(44034), added: 44529, mode: `MaxEncodedLen`)
 	/// Storage: `DataRenewal::PermanentStorageUsed` (r:1 w:1)

--- a/runtimes/bulletin-paseo/src/weights/pallet_bulletin_transaction_storage.rs
+++ b/runtimes/bulletin-paseo/src/weights/pallet_bulletin_transaction_storage.rs
@@ -237,8 +237,8 @@ impl<T: frame_system::Config> pallet_bulletin_transaction_storage::WeightInfo fo
 	/// Proof: `DataRenewal::PermanentStorageUsed` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
 	/// Storage: UNKNOWN KEY `0xc20bbe95ae9a16ecbfcfef6c5ccc7871` (r:1 w:0)
 	/// Proof: UNKNOWN KEY `0xc20bbe95ae9a16ecbfcfef6c5ccc7871` (r:1 w:0)
-	/// Storage: `DataRenewal::PendingAutoRenewals` (r:1 w:1)
-	/// Proof: `DataRenewal::PendingAutoRenewals` (`max_values`: Some(1), `max_size`: Some(77826), added: 78321, mode: `MaxEncodedLen`)
+	/// Storage: `DataRenewal::PendingRenewals` (r:1 w:1)
+	/// Proof: `DataRenewal::PendingRenewals` (`max_values`: Some(1), `max_size`: Some(77826), added: 78321, mode: `MaxEncodedLen`)
 	/// Storage: `DataRenewal::Renewals` (r:512 w:0)
 	/// Proof: `DataRenewal::Renewals` (`max_values`: None, `max_size`: Some(82), added: 2557, mode: `MaxEncodedLen`)
 	/// The range of component `n` is `[0, 512]`.

--- a/runtimes/bulletin-westend/src/weights/pallet_bulletin_data_renewal.rs
+++ b/runtimes/bulletin-westend/src/weights/pallet_bulletin_data_renewal.rs
@@ -128,8 +128,8 @@ impl<T: frame_system::Config> pallet_bulletin_data_renewal::WeightInfo for Weigh
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
-	/// Storage: `DataRenewal::PendingAutoRenewals` (r:1 w:1)
-	/// Proof: `DataRenewal::PendingAutoRenewals` (`max_values`: Some(1), `max_size`: Some(77826), added: 78321, mode: `MaxEncodedLen`)
+	/// Storage: `DataRenewal::PendingRenewals` (r:1 w:1)
+	/// Proof: `DataRenewal::PendingRenewals` (`max_values`: Some(1), `max_size`: Some(77826), added: 78321, mode: `MaxEncodedLen`)
 	/// Storage: `TransactionStorage::BlockTransactions` (r:1 w:1)
 	/// Proof: `TransactionStorage::BlockTransactions` (`max_values`: Some(1), `max_size`: Some(44034), added: 44529, mode: `MaxEncodedLen`)
 	/// Storage: `DataRenewal::PermanentStorageUsed` (r:1 w:1)

--- a/runtimes/bulletin-westend/src/weights/pallet_bulletin_transaction_storage.rs
+++ b/runtimes/bulletin-westend/src/weights/pallet_bulletin_transaction_storage.rs
@@ -235,8 +235,8 @@ impl<T: frame_system::Config> pallet_bulletin_transaction_storage::WeightInfo fo
 	/// Proof: `TransactionStorage::TransactionByContentHash` (`max_values`: None, `max_size`: Some(56), added: 2531, mode: `MaxEncodedLen`)
 	/// Storage: `DataRenewal::PermanentStorageUsed` (r:1 w:1)
 	/// Proof: `DataRenewal::PermanentStorageUsed` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
-	/// Storage: `DataRenewal::PendingAutoRenewals` (r:1 w:1)
-	/// Proof: `DataRenewal::PendingAutoRenewals` (`max_values`: Some(1), `max_size`: Some(77826), added: 78321, mode: `MaxEncodedLen`)
+	/// Storage: `DataRenewal::PendingRenewals` (r:1 w:1)
+	/// Proof: `DataRenewal::PendingRenewals` (`max_values`: Some(1), `max_size`: Some(77826), added: 78321, mode: `MaxEncodedLen`)
 	/// Storage: `DataRenewal::Renewals` (r:512 w:0)
 	/// Proof: `DataRenewal::Renewals` (`max_values`: None, `max_size`: Some(82), added: 2557, mode: `MaxEncodedLen`)
 	/// The range of component `n` is `[0, 512]`.

--- a/zombienet-sdk-tests/tests/auto_renew_storage.rs
+++ b/zombienet-sdk-tests/tests/auto_renew_storage.rs
@@ -51,7 +51,7 @@ const BITSWAP_EVICTION_TIMEOUT_SECS: u64 = 300;
 
 const NUM_RENEWAL_CYCLES: u64 = 2;
 const TOPUP_TX_COUNT: u32 = 5;
-/// `+1` is safety: without it, a single byte short flips auto-renewal into `AutoRenewalFailed`.
+/// `+1` is safety: without it, a single byte short flips auto-renewal into `RenewalFailed`.
 const TOPUP_BYTES_MULTIPLIER: u64 = NUM_RENEWAL_CYCLES + 1;
 
 /// Pruning smaller than retention: the store block ages out of the pruning window before
@@ -711,16 +711,16 @@ async fn parachain_renew_one_shot_lifecycle_test() -> Result<()> {
 	let renewal_hash = finalized_block_hash_at(client, renewal_block).await?;
 	let renewal_events = client.blocks().at(renewal_hash).await?.events().await?;
 	assert_eq!(
-		count_renewal_event_for(&renewal_events, "DataAutoRenewed", &content_hash),
+		count_renewal_event_for(&renewal_events, "DataRenewed", &content_hash),
 		1,
-		"expected 1 DataAutoRenewed for {} at renewal block {}",
+		"expected 1 DataRenewed for {} at renewal block {}",
 		hash_hex,
 		renewal_block
 	);
 	assert_eq!(
-		count_renewal_event_for(&renewal_events, "AutoRenewalFailed", &content_hash),
+		count_renewal_event_for(&renewal_events, "RenewalFailed", &content_hash),
 		0,
-		"expected 0 AutoRenewalFailed for {} at renewal block {}",
+		"expected 0 RenewalFailed for {} at renewal block {}",
 		hash_hex,
 		renewal_block
 	);
@@ -749,16 +749,16 @@ async fn parachain_renew_one_shot_lifecycle_test() -> Result<()> {
 	let second_expiry_hash = finalized_block_hash_at(client, second_expiry_block).await?;
 	let expiry_events = client.blocks().at(second_expiry_hash).await?.events().await?;
 	assert_eq!(
-		count_renewal_event_for(&expiry_events, "DataAutoRenewed", &content_hash),
+		count_renewal_event_for(&expiry_events, "DataRenewed", &content_hash),
 		0,
 		"expected no renewal for {} at block {}: the one-shot already fired",
 		hash_hex,
 		second_expiry_block
 	);
 	assert_eq!(
-		count_renewal_event_for(&expiry_events, "AutoRenewalFailed", &content_hash),
+		count_renewal_event_for(&expiry_events, "RenewalFailed", &content_hash),
 		0,
-		"expected no AutoRenewalFailed for {} at block {}: nothing should be registered",
+		"expected no RenewalFailed for {} at block {}: nothing should be registered",
 		hash_hex,
 		second_expiry_block
 	);
@@ -884,16 +884,16 @@ async fn parachain_force_renew_lifecycle_test() -> Result<()> {
 	let sweep_hash = finalized_block_hash_at(client, sweep_block).await?;
 	let sweep_events = client.blocks().at(sweep_hash).await?.events().await?;
 	assert_eq!(
-		count_renewal_event_for(&sweep_events, "DataAutoRenewed", &content_hash),
+		count_renewal_event_for(&sweep_events, "DataRenewed", &content_hash),
 		0,
 		"expected no renewal for {} at sweep block {}: force_renew is synchronous only",
 		hash_hex,
 		sweep_block
 	);
 	assert_eq!(
-		count_renewal_event_for(&sweep_events, "AutoRenewalFailed", &content_hash),
+		count_renewal_event_for(&sweep_events, "RenewalFailed", &content_hash),
 		0,
-		"expected no AutoRenewalFailed for {} at sweep block {}: nothing should be registered",
+		"expected no RenewalFailed for {} at sweep block {}: nothing should be registered",
 		hash_hex,
 		sweep_block
 	);
@@ -1582,7 +1582,7 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 	);
 
 	tracing::info!("--- Block weight stats ---");
-	tracing::info!("Format: block N | extrinsics={{n}} DataAutoRenewed={{n}} AutoRenewalFailed={{n}} | normal=(ref_time,proof_size) op=(...) mand=(...)");
+	tracing::info!("Format: block N | extrinsics={{n}} DataRenewed={{n}} RenewalFailed={{n}} | normal=(ref_time,proof_size) op=(...) mand=(...)");
 
 	let mut total_renewed: u32 = 0;
 	let mut weight_violations: Vec<String> = Vec::new();
@@ -1597,12 +1597,12 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 		let auto_renewed: u32 = events
 			.iter()
 			.filter_map(|e| e.ok())
-			.filter(|e| e.pallet_name() == "DataRenewal" && e.variant_name() == "DataAutoRenewed")
+			.filter(|e| e.pallet_name() == "DataRenewal" && e.variant_name() == "DataRenewed")
 			.count() as u32;
 		let auto_renewal_failed: u32 = events
 			.iter()
 			.filter_map(|e| e.ok())
-			.filter(|e| e.pallet_name() == "DataRenewal" && e.variant_name() == "AutoRenewalFailed")
+			.filter(|e| e.pallet_name() == "DataRenewal" && e.variant_name() == "RenewalFailed")
 			.count() as u32;
 		let weight_value = client
 			.storage()
@@ -1677,9 +1677,9 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 	tracing::info!("Total renewals across window: {} / {}", total_renewed, expected_total);
 	if total_renewed < expected_total {
 		anyhow::bail!(
-			"Expected at least {} DataAutoRenewed events across the renewal window {}..={} \
+			"Expected at least {} DataRenewed events across the renewal window {}..={} \
 			 ({} items × {} cycles), saw {}. Some items did not renew (possibly insufficient \
-			 authorization, PendingAutoRenewals overflow, or do_renew returning Err).",
+			 authorization, PendingRenewals overflow, or do_renew returning Err).",
 			expected_total,
 			first_renewal_block,
 			last_renewal_block,
@@ -1715,25 +1715,29 @@ async fn parachain_auto_renew_many_items_test() -> Result<()> {
 	for n in exhaustion_block..=exhaustion_block + 1 {
 		let hash = finalized_block_hash_at(client, n).await?;
 		let events = client.blocks().at(hash).await?.events().await?;
-		total_failed += count_event(&events, "AutoRenewalFailed");
-		total_renewed_post_window += count_event(&events, "DataAutoRenewed");
+		total_failed += count_event(&events, "RenewalFailed");
+		total_renewed_post_window += count_event(&events, "DataRenewed");
 	}
 	assert_eq!(
-		total_failed, MANY_ITEMS_COUNT,
-		"expected exactly {} AutoRenewalFailed events at blocks {}..={} (cycle N+1 exhaustion); saw {}",
-		MANY_ITEMS_COUNT, exhaustion_block, exhaustion_block + 1, total_failed
+		total_failed,
+		MANY_ITEMS_COUNT,
+		"expected exactly {} RenewalFailed events at blocks {}..={} (cycle N+1 exhaustion); saw {}",
+		MANY_ITEMS_COUNT,
+		exhaustion_block,
+		exhaustion_block + 1,
+		total_failed
 	);
 	assert_eq!(
 		total_renewed_post_window,
 		0,
-		"expected 0 DataAutoRenewed events post-exhaustion at blocks {}..={}; saw {} \
+		"expected 0 DataRenewed events post-exhaustion at blocks {}..={}; saw {} \
 		 (Alice's authorization should have been fully consumed by the observation window)",
 		exhaustion_block,
 		exhaustion_block + 1,
 		total_renewed_post_window
 	);
 	tracing::info!(
-		"✓ All {} items hit AutoRenewalFailed at blocks {}..={}; AutoRenewals storage drained",
+		"✓ All {} items hit RenewalFailed at blocks {}..={}; AutoRenewals storage drained",
 		MANY_ITEMS_COUNT,
 		exhaustion_block,
 		exhaustion_block + 1,
@@ -2111,7 +2115,7 @@ async fn parachain_auto_renew_many_items_worst_case_test() -> Result<()> {
 	);
 
 	tracing::info!("--- Block weight stats ---");
-	tracing::info!("Format: block N | extrinsics={{n}} DataAutoRenewed={{n}} AutoRenewalFailed={{n}} | normal=(ref_time,proof_size) op=(...) mand=(...)");
+	tracing::info!("Format: block N | extrinsics={{n}} DataRenewed={{n}} RenewalFailed={{n}} | normal=(ref_time,proof_size) op=(...) mand=(...)");
 
 	let mut total_renewed: u32 = 0;
 	let mut weight_violations: Vec<String> = Vec::new();
@@ -2125,12 +2129,12 @@ async fn parachain_auto_renew_many_items_worst_case_test() -> Result<()> {
 		let auto_renewed: u32 = events
 			.iter()
 			.filter_map(|e| e.ok())
-			.filter(|e| e.pallet_name() == "DataRenewal" && e.variant_name() == "DataAutoRenewed")
+			.filter(|e| e.pallet_name() == "DataRenewal" && e.variant_name() == "DataRenewed")
 			.count() as u32;
 		let auto_renewal_failed: u32 = events
 			.iter()
 			.filter_map(|e| e.ok())
-			.filter(|e| e.pallet_name() == "DataRenewal" && e.variant_name() == "AutoRenewalFailed")
+			.filter(|e| e.pallet_name() == "DataRenewal" && e.variant_name() == "RenewalFailed")
 			.count() as u32;
 		let weight_value = client
 			.storage()
@@ -2196,7 +2200,7 @@ async fn parachain_auto_renew_many_items_worst_case_test() -> Result<()> {
 	tracing::info!("Total renewals across window: {} / {}", total_renewed, expected_total);
 	if total_renewed < expected_total {
 		anyhow::bail!(
-			"Expected at least {} DataAutoRenewed events, saw {}",
+			"Expected at least {} DataRenewed events, saw {}",
 			expected_total,
 			total_renewed
 		);
@@ -2225,25 +2229,29 @@ async fn parachain_auto_renew_many_items_worst_case_test() -> Result<()> {
 	for n in exhaustion_block..=exhaustion_block + 1 {
 		let hash = finalized_block_hash_at(&client, n).await?;
 		let events = client.blocks().at(hash).await?.events().await?;
-		total_failed += count_event(&events, "AutoRenewalFailed");
-		total_renewed_post_window += count_event(&events, "DataAutoRenewed");
+		total_failed += count_event(&events, "RenewalFailed");
+		total_renewed_post_window += count_event(&events, "DataRenewed");
 	}
 	assert_eq!(
-		total_failed, WORST_CASE_WORKERS,
-		"expected exactly {} AutoRenewalFailed events at blocks {}..={} (cycle N+1 exhaustion); saw {}",
-		WORST_CASE_WORKERS, exhaustion_block, exhaustion_block + 1, total_failed
+		total_failed,
+		WORST_CASE_WORKERS,
+		"expected exactly {} RenewalFailed events at blocks {}..={} (cycle N+1 exhaustion); saw {}",
+		WORST_CASE_WORKERS,
+		exhaustion_block,
+		exhaustion_block + 1,
+		total_failed
 	);
 	assert_eq!(
 		total_renewed_post_window,
 		0,
-		"expected 0 DataAutoRenewed post-exhaustion at blocks {}..={}; saw {} (every worker's \
+		"expected 0 DataRenewed post-exhaustion at blocks {}..={}; saw {} (every worker's \
 		 authorization should have been fully consumed by the observation window)",
 		exhaustion_block,
 		exhaustion_block + 1,
 		total_renewed_post_window
 	);
 	tracing::info!(
-		"✓ All {} workers hit AutoRenewalFailed at blocks {}..={}; AutoRenewals storage drained",
+		"✓ All {} workers hit RenewalFailed at blocks {}..={}; AutoRenewals storage drained",
 		WORST_CASE_WORKERS,
 		exhaustion_block,
 		exhaustion_block + 1,
@@ -2788,25 +2796,25 @@ async fn parachain_on_initialize_cleanup_test() -> Result<()> {
 	let auto_renewed = events
 		.iter()
 		.filter_map(|e| e.ok())
-		.filter(|e| e.pallet_name() == "DataRenewal" && e.variant_name() == "DataAutoRenewed")
+		.filter(|e| e.pallet_name() == "DataRenewal" && e.variant_name() == "DataRenewed")
 		.count() as u32;
 	let auto_renewal_failed = events
 		.iter()
 		.filter_map(|e| e.ok())
-		.filter(|e| e.pallet_name() == "DataRenewal" && e.variant_name() == "AutoRenewalFailed")
+		.filter(|e| e.pallet_name() == "DataRenewal" && e.variant_name() == "RenewalFailed")
 		.count() as u32;
 	assert_eq!(
 		auto_renewed, ON_INIT_CLEANUP_ITEMS_PER_SET,
-		"expected {} DataAutoRenewed events at expiry block {}, saw {}",
+		"expected {} DataRenewed events at expiry block {}, saw {}",
 		ON_INIT_CLEANUP_ITEMS_PER_SET, expiry_block, auto_renewed
 	);
 	assert_eq!(
 		auto_renewal_failed, 0,
-		"expected 0 AutoRenewalFailed events at expiry block {}, saw {}",
+		"expected 0 RenewalFailed events at expiry block {}, saw {}",
 		expiry_block, auto_renewal_failed
 	);
 	tracing::info!(
-		"✓ {} DataAutoRenewed events at expiry block {} (and zero AutoRenewalFailed)",
+		"✓ {} DataRenewed events at expiry block {} (and zero RenewalFailed)",
 		auto_renewed,
 		expiry_block
 	);
@@ -3581,7 +3589,7 @@ async fn parachain_restart_pruning_decrease_test() -> Result<()> {
 }
 
 /// Cycles 1 and 2 fit Alice's `bytes_allowance`; cycle 3 trips `PERMANENT_ALLOWANCE_EXCEEDED`
-/// and the pallet emits `AutoRenewalFailed`, removing the entry from `AutoRenewals`.
+/// and the pallet emits `RenewalFailed`, removing the entry from `AutoRenewals`.
 #[tokio::test(flavor = "multi_thread")]
 async fn parachain_auto_renew_quota_exhaustion_test() -> Result<()> {
 	const TEST: &str = "para_auto_renew_quota_exhaustion";
@@ -3669,16 +3677,16 @@ async fn parachain_auto_renew_quota_exhaustion_test() -> Result<()> {
 
 		let renewal_hash = finalized_block_hash_at(client, renewal_block).await?;
 		let events = client.blocks().at(renewal_hash).await?.events().await?;
-		let renewed = count_event(&events, "DataAutoRenewed");
-		let failed = count_event(&events, "AutoRenewalFailed");
+		let renewed = count_event(&events, "DataRenewed");
+		let failed = count_event(&events, "RenewalFailed");
 		assert_eq!(
 			renewed, 1,
-			"[cycle {}] expected exactly 1 DataAutoRenewed event at block {}, saw {}",
+			"[cycle {}] expected exactly 1 DataRenewed event at block {}, saw {}",
 			cycle, renewal_block, renewed
 		);
 		assert_eq!(
 			failed, 0,
-			"[cycle {}] expected 0 AutoRenewalFailed events at block {}, saw {}",
+			"[cycle {}] expected 0 RenewalFailed events at block {}, saw {}",
 			cycle, renewal_block, failed
 		);
 		verify_node_bitswap(
@@ -3689,7 +3697,7 @@ async fn parachain_auto_renew_quota_exhaustion_test() -> Result<()> {
 		)
 		.await
 		.with_context(|| format!("cycle {} did not preserve the data", cycle))?;
-		tracing::info!("[cycle {}] ✓ DataAutoRenewed at block {}", cycle, renewal_block);
+		tracing::info!("[cycle {}] ✓ DataRenewed at block {}", cycle, renewal_block);
 	}
 
 	// Cycle 3: bytes_permanent (= 2L) + L > bytes_allowance (= 2L).
@@ -3703,20 +3711,20 @@ async fn parachain_auto_renew_quota_exhaustion_test() -> Result<()> {
 
 	let r3_hash = finalized_block_hash_at(client, r3).await?;
 	let events = client.blocks().at(r3_hash).await?.events().await?;
-	let failed = count_event(&events, "AutoRenewalFailed");
-	let renewed = count_event(&events, "DataAutoRenewed");
+	let failed = count_event(&events, "RenewalFailed");
+	let renewed = count_event(&events, "DataRenewed");
 	tracing::info!("[cycle 3] block {}: renewed={}, failed={}", r3, renewed, failed);
 	assert_eq!(
 		failed, 1,
-		"[cycle 3] expected exactly 1 AutoRenewalFailed event at block {}, saw {} (renewed={})",
+		"[cycle 3] expected exactly 1 RenewalFailed event at block {}, saw {} (renewed={})",
 		r3, failed, renewed
 	);
 	assert_eq!(
 		renewed, 0,
-		"[cycle 3] expected 0 DataAutoRenewed events at block {}, saw {}",
+		"[cycle 3] expected 0 DataRenewed events at block {}, saw {}",
 		r3, renewed
 	);
-	tracing::info!("[cycle 3] ✓ AutoRenewalFailed at block {}", r3);
+	tracing::info!("[cycle 3] ✓ RenewalFailed at block {}", r3);
 
 	// Query at the renewal block's hash, not `at_latest` (which reads finalized state and
 	// lags ~10s behind best on cumulus).
@@ -3728,7 +3736,7 @@ async fn parachain_auto_renew_quota_exhaustion_test() -> Result<()> {
 	let auto_renewals_after = client.storage().at(r3_hash).fetch(&auto_renewals_addr).await?;
 	assert!(
 		auto_renewals_after.is_none(),
-		"AutoRenewals[{}] should be None at block {} after AutoRenewalFailed",
+		"AutoRenewals[{}] should be None at block {} after RenewalFailed",
 		hash_hex,
 		r3
 	);
@@ -3762,12 +3770,12 @@ async fn dump_renewal_window(
 			},
 		};
 		let events = client.blocks().at(hash).await?.events().await?;
-		let renewed = count_event(&events, "DataAutoRenewed");
-		let failed = count_event(&events, "AutoRenewalFailed");
+		let renewed = count_event(&events, "DataRenewed");
+		let failed = count_event(&events, "RenewalFailed");
 		let enabled = count_event(&events, "RenewalEnabled");
 		let stored = count_event(&events, "Stored");
 		tracing::info!(
-			"[{}]   block {} ({}): Stored={} RenewalEnabled={} DataAutoRenewed={} AutoRenewalFailed={}",
+			"[{}]   block {} ({}): Stored={} RenewalEnabled={} DataRenewed={} RenewalFailed={}",
 			label,
 			n,
 			hex::encode(&hash.0[..4]),
@@ -3781,7 +3789,7 @@ async fn dump_renewal_window(
 }
 
 /// Authorization expires between auto-renew cycles: cycle 1 succeeds, cycle 2 trips the
-/// expired branch and emits `AutoRenewalFailed`, then re-authorizing exercises the
+/// expired branch and emits `RenewalFailed`, then re-authorizing exercises the
 /// expired-but-present reset path (counters zeroed) for a fresh item.
 #[tokio::test(flavor = "multi_thread")]
 async fn parachain_auto_renew_authorization_expires_mid_cycle_test() -> Result<()> {
@@ -3871,18 +3879,18 @@ async fn parachain_auto_renew_authorization_expires_mid_cycle_test() -> Result<(
 	let r1_hash = finalized_block_hash_at(client, r1).await?;
 	let r1_events = client.blocks().at(r1_hash).await?.events().await?;
 	assert_eq!(
-		count_event(&r1_events, "DataAutoRenewed"),
+		count_event(&r1_events, "DataRenewed"),
 		1,
-		"[cycle 1] expected 1 DataAutoRenewed at block {}",
+		"[cycle 1] expected 1 DataRenewed at block {}",
 		r1
 	);
 	assert_eq!(
-		count_event(&r1_events, "AutoRenewalFailed"),
+		count_event(&r1_events, "RenewalFailed"),
 		0,
-		"[cycle 1] expected 0 AutoRenewalFailed at block {}",
+		"[cycle 1] expected 0 RenewalFailed at block {}",
 		r1
 	);
-	tracing::info!("[cycle 1] ✓ DataAutoRenewed at block {}", r1);
+	tracing::info!("[cycle 1] ✓ DataRenewed at block {}", r1);
 
 	wait_for_finalized_height(collator1, r2 + 1, BLOCK_PRODUCTION_TIMEOUT_SECS).await?;
 	// Proof for the cycle-1 renewal at r1 fires at `r2 - 1 = r1 + RP`.
@@ -3890,16 +3898,16 @@ async fn parachain_auto_renew_authorization_expires_mid_cycle_test() -> Result<(
 	let r2_hash = finalized_block_hash_at(client, r2).await?;
 	let r2_events = client.blocks().at(r2_hash).await?.events().await?;
 	assert_eq!(
-		count_event(&r2_events, "AutoRenewalFailed"),
+		count_event(&r2_events, "RenewalFailed"),
 		1,
-		"[cycle 2] expected 1 AutoRenewalFailed at block {} (auth expired at {})",
+		"[cycle 2] expected 1 RenewalFailed at block {} (auth expired at {})",
 		r2,
 		override_expiration
 	);
 	assert_eq!(
-		count_event(&r2_events, "DataAutoRenewed"),
+		count_event(&r2_events, "DataRenewed"),
 		0,
-		"[cycle 2] expected 0 DataAutoRenewed at block {}",
+		"[cycle 2] expected 0 DataRenewed at block {}",
 		r2
 	);
 
@@ -3911,11 +3919,11 @@ async fn parachain_auto_renew_authorization_expires_mid_cycle_test() -> Result<(
 	let auto_renewals_after = client.storage().at(r2_hash).fetch(&auto_renewals_addr).await?;
 	assert!(
 		auto_renewals_after.is_none(),
-		"AutoRenewals[{}] should be None at block {} after AutoRenewalFailed",
+		"AutoRenewals[{}] should be None at block {} after RenewalFailed",
 		hash_hex,
 		r2
 	);
-	tracing::info!("[cycle 2] ✓ AutoRenewalFailed at block {}; AutoRenewals[hash] removed", r2);
+	tracing::info!("[cycle 2] ✓ RenewalFailed at block {}; AutoRenewals[hash] removed", r2);
 
 	// Expired-but-present: the pallet zeroes counters and installs a fresh expiration.
 	let alice_pk = subxt_signer::sr25519::dev::alice().public_key().0;
@@ -3973,15 +3981,15 @@ async fn parachain_auto_renew_authorization_expires_mid_cycle_test() -> Result<(
 	let r1_after_hash = finalized_block_hash_at(client, r1_after).await?;
 	let r1_after_events = client.blocks().at(r1_after_hash).await?.events().await?;
 	assert_eq!(
-		count_event(&r1_after_events, "DataAutoRenewed"),
+		count_event(&r1_after_events, "DataRenewed"),
 		1,
-		"post-reauth cycle 1: expected 1 DataAutoRenewed at block {} (counters should be reset)",
+		"post-reauth cycle 1: expected 1 DataRenewed at block {} (counters should be reset)",
 		r1_after
 	);
 	assert_eq!(
-		count_event(&r1_after_events, "AutoRenewalFailed"),
+		count_event(&r1_after_events, "RenewalFailed"),
 		0,
-		"post-reauth cycle 1: expected 0 AutoRenewalFailed at block {}",
+		"post-reauth cycle 1: expected 0 RenewalFailed at block {}",
 		r1_after
 	);
 	verify_node_bitswap(collator1, &data2, BITSWAP_TIMEOUT_SECS, "post-reauth cycle 1").await?;


### PR DESCRIPTION
The renewal queue, drain and their events/errors serve both the one-shot `renew` and the recurring `enable_auto_renew`, so "auto" was misleading.

- `Event::DataAutoRenewed` → `Event::DataRenewed`
- `Event::AutoRenewalFailed` → `Event::RenewalFailed`
- `PendingAutoRenewals` → `PendingRenewals`
- `Error::AutoRenewalAlreadyEnabled` → `Error::RenewalAlreadyEnabled`
- `AUTO_RENEWAL_ALREADY_ENABLED` → `RENEWAL_ALREADY_ENABLED` (wire code `Custom(11)` unchanged)
- `do_process_auto_renewals` → `do_process_pending_renewals`

Names reached only from `enable_auto_renew` / `disable_auto_renew` keep `AUTO_RENEWAL`. The legacy `TransactionStorage::PendingAutoRenewals` key literals in the split migration are unchanged; `PendingRenewals` is per-block scratch that `on_finalize` asserts is drained, so its new key needs no migration.