### PR TITLE
ci: compare bench weights against base repo main, not fork main

### DIFF
--- a/.github/workflows/cmd-run.yml
+++ b/.github/workflows/cmd-run.yml
@@ -253,8 +253,12 @@ jobs:
         id: subweight
         if: startsWith(github.event.inputs.cmd, 'bench')
         shell: bash
+        env:
+          BASE_REPO: ${{ github.repository }}
         run: |
-          git fetch
+          git remote add upstream "https://github.com/${BASE_REPO}" 2>/dev/null || \
+            git remote set-url upstream "https://github.com/${BASE_REPO}"
+          git fetch --depth=1 upstream main
           git remote -v
           echo $(git log -n 2 --oneline)
 
@@ -265,7 +269,7 @@ jobs:
             --no-color \
             --change added changed \
             --ignore-errors \
-            refs/remotes/origin/main $PR_BRANCH)
+            refs/remotes/upstream/main $PR_BRANCH)
 
           echo $result
 


### PR DESCRIPTION
## Problem

`cmd bench` produced wrong or empty subweight reports on PRs from forks.

The `cmd` job checks out the PR's *head* repository (`pr.head.repo.full_name`), so `origin` inside the runner is the contributor's fork. The subweight step compared `refs/remotes/origin/main` against the PR branch — that is the *fork's* `main`, which is usually stale and, with checkout's shallow default refspec, frequently not fetched at all. The baseline was therefore either missing or outdated, so the weight comparison was meaningless.

## Fix

Add an explicit `upstream` remote pointing at the base repository (`github.repository`), shallow-fetch its `main`, and compare against `refs/remotes/upstream/main`:

- `git remote add upstream ... || git remote set-url upstream ...` — idempotent,
  so re-runs and reused self-hosted workspaces don't fail.
- `git fetch --depth=1 upstream main` — only the tip commit is needed for a
  file-content comparison, so this stays cheap.

`origin` is left untouched, so the checkout that gets built and benchmarked is unchanged. Same-repo PRs are unaffected (upstream and origin resolve to the same repo).