### PR TITLE
ci: keep external runtime checkouts out of target/

### DIFF
--- a/.github/actions/build-external-runtime/action.yml
+++ b/.github/actions/build-external-runtime/action.yml
@@ -1,19 +1,13 @@
 name: Build external runtime
 description: |
-  Resolve an external runtime ref to a commit sha, restore the per-sha WASM
-  build cache, and build the runtime via `just build-external-runtime`.
-  Outputs the resolved sha and the built WASM path. Callers only need to
-  checkout the repo first.
+  Restore the per-sha WASM cache and build the runtime via
+  `just build-external-runtime`. Repo, ref, and paths all come from
+  scripts/runtimes-matrix.json via `just external-runtime-paths`. Callers only
+  need to checkout the repo first.
 
 inputs:
   name:
     description: Runtime name in scripts/runtimes-matrix.json.
-    required: true
-  repo:
-    description: Git URL of the external runtime repo.
-    required: true
-  ref:
-    description: Branch, tag, or pinned commit sha.
     required: true
   features:
     description: Cargo features to build with. Each feature set uses its own checkout and cache.
@@ -36,41 +30,25 @@ runs:
 
     # Key the WASM cache on the commit sha so re-runs skip the multi-minute
     # out-of-tree build.
-    - name: Resolve external runtime ref
+    - name: Resolve external runtime paths
       id: resolve
       shell: bash
+      working-directory: examples
       env:
-        REPO: ${{ inputs.repo }}
-        REF: ${{ inputs.ref }}
+        NAME: ${{ inputs.name }}
         FEATURES: ${{ inputs.features }}
       run: |
         set -euo pipefail
-        # A pinned commit sha needs no resolution (ls-remote only sees refs).
-        # POSIX sh here, no [[ =~ ]].
-        if echo "$REF" | grep -qE '^[0-9a-f]{40}$'; then
-          SHA="$REF"
-        else
-          SHA=$(git ls-remote "$REPO" "$REF" | awk '{print $1}' | head -n1)
-        fi
-        if [ -z "$SHA" ]; then
-          echo "Failed to resolve $REF in $REPO"
-          exit 1
-        fi
+        read -r SHA WASM_DIR _ KEY < <(just external-runtime-paths "$NAME" "$FEATURES")
         echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-        # Mirror the variant-suffix logic of `build-external-runtime` in
-        # examples/justfile so the cache path matches the recipe's output dir.
-        if [ -n "$FEATURES" ]; then
-          SUFFIX="-$(echo "$FEATURES" | tr ',' '-' | tr -cd 'a-zA-Z0-9-')"
-        else
-          SUFFIX=""
-        fi
-        echo "variant-suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
+        echo "wasm-dir=$WASM_DIR" >> "$GITHUB_OUTPUT"
+        echo "cache-key=$KEY" >> "$GITHUB_OUTPUT"
 
     - name: Cache external runtime WASM
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
-        path: .external-runtimes/wasm/${{ inputs.name }}${{ steps.resolve.outputs.variant-suffix }}/${{ steps.resolve.outputs.sha }}
-        key: external-runtime-wasm-${{ inputs.name }}${{ steps.resolve.outputs.variant-suffix }}-${{ steps.resolve.outputs.sha }}
+        path: ${{ steps.resolve.outputs.wasm-dir }}
+        key: ${{ steps.resolve.outputs.cache-key }}
 
     - name: Build external runtime
       id: build

--- a/.github/actions/build-external-runtime/action.yml
+++ b/.github/actions/build-external-runtime/action.yml
@@ -57,7 +57,7 @@ runs:
           exit 1
         fi
         echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-        # Mirror the checkout-dir suffix logic of `build-external-runtime` in
+        # Mirror the variant-suffix logic of `build-external-runtime` in
         # examples/justfile so the cache path matches the recipe's output dir.
         if [ -n "$FEATURES" ]; then
           SUFFIX="-$(echo "$FEATURES" | tr ',' '-' | tr -cd 'a-zA-Z0-9-')"
@@ -66,13 +66,11 @@ runs:
         fi
         echo "variant-suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
 
-    - name: Cache external runtime build
+    - name: Cache external runtime WASM
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
-        path: .external-runtimes/${{ inputs.name }}${{ steps.resolve.outputs.variant-suffix }}
-        # `-v2`: an archive from the old `target/external-runtimes` layout restores to
-        # that path and still counts as a hit, leaving this path empty and unsaved.
-        key: external-runtime-v2-${{ inputs.name }}${{ steps.resolve.outputs.variant-suffix }}-${{ steps.resolve.outputs.sha }}
+        path: .external-runtimes/wasm/${{ inputs.name }}${{ steps.resolve.outputs.variant-suffix }}/${{ steps.resolve.outputs.sha }}
+        key: external-runtime-wasm-${{ inputs.name }}${{ steps.resolve.outputs.variant-suffix }}-${{ steps.resolve.outputs.sha }}
 
     - name: Build external runtime
       id: build

--- a/.github/actions/build-external-runtime/action.yml
+++ b/.github/actions/build-external-runtime/action.yml
@@ -69,8 +69,10 @@ runs:
     - name: Cache external runtime build
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
-        path: target/external-runtimes/${{ inputs.name }}${{ steps.resolve.outputs.variant-suffix }}
-        key: external-runtime-${{ inputs.name }}${{ steps.resolve.outputs.variant-suffix }}-${{ steps.resolve.outputs.sha }}
+        path: .external-runtimes/${{ inputs.name }}${{ steps.resolve.outputs.variant-suffix }}
+        # `-v2`: an archive from the old `target/external-runtimes` layout restores to
+        # that path and still counts as a hit, leaving this path empty and unsaved.
+        key: external-runtime-v2-${{ inputs.name }}${{ steps.resolve.outputs.variant-suffix }}-${{ steps.resolve.outputs.sha }}
 
     - name: Build external runtime
       id: build

--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -204,8 +204,6 @@ jobs:
         uses: ./.github/actions/build-external-runtime
         with:
           name: ${{ matrix.runtime.name }}
-          repo: ${{ matrix.runtime.external_runtime.repo }}
-          ref: ${{ matrix.runtime.external_runtime.ref }}
           features: try-runtime
 
       - name: Run ${{ matrix.runtime.name }} (${{ matrix.runtime.instance }}) Runtime Checks

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -116,8 +116,6 @@ jobs:
         uses: ./.github/actions/build-external-runtime
         with:
           name: ${{ matrix.runtime.name }}
-          repo: ${{ matrix.runtime.external_runtime.repo }}
-          ref: ${{ matrix.runtime.external_runtime.ref }}
 
       - name: Start services
         working-directory: examples

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # scripts/get_polkadot_binaries.sh
 /.polkadot-binaries/
 
+# Out-of-tree runtime checkouts built by `just build-external-runtime`
+/.external-runtimes/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 # scripts/get_polkadot_binaries.sh
 /.polkadot-binaries/
 
-# Out-of-tree runtime checkouts built by `just build-external-runtime`
+# External runtime checkouts and their WASM, from `just build-external-runtime`
 /.external-runtimes/
 
 # OS

--- a/examples/justfile
+++ b/examples/justfile
@@ -134,7 +134,7 @@ bulletin-parachain-zombienet-start test_dir runtime="bulletin-westend-runtime":
     just _wait-for-rpc $ZOMBIENET_PID "{{ test_dir }}/zombienet.log"
 
 # Build a runtime that lives in an external (Fellows) repo and print the WASM path.
-# Different feature sets use separate checkouts so their build caches don't collide.
+# Different feature sets get separate checkouts and cached blobs.
 build-external-runtime name features="":
     #!/usr/bin/env bash
     set -e
@@ -152,30 +152,60 @@ build-external-runtime name features="":
     else
         VARIANT_SUFFIX=""
     fi
-    # Outside `target/`, which the CI Rust cache owns: its restores can leave a
-    # broken checkout behind.
-    CHECKOUT_DIR="$ROOT_DIR/.external-runtimes/{{ name }}${VARIANT_SUFFIX}"
-    WASM_PATH="$CHECKOUT_DIR/target/release/wbuild/$PACKAGE/${PACKAGE//-/_}.compact.compressed.wasm"
+    # A ref that is already a sha needs no resolution (ls-remote only sees refs).
+    if echo "$REF" | grep -qE '^[0-9a-f]{40}$'; then
+        SHA="$REF"
+    else
+        SHA=$(git ls-remote "$REPO" "$REF" | awk '{print $1}' | head -n1)
+        if [ -z "$SHA" ]; then
+            >&2 echo "❌ Cannot resolve $REF in $REPO"
+            exit 1
+        fi
+    fi
+
+    # Only the blob is worth keeping between runs: the checkout and its `target/` run to
+    # several GB, enough to evict every other cache in the repo. Keyed by sha so a pin
+    # bump cannot serve a stale blob.
+    WASM_DIR="$ROOT_DIR/.external-runtimes/wasm/{{ name }}${VARIANT_SUFFIX}/$SHA"
+    WASM_PATH="$WASM_DIR/${PACKAGE//-/_}.compact.compressed.wasm"
+    SRC_DIR="$ROOT_DIR/.external-runtimes/src/{{ name }}${VARIANT_SUFFIX}"
 
     >&2 echo "🔧 build-external-runtime: {{ name }} from $REPO @ $REF ($SUBPATH) [features=${FEATURES:-default}]"
 
+    if [ -f "$WASM_PATH" ]; then
+        >&2 echo "♻️  Reusing cached WASM at $WASM_PATH"
+        echo "$WASM_PATH"
+        exit 0
+    fi
+
     sync_checkout() {
-        if [ ! -d "$CHECKOUT_DIR/.git" ]; then
-            >&2 echo "📥 Cloning $REPO into $CHECKOUT_DIR..."
-            git clone --filter=blob:none "$REPO" "$CHECKOUT_DIR" >&2
+        if [ ! -d "$SRC_DIR/.git" ]; then
+            >&2 echo "📥 Cloning $REPO into $SRC_DIR..."
+            git clone --filter=blob:none "$REPO" "$SRC_DIR" >&2
         else
-            git -C "$CHECKOUT_DIR" remote set-url origin "$REPO"
+            git -C "$SRC_DIR" remote set-url origin "$REPO"
         fi
 
-        >&2 echo "🔀 Fetching ref: $REF..."
-        git -C "$CHECKOUT_DIR" fetch --depth 1 origin "$REF" >&2
-        # --force: HEAD can already be at $REF with worktree files missing, where a
+        >&2 echo "🔀 Fetching ref: $SHA..."
+        git -C "$SRC_DIR" fetch --depth 1 origin "$SHA" >&2
+        # --force: HEAD can already be at $SHA with worktree files missing, where a
         # plain checkout is a no-op.
-        git -C "$CHECKOUT_DIR" checkout -q --force FETCH_HEAD
+        git -C "$SRC_DIR" checkout -q --force FETCH_HEAD
     }
 
-    mkdir -p "$(dirname "$CHECKOUT_DIR")"
+    mkdir -p "$(dirname "$SRC_DIR")"
     sync_checkout
+
+    # For a checkout `--force` cannot repair.
+    if [ ! -d "$SRC_DIR/$SUBPATH" ]; then
+        >&2 echo "🧹 $SUBPATH missing after checkout, re-cloning $SRC_DIR..."
+        rm -rf "$SRC_DIR"
+        sync_checkout
+    fi
+    if [ ! -d "$SRC_DIR/$SUBPATH" ]; then
+        >&2 echo "❌ $SUBPATH not found in $REPO @ $SHA"
+        exit 1
+    fi
 
     # --locked: honor the external repo's Cargo.lock; fresh resolution can
     # drift to dep versions the pinned rev never built against.
@@ -184,29 +214,16 @@ build-external-runtime name features="":
         BUILD_ARGS+=(--features "$FEATURES")
     fi
 
-    if [ ! -f "$WASM_PATH" ]; then
-        # For a checkout `--force` cannot repair. Inside the rebuild branch so the
-        # `rm -rf` can never discard a cached WASM.
-        if [ ! -d "$CHECKOUT_DIR/$SUBPATH" ]; then
-            >&2 echo "🧹 $SUBPATH missing after checkout, re-cloning $CHECKOUT_DIR..."
-            rm -rf "$CHECKOUT_DIR"
-            sync_checkout
-        fi
-        if [ ! -d "$CHECKOUT_DIR/$SUBPATH" ]; then
-            >&2 echo "❌ $SUBPATH not found in $REPO @ $REF"
-            exit 1
-        fi
+    >&2 echo "🔨 Building $PACKAGE [features=${FEATURES:-default}]..."
+    (cd "$SRC_DIR/$SUBPATH" && cargo build "${BUILD_ARGS[@]}" >&2)
 
-        >&2 echo "🔨 Building $PACKAGE [features=${FEATURES:-default}]..."
-        (cd "$CHECKOUT_DIR/$SUBPATH" && cargo build "${BUILD_ARGS[@]}" >&2)
-    else
-        >&2 echo "♻️  Reusing cached WASM at $WASM_PATH"
-    fi
-
-    if [ ! -f "$WASM_PATH" ]; then
-        >&2 echo "❌ WASM not produced at: $WASM_PATH"
+    BUILT="$SRC_DIR/target/release/wbuild/$PACKAGE/${PACKAGE//-/_}.compact.compressed.wasm"
+    if [ ! -f "$BUILT" ]; then
+        >&2 echo "❌ WASM not produced at: $BUILT"
         exit 1
     fi
+    mkdir -p "$WASM_DIR"
+    cp "$BUILT" "$WASM_PATH"
 
     echo "$WASM_PATH"
 

--- a/examples/justfile
+++ b/examples/justfile
@@ -133,25 +133,15 @@ bulletin-parachain-zombienet-start test_dir runtime="bulletin-westend-runtime":
     echo "   Log: {{ test_dir }}/zombienet.log"
     just _wait-for-rpc $ZOMBIENET_PID "{{ test_dir }}/zombienet.log"
 
-# Build a runtime that lives in an external (Fellows) repo and print the WASM path.
-# Different feature sets get separate checkouts and cached blobs.
-build-external-runtime name features="":
+# Print `<sha> <wasm-dir> <src-dir> <cache-key>`, dirs repo-relative.
+# The CI cache action reads this so its key and path cannot drift from the recipe below.
+external-runtime-paths name features="":
     #!/usr/bin/env bash
     set -e
-    ROOT_DIR="{{ justfile_directory() }}/.."
-    MATRIX="$ROOT_DIR/scripts/runtimes-matrix.json"
-
+    MATRIX="{{ justfile_directory() }}/../scripts/runtimes-matrix.json"
     REPO=$(jq -er --arg n "{{ name }}" '.[] | select(.name == $n) | .external_runtime.repo' "$MATRIX")
     REF=$(jq -er --arg n "{{ name }}" '.[] | select(.name == $n) | .external_runtime.ref' "$MATRIX")
-    SUBPATH=$(jq -er --arg n "{{ name }}" '.[] | select(.name == $n) | .external_runtime.path' "$MATRIX")
-    PACKAGE=$(jq -er --arg n "{{ name }}" '.[] | select(.name == $n) | .package' "$MATRIX")
 
-    FEATURES="{{ features }}"
-    if [ -n "$FEATURES" ]; then
-        VARIANT_SUFFIX="-$(echo "$FEATURES" | tr ',' '-' | tr -cd 'a-zA-Z0-9-')"
-    else
-        VARIANT_SUFFIX=""
-    fi
     # A ref that is already a sha needs no resolution (ls-remote only sees refs).
     if echo "$REF" | grep -qE '^[0-9a-f]{40}$'; then
         SHA="$REF"
@@ -163,14 +153,39 @@ build-external-runtime name features="":
         fi
     fi
 
-    # Only the blob is worth keeping between runs: the checkout and its `target/` run to
-    # several GB, enough to evict every other cache in the repo. Keyed by sha so a pin
-    # bump cannot serve a stale blob.
-    WASM_DIR="$ROOT_DIR/.external-runtimes/wasm/{{ name }}${VARIANT_SUFFIX}/$SHA"
-    WASM_PATH="$WASM_DIR/${PACKAGE//-/_}.compact.compressed.wasm"
-    SRC_DIR="$ROOT_DIR/.external-runtimes/src/{{ name }}${VARIANT_SUFFIX}"
+    FEATURES="{{ features }}"
+    if [ -n "$FEATURES" ]; then
+        VARIANT_SUFFIX="-$(echo "$FEATURES" | tr ',' '-' | tr -cd 'a-zA-Z0-9-')"
+    else
+        VARIANT_SUFFIX=""
+    fi
 
-    >&2 echo "🔧 build-external-runtime: {{ name }} from $REPO @ $REF ($SUBPATH) [features=${FEATURES:-default}]"
+    echo "$SHA" \
+        ".external-runtimes/wasm/{{ name }}${VARIANT_SUFFIX}/$SHA" \
+        ".external-runtimes/src/{{ name }}${VARIANT_SUFFIX}" \
+        "external-runtime-wasm-{{ name }}${VARIANT_SUFFIX}-$SHA"
+
+# Build a runtime that lives in an external (Fellows) repo and print the WASM path.
+# Different feature sets get separate checkouts and cached blobs.
+build-external-runtime name features="":
+    #!/usr/bin/env bash
+    set -e
+    ROOT_DIR="{{ justfile_directory() }}/.."
+    MATRIX="$ROOT_DIR/scripts/runtimes-matrix.json"
+
+    REPO=$(jq -er --arg n "{{ name }}" '.[] | select(.name == $n) | .external_runtime.repo' "$MATRIX")
+    SUBPATH=$(jq -er --arg n "{{ name }}" '.[] | select(.name == $n) | .external_runtime.path' "$MATRIX")
+    PACKAGE=$(jq -er --arg n "{{ name }}" '.[] | select(.name == $n) | .package' "$MATRIX")
+    FEATURES="{{ features }}"
+
+    # Only the blob is kept between runs: the checkout and its `target/` run to several
+    # GB, enough to evict every other cache in the repo.
+    read -r SHA WASM_REL SRC_REL _ < <(just external-runtime-paths "{{ name }}" "$FEATURES")
+    WASM_DIR="$ROOT_DIR/$WASM_REL"
+    WASM_PATH="$WASM_DIR/${PACKAGE//-/_}.compact.compressed.wasm"
+    SRC_DIR="$ROOT_DIR/$SRC_REL"
+
+    >&2 echo "🔧 build-external-runtime: {{ name }} from $REPO @ $SHA ($SUBPATH) [features=${FEATURES:-default}]"
 
     if [ -f "$WASM_PATH" ]; then
         >&2 echo "♻️  Reusing cached WASM at $WASM_PATH"

--- a/examples/justfile
+++ b/examples/justfile
@@ -152,22 +152,30 @@ build-external-runtime name features="":
     else
         VARIANT_SUFFIX=""
     fi
-    CHECKOUT_DIR="$ROOT_DIR/target/external-runtimes/{{ name }}${VARIANT_SUFFIX}"
+    # Outside `target/`, which the CI Rust cache owns: its restores can leave a
+    # broken checkout behind.
+    CHECKOUT_DIR="$ROOT_DIR/.external-runtimes/{{ name }}${VARIANT_SUFFIX}"
     WASM_PATH="$CHECKOUT_DIR/target/release/wbuild/$PACKAGE/${PACKAGE//-/_}.compact.compressed.wasm"
 
     >&2 echo "🔧 build-external-runtime: {{ name }} from $REPO @ $REF ($SUBPATH) [features=${FEATURES:-default}]"
 
-    mkdir -p "$(dirname "$CHECKOUT_DIR")"
-    if [ ! -d "$CHECKOUT_DIR/.git" ]; then
-        >&2 echo "📥 Cloning $REPO into $CHECKOUT_DIR..."
-        git clone --filter=blob:none "$REPO" "$CHECKOUT_DIR" >&2
-    else
-        git -C "$CHECKOUT_DIR" remote set-url origin "$REPO"
-    fi
+    sync_checkout() {
+        if [ ! -d "$CHECKOUT_DIR/.git" ]; then
+            >&2 echo "📥 Cloning $REPO into $CHECKOUT_DIR..."
+            git clone --filter=blob:none "$REPO" "$CHECKOUT_DIR" >&2
+        else
+            git -C "$CHECKOUT_DIR" remote set-url origin "$REPO"
+        fi
 
-    >&2 echo "🔀 Fetching ref: $REF..."
-    git -C "$CHECKOUT_DIR" fetch --depth 1 origin "$REF" >&2
-    git -C "$CHECKOUT_DIR" checkout -q FETCH_HEAD
+        >&2 echo "🔀 Fetching ref: $REF..."
+        git -C "$CHECKOUT_DIR" fetch --depth 1 origin "$REF" >&2
+        # --force: HEAD can already be at $REF with worktree files missing, where a
+        # plain checkout is a no-op.
+        git -C "$CHECKOUT_DIR" checkout -q --force FETCH_HEAD
+    }
+
+    mkdir -p "$(dirname "$CHECKOUT_DIR")"
+    sync_checkout
 
     # --locked: honor the external repo's Cargo.lock; fresh resolution can
     # drift to dep versions the pinned rev never built against.
@@ -177,6 +185,18 @@ build-external-runtime name features="":
     fi
 
     if [ ! -f "$WASM_PATH" ]; then
+        # For a checkout `--force` cannot repair. Inside the rebuild branch so the
+        # `rm -rf` can never discard a cached WASM.
+        if [ ! -d "$CHECKOUT_DIR/$SUBPATH" ]; then
+            >&2 echo "🧹 $SUBPATH missing after checkout, re-cloning $CHECKOUT_DIR..."
+            rm -rf "$CHECKOUT_DIR"
+            sync_checkout
+        fi
+        if [ ! -d "$CHECKOUT_DIR/$SUBPATH" ]; then
+            >&2 echo "❌ $SUBPATH not found in $REPO @ $REF"
+            exit 1
+        fi
+
         >&2 echo "🔨 Building $PACKAGE [features=${FEATURES:-default}]..."
         (cd "$CHECKOUT_DIR/$SUBPATH" && cargo build "${BUILD_ARGS[@]}" >&2)
     else


### PR DESCRIPTION
Causing CI to fail due to cache miss
|Issue | CI Build failure|
| --- | --- |
| https://github.com/paritytech/polkadot-bulletin-chain/pull/738 | / https://github.com/paritytech/polkadot-bulletin-chain/actions/runs/32051138348/job/95451163257?pr=738 |
| https://github.com/paritytech/polkadot-bulletin-chain/pull/753 | / https://github.com/paritytech/polkadot-bulletin-chain/actions/runs/32251895470/job/96064992991?pr=753 }

## What is broken

The `bulletin-polkadot` integration job fails in its first step, "Build external runtime", after about a minute. It never gets to compiling our code or running tests:

🔨 Building bulletin-polkadot-runtime [features=default]...
cd: .../target/external-runtimes/bulletin-polkadot/./system-parachains/bulletin/bulletin-polkadot: No such file or directory

This is not specific to a branch, `main` fails the same way. The pattern is the cache:

| run | branch | cache | result |
|---|---|---|---|
| 32246772062 | main, 11:16Z | restored | pass |
| 32251079129 | main, 12:08Z | `Cache not found` | fail |
| 32251895470 | rs-batch-perm-storage-used-event | `Cache not found` | fail |
| 32261255386 | rs-rename-pendingAutoRenewals | `Cache not found` | fail |

## Why it happens

The checkout was placed under `target/`, and `Swatinem/rust-cache` also owns that directory. When it restores `target/`, we can end up with a `.git` but no files next to it. Our recipe then skips cloning, because it clones only when `.git` is missing, and `git checkout FETCH_HEAD` does nothing, because HEAD already points at the pinned commit. So no file is restored, no command fails, and only the `cd` at the end complains. I reproduced this locally by deleting the files while keeping HEAD at the pinned commit: a normal checkout leaves the directory missing, a forced checkout brings it back.

There is a second problem behind the first one. We cached the whole checkout together with its `target/`, which is a few GB per entry. The repo has 10 GB for all caches, so these entries push each other out. That is most likely why the cache was missing in the first place.

## What this PR changes

**Cache only the WASM, around 2 MB, and nothing else.** The checkout and its `target/` are not worth keeping between runs, and once we stop caching them, the broken checkout above cannot happen anymore. A cache hit is now also cheaper, because we do not touch git at all. There is no downside for build time: the key is the commit sha, so a miss always meant a full build.

| path | cached | what it is |
|---|---|---|
| `.external-runtimes/src/<name><variant>` | no | checkout we build in |
| `.external-runtimes/wasm/<name><variant>/<sha>/<pkg>.compact.compressed.wasm` | yes | the blob |

**Keep both outside `target/`,** so that no other cache action can touch them.

**Use `git checkout --force`.** CI cannot produce a half restored checkout anymore, but a local one can still be in a strange state, and a forced checkout brings it back to the pinned commit.

**Check that the runtime directory is really there before building.** If it is missing we clone once more, and if it is still missing we stop with a clear message instead of a confusing `cd` error. This is also the message you would get if the external repo moves the runtime to another directory, and it points to the matrix entry that needs an update.

**Compute the sha, the paths and the cache key in one place.** `just external-runtime-paths <name> [features]` prints them and the action reads it, so the cache path and the recipe can no longer disagree. Until now the action and the justfile both resolved the ref to a sha, both built the variant suffix, both spelled out the cache path, and the workflows passed `repo` and `ref` that the recipe read from the matrix anyway. The key includes the variant, so the normal and the `try-runtime` build of the same runtime do not share one entry:

external-runtime-wasm-bulletin-polkadot-e93abddf…
external-runtime-wasm-bulletin-polkadot-try-runtime-e93abddf…

## Notes

- The blob path now contains the sha. Before, a new pin was checked out but the old blob was reused, which was wrong.
- Local reruns work offline now, and the checkout keeps its `target/`, so dependencies are still reused after a pin bump.
- If you edit the checkout under `.external-runtimes/src/` by hand, the forced checkout will throw those edits away. For testing a modified external runtime, point `external_runtime.repo`/`ref` in `scripts/runtimes-matrix.json` to your own commit.
- The first run after merge builds the external runtime once per runtime and feature variant, as with any change of a cache key.
