### PR TITLE
storage-bench: serve-load duty cycle and window-sliced metrics

### DIFF
--- a/docs/storage-benchmark.md
+++ b/docs/storage-benchmark.md
@@ -26,10 +26,36 @@ Pre-grow the DB so proof reads hit a cold random location in the full set, not a
 
 Block import p99 + authoring p99 well inside the block time; no growing import lag; proof-read p99
 low-ms; Bitswap >= 95% within 2 s. Metrics: `substrate_block_verification_and_import_time`,
-`substrate_proposer_block_constructed`, `substrate_block_height{status="best"}`,
+`substrate_proposer_block_constructed`, `substrate_dev_seal_block_import_time` and
+`substrate_dev_seal_inherent_data_time` (polkadot-sdk#12984 / #12985: the author's own import
+and the proof read never reach the two stock histograms), `substrate_block_height{status="best"}`,
 `kubelet_volume_stats_*`, Bitswap p95.
+
+The Bitswap serve histogram (`substrate_sub_libp2p_bitswap_inbound_request_duration_seconds`)
+exists only on the litep2p backend; the libp2p backend registers no bitswap metrics at all. The
+dev node hardcodes litep2p, but no peer may be started with `--network-backend libp2p` or its
+serve rows read NA.
+
+## Serve-load duty cycle
+
+The full-sync peers are the main serve load and a one-shot cohort: start every peer before the
+author seals its first block on top of the snapshot. From that block on the author prunes bodies
+from the front of the chain (`--blocks-pruning` == snapshot height), so a full sync from genesis
+started any later can never complete. One cohort per snapshot restore; a crashed peer cannot
+rejoin the run.
+
+Peers are expected to finish inside the run, so the serve load is not constant and a single 24 h
+aggregate dilutes the loaded hours. Record when each peer catches up
+(`scripts/storage-bench/wait-peers.sh`, one CSV row per poll) and report two windows via
+`collect-metrics.sh` `AT`/`WINDOW`:
+
+1. loaded: run start until the last peer catches up (sync serve + paced bitswap reads)
+2. quiet: from there to run end; switch the bitswap driver to the saturation step
+   (`bulletin-stress-test bitswap bulk-read --rate 0`) so read pressure does not disappear
+   with the peers.
 
 ## Scripts
 
 `scripts/storage-bench/`: `fio-block-critical.fio` (pre-screen), `throttle.sh` (emulate a tier
-via cgroup v2 io.max), `collect-metrics.sh` (Prometheus snapshot).
+via cgroup v2 io.max), `collect-metrics.sh` (Prometheus snapshot, window-sliceable via
+`AT`/`WINDOW`), `wait-peers.sh` (peer catch-up watcher, emits the window boundaries).

--- a/scripts/storage-bench/collect-metrics.sh
+++ b/scripts/storage-bench/collect-metrics.sh
@@ -6,24 +6,38 @@
 #   PROM=http://prometheus:9090 CHAIN=<chain> NS=<namespace> WINDOW=10m \
 #     scripts/storage-bench/collect-metrics.sh <arm-label>
 # Writes <arm-label>.metrics.txt. Run once per arm (nvme / gp3 / sata) x block-time.
+#
+# The serve load is not constant (sync peers finish mid-run), so slice each run
+# into windows instead of one aggregate: set AT to the evaluation instant
+# (epoch seconds or RFC3339) and WINDOW to the slice length. Timestamps come
+# from wait-peers.sh:
+#   loaded (peers syncing):  AT=<last-peer-caught-up> WINDOW=<sync duration>  <arm>-loaded
+#   quiet (after catch-up):  AT=<run end>             WINDOW=<remaining time> <arm>-quiet
 set -euo pipefail
 
 PROM="${PROM:?set PROM to the Prometheus base URL}"
-ARM="${1:?arm label, e.g. gp3-6s}"
+ARM="${1:?arm label, e.g. gp3-6s or gp3-6s-loaded}"
 CHAIN="${CHAIN:-bulletin}"
 NS="${NS:-bulletin}"
 WINDOW="${WINDOW:-10m}"
+AT="${AT:-}"
 OUT="${ARM}.metrics.txt"
 
 q() { curl -sG "$PROM/api/v1/query" --data-urlencode "query=$1" \
+        ${AT:+--data-urlencode "time=$AT"} \
         | python3 -c 'import sys,json;d=json.load(sys.stdin)["data"]["result"];print(d[0]["value"][1] if d else "NA")'; }
 
 SEL="chain=~\"$CHAIN\""
 
 {
-  echo "arm: $ARM   window: $WINDOW   $(date -u +%FT%TZ)"
+  echo "arm: $ARM   window: $WINDOW   at: ${AT:-now}   $(date -u +%FT%TZ)"
   echo "block import p99 (s):    $(q "histogram_quantile(0.99, sum(rate(substrate_block_verification_and_import_time_bucket{$SEL}[$WINDOW])) by (le))")"
   echo "authoring p99 (s):       $(q "histogram_quantile(0.99, sum(rate(substrate_proposer_block_constructed_bucket{$SEL}[$WINDOW])) by (le))")"
+  # Dev-seal metrics from polkadot-sdk#12984 / #12985: the author's own import
+  # and the inherent build (the transaction-storage proof read) do not show up
+  # in the two stock histograms above.
+  echo "own import p99 (s):      $(q "histogram_quantile(0.99, sum(rate(substrate_dev_seal_block_import_time_bucket{$SEL}[$WINDOW])) by (le))")"
+  echo "inherent build p99 (s):  $(q "histogram_quantile(0.99, sum(rate(substrate_dev_seal_inherent_data_time_bucket{$SEL}[$WINDOW])) by (le))")"
   echo "best-block rate (1/s):   $(q "sum(rate(substrate_block_height{status=\"best\",$SEL}[$WINDOW]))")"
   echo "disk free ratio:         $(q "min(kubelet_volume_stats_available_bytes{namespace=\"$NS\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$NS\"})")"
   echo "permanent storage ratio: $(q "max(bulletin_permanent_storage_used_ratio{$SEL})")"

--- a/scripts/storage-bench/wait-peers.sh
+++ b/scripts/storage-bench/wait-peers.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Watch the sync peers catch up to the author and record when each one finishes.
+#
+# The full-sync peers are a one-shot cohort: every peer must be running before
+# the author seals its first block on top of the snapshot. From that block on,
+# the author prunes bodies from the front of the chain (blocks-pruning ==
+# snapshot height), so a full sync from genesis started later can never
+# complete. One cohort per snapshot restore; a crashed peer cannot rejoin.
+#
+# Emits one CSV row per peer per poll and exits once every peer is caught up.
+# The caught_up timestamps are the window boundaries for collect-metrics.sh
+# (loaded vs quiet), and the moment to switch the bitswap driver to the
+# saturation step so read pressure does not disappear with the peers.
+#
+# Usage:
+#   AUTHOR_RPC=http://127.0.0.1:9944 \
+#   PEER_RPCS=http://127.0.0.1:9945,http://127.0.0.1:9946,http://127.0.0.1:9947 \
+#     scripts/storage-bench/wait-peers.sh
+set -euo pipefail
+
+AUTHOR_RPC="${AUTHOR_RPC:?author RPC URL}"
+PEER_RPCS="${PEER_RPCS:?comma-separated peer RPC URLs}"
+OUT="${OUT:-peers.csv}"
+# Blocks behind the author that still count as caught up (tip chatter).
+LAG="${LAG:-5}"
+POLL="${POLL:-30}"
+
+height() {
+  curl -s -m 5 -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"chain_getHeader","params":[]}' "$1" \
+    | python3 -c 'import sys,json; print(int(json.load(sys.stdin)["result"]["number"],16))' \
+    2>/dev/null || echo -1
+}
+
+IFS=',' read -ra PEERS <<< "$PEER_RPCS"
+declare -A done_at
+echo "ts,peer,height,author_height,event" > "$OUT"
+
+while :; do
+  author=$(height "$AUTHOR_RPC")
+  all_done=1
+  for peer in "${PEERS[@]}"; do
+    [ -n "${done_at[$peer]:-}" ] && continue
+    h=$(height "$peer")
+    ts=$(date -u +%s)
+    if [ "$h" -ge 0 ] && [ "$author" -ge 0 ] && [ $((author - h)) -le "$LAG" ]; then
+      done_at[$peer]=$ts
+      echo "$ts,$peer,$h,$author,caught_up" >> "$OUT"
+      echo "peer $peer caught up at epoch $ts (height $h, author $author)" >&2
+    else
+      echo "$ts,$peer,$h,$author,syncing" >> "$OUT"
+      all_done=0
+    fi
+  done
+  [ "$all_done" -eq 1 ] && { echo "all peers caught up" >&2; exit 0; }
+  sleep "$POLL"
+done


### PR DESCRIPTION
Stacked on #647, for #749. Sync peers are a one-shot cohort (bodies prune from the front once the run starts) and finish mid-run: `wait-peers.sh` records catch-up timestamps, `collect-metrics.sh` gets `AT`/`WINDOW` to slice loaded vs quiet windows plus the dev-seal histograms from polkadot-sdk#12984/#12985. Depends on #763 for the post-sync saturation step.