### PR TITLE
stress-test: fill payload mix and height stop

### DIFF
--- a/stress-test/src/main.rs
+++ b/stress-test/src/main.rs
@@ -17,7 +17,7 @@ use bulletin_stress_test::{
 	chain_info::{ChainLimits, EnvironmentInfo},
 	client,
 	metrics::{self, metrics, RunOutcome},
-	report, scenarios,
+	pipeline, report, scenarios,
 };
 
 #[derive(Parser)]
@@ -117,11 +117,22 @@ enum Commands {
 		instances: usize,
 	},
 	/// Continuous saturating feeder for dataset builds: reuse accounts with
-	/// sequential nonces and keep the tx pool full. Runs until killed.
+	/// sequential nonces and keep the tx pool full. Runs until killed, or
+	/// until the chain reaches --until-height.
 	Fill {
 		/// Payload size per store, bytes
 		#[arg(long, default_value = "524288")]
 		payload_bytes: usize,
+
+		/// Weighted payload mix "bytes:weight,..." (e.g.
+		/// "8192:60,524288:35,1900000:5"); overrides --payload-bytes
+		#[arg(long)]
+		payload_mix: Option<String>,
+
+		/// Stop once the chain reaches this height (0 = run until killed).
+		/// Lets a build script lay down height-keyed profile bands.
+		#[arg(long, default_value = "0")]
+		until_height: u64,
 
 		/// Reusable accounts in the pool
 		#[arg(long, default_value = "64")]
@@ -384,13 +395,19 @@ async fn run_once(cli: &Cli, ws_urls: &[String], cancel: &Arc<AtomicBool>) -> Re
 				tracing::error!("Throughput command failed: {e}");
 				command_error = Some(e);
 			},
-		Commands::Fill { payload_bytes, accounts, workers } =>
+		Commands::Fill { payload_bytes, ref payload_mix, until_height, accounts, workers } => {
+			let payload_mode = match payload_mix {
+				Some(spec) =>
+					pipeline::StorePayloadMode::Mixed(pipeline::PayloadSizeMix::from_spec(spec)?),
+				None => pipeline::StorePayloadMode::Fixed(payload_bytes),
+			};
 			if let Err(e) = bulletin_stress_test::scenarios::fill::run_fill(
 				&client,
 				&authorizer_signer,
 				&nonce_tracker,
 				ws_url_refs[0],
-				payload_bytes,
+				payload_mode,
+				until_height,
 				accounts,
 				workers,
 			)
@@ -398,7 +415,8 @@ async fn run_once(cli: &Cli, ws_urls: &[String], cancel: &Arc<AtomicBool>) -> Re
 			{
 				tracing::error!("Fill command failed: {e}");
 				command_error = Some(e);
-			},
+			}
+		},
 		Commands::Bitswap {
 			ref test,
 			payload_size,

--- a/stress-test/src/pipeline.rs
+++ b/stress-test/src/pipeline.rs
@@ -95,6 +95,28 @@ impl PayloadSizeMix {
 		Ok(Self { sizes, weights, total })
 	}
 
+	/// Parse a `"bytes:weight,bytes:weight"` spec, e.g. `"8192:60,524288:35"`.
+	pub fn from_spec(spec: &str) -> anyhow::Result<Self> {
+		let pairs = spec
+			.split(',')
+			.map(|entry| {
+				let (size, weight) = entry.split_once(':').ok_or_else(|| {
+					anyhow::anyhow!("payload mix entry {entry:?}: expected bytes:weight")
+				})?;
+				Ok((
+					size.trim()
+						.parse::<usize>()
+						.map_err(|e| anyhow::anyhow!("payload mix size {size:?}: {e}"))?,
+					weight
+						.trim()
+						.parse::<u32>()
+						.map_err(|e| anyhow::anyhow!("payload mix weight {weight:?}: {e}"))?,
+				))
+			})
+			.collect::<anyhow::Result<Vec<_>>>()?;
+		Self::from_weighted_sizes(&pairs)
+	}
+
 	#[must_use]
 	pub fn max_payload_bytes(&self) -> usize {
 		*self.sizes.iter().max().unwrap_or(&0)

--- a/stress-test/src/scenarios/fill.rs
+++ b/stress-test/src/scenarios/fill.rs
@@ -3,13 +3,15 @@
 
 //! Saturating feeder: a fixed pool of reused accounts with sequential nonces
 //! keeps the tx pool full so every sealed block goes out full. Runs until
-//! killed. Built for dataset generation (manual-seal dev node), where the
-//! one-shot-account pipeline leaves blocks mostly empty between batches.
+//! killed or until the chain reaches `until_height`, so a build script can lay
+//! down height-keyed bands of different payload profiles. Built for dataset
+//! generation (manual-seal dev node), where the one-shot-account pipeline
+//! leaves blocks mostly empty between batches.
 
 use anyhow::Result;
 use std::{
 	sync::{
-		atomic::{AtomicU64, Ordering},
+		atomic::{AtomicBool, AtomicU64, Ordering},
 		Arc,
 	},
 	time::{Duration, Instant},
@@ -24,6 +26,7 @@ use crate::{
 	accounts::{keypair_at_derivation_prefix, NonceTracker},
 	authorize::authorize_accounts,
 	client::{fetch_txpool_pending_total, BulletinConfig, BulletinExtrinsicParamsBuilder},
+	pipeline::StorePayloadMode,
 	store::{generate_payload, store_submit_pre_signed},
 };
 
@@ -55,13 +58,17 @@ const POOL_HIGH_WATER: usize = 600;
 /// How often each worker re-checks the pool depth, in submissions.
 const POOL_CHECK_EVERY: u64 = 8;
 
-/// Run the saturating feeder until the process is killed.
+/// Run the saturating feeder until the process is killed, or until the chain
+/// reaches `until_height` (0 = never). Per-store payload sizes come from
+/// `payload_mode` (fixed, or sampled from a weighted mix).
+#[allow(clippy::too_many_arguments)]
 pub async fn run_fill(
 	client: &OnlineClient<BulletinConfig>,
 	authorizer: &Keypair,
 	authorizer_nonces: &NonceTracker,
 	ws_url: &str,
-	payload_bytes: usize,
+	payload_mode: StorePayloadMode,
+	until_height: u64,
 	num_accounts: u32,
 	workers: u32,
 ) -> Result<()> {
@@ -90,6 +97,8 @@ pub async fn run_fill(
 	}
 
 	let submitted = Arc::new(AtomicU64::new(0));
+	let submitted_bytes = Arc::new(AtomicU64::new(0));
+	let stop = Arc::new(AtomicBool::new(false));
 	let start = Instant::now();
 
 	let mut tasks = Vec::new();
@@ -102,6 +111,9 @@ pub async fn run_fill(
 		let nonces = store_nonces.clone();
 		let ws_url = ws_url.to_string();
 		let submitted = submitted.clone();
+		let submitted_bytes = submitted_bytes.clone();
+		let stop = stop.clone();
+		let payload_mode = payload_mode.clone();
 
 		tasks.push(tokio::spawn(async move {
 			let rpc = jsonrpsee::ws_client::WsClientBuilder::default()
@@ -110,11 +122,15 @@ pub async fn run_fill(
 				.await?;
 			let mut i = 0usize;
 			let mut since_check = 0u64;
-			loop {
+			while !stop.load(Ordering::Relaxed) {
 				let kp = my_keypairs[i % my_keypairs.len()].clone();
 				let id = my_ids[i % my_ids.len()].clone();
 				i += 1;
 
+				let payload_bytes = match &payload_mode {
+					StorePayloadMode::Fixed(n) => *n,
+					StorePayloadMode::Mixed(mix) => mix.sample(&mut rand::thread_rng()),
+				};
 				let nonce = nonces.next_nonce(&id);
 				let c = client.clone();
 				let encoded = tokio::task::spawn_blocking(move || {
@@ -131,40 +147,66 @@ pub async fn run_fill(
 					continue;
 				}
 				submitted.fetch_add(1, Ordering::Relaxed);
+				submitted_bytes.fetch_add(payload_bytes as u64, Ordering::Relaxed);
 
 				since_check += 1;
 				if since_check >= POOL_CHECK_EVERY {
 					since_check = 0;
 					// Err means the depth is unknown: back off rather than flood.
-					while fetch_txpool_pending_total(&ws_url).await.unwrap_or(usize::MAX) >
-						POOL_HIGH_WATER
+					// The stop check matters here: after the target height the
+					// node may stop sealing and the pool never drains.
+					while !stop.load(Ordering::Relaxed) &&
+						fetch_txpool_pending_total(&ws_url).await.unwrap_or(usize::MAX) >
+							POOL_HIGH_WATER
 					{
 						tokio::time::sleep(Duration::from_millis(200)).await;
 					}
 				}
 			}
-			#[allow(unreachable_code)]
 			Ok::<_, anyhow::Error>(())
 		}));
 	}
 
-	// Progress line once a minute; the runner script tracks height and DB size.
-	// Nonce re-sync from chain heals ladders broken by silent pool drops
-	// (a dropped tx strands every higher nonce of that account as future).
+	// Height check every tick (band boundaries are height-keyed, so the
+	// overshoot is one tick of sealing); progress line and nonce re-sync once
+	// a minute. The re-sync heals ladders broken by silent pool drops (a
+	// dropped tx strands every higher nonce of that account as future).
+	let mut ticks = 0u64;
 	loop {
-		tokio::time::sleep(Duration::from_secs(60)).await;
-		for id in &account_ids {
-			if let Err(e) = store_nonces.refresh(client, id).await {
-				tracing::warn!("fill: nonce refresh failed for {id}: {e}");
+		tokio::time::sleep(Duration::from_secs(5)).await;
+		ticks += 1;
+
+		if until_height > 0 {
+			match client.blocks().at_latest().await {
+				Ok(block) => {
+					let height: u64 = block.number().into();
+					if height >= until_height {
+						tracing::info!("fill: reached height {height} >= {until_height}, stopping");
+						stop.store(true, Ordering::Relaxed);
+						for task in tasks {
+							let _ = task.await;
+						}
+						return Ok(());
+					}
+				},
+				Err(e) => tracing::warn!("fill: height check failed: {e}"),
 			}
 		}
-		let n = submitted.load(Ordering::Relaxed);
-		let mib = n as f64 * payload_bytes as f64 / 1024.0 / 1024.0;
-		let secs = start.elapsed().as_secs_f64();
-		tracing::info!(
-			"fill: {n} stores submitted, ~{mib:.0} MiB payload, avg {:.1} MiB/s",
-			mib / secs
-		);
+
+		if ticks.is_multiple_of(12) {
+			for id in &account_ids {
+				if let Err(e) = store_nonces.refresh(client, id).await {
+					tracing::warn!("fill: nonce refresh failed for {id}: {e}");
+				}
+			}
+			let n = submitted.load(Ordering::Relaxed);
+			let mib = submitted_bytes.load(Ordering::Relaxed) as f64 / 1024.0 / 1024.0;
+			let secs = start.elapsed().as_secs_f64();
+			tracing::info!(
+				"fill: {n} stores submitted, ~{mib:.0} MiB payload, avg {:.1} MiB/s",
+				mib / secs
+			);
+		}
 		if tasks.iter().all(|t| t.is_finished()) {
 			anyhow::bail!("fill: all workers exited");
 		}


### PR DESCRIPTION
Stacked on `ndk/stress-test-fill`, for #749. Adds `--payload-mix bytes:weight,...` (per-store sampled sizes, reuses `PayloadSizeMix`) and `--until-height`, so the build script can lay down height-keyed profile bands, e.g. small-flood bands inside the proof and delete windows.