### PR TITLE
storage-bench: bare-box metrics collection

### DIFF
--- a/docs/storage-benchmark.md
+++ b/docs/storage-benchmark.md
@@ -54,8 +54,23 @@ aggregate dilutes the loaded hours. Record when each peer catches up
    (`bulletin-stress-test bitswap bulk-read --rate 0`) so read pressure does not disappear
    with the peers.
 
+## Bare box metrics
+
+The box has no ops stack, and the node's raw `/metrics` endpoint cannot answer quantile
+queries, so run a local Prometheus with `scripts/storage-bench/prometheus-box.yml` (author on
+9615, peers 9616+, node_exporter on 9100) and point `collect-metrics.sh` at it:
+
+    PROM=http://127.0.0.1:9090 SEL='job="author"' MOUNT=/mnt/<arm> \
+      scripts/storage-bench/collect-metrics.sh <arm>
+
+`SEL` must single out the author or the peers' import histograms (their DBs sit on the fast
+disk) blend into the percentiles. `MOUNT` switches the disk-free row from kubelet to
+node_exporter. `bulletin_permanent_storage_used_ratio` has no exporter outside the ops stack
+and reads NA on the box.
+
 ## Scripts
 
 `scripts/storage-bench/`: `fio-block-critical.fio` (pre-screen), `throttle.sh` (emulate a tier
 via cgroup v2 io.max), `collect-metrics.sh` (Prometheus snapshot, window-sliceable via
-`AT`/`WINDOW`), `wait-peers.sh` (peer catch-up watcher, emits the window boundaries).
+`AT`/`WINDOW`, bare-box capable via `SEL`/`MOUNT`), `wait-peers.sh` (peer catch-up watcher,
+emits the window boundaries), `prometheus-box.yml` (local Prometheus for the box).

--- a/scripts/storage-bench/collect-metrics.sh
+++ b/scripts/storage-bench/collect-metrics.sh
@@ -13,6 +13,14 @@
 # from wait-peers.sh:
 #   loaded (peers syncing):  AT=<last-peer-caught-up> WINDOW=<sync duration>  <arm>-loaded
 #   quiet (after catch-up):  AT=<run end>             WINDOW=<remaining time> <arm>-quiet
+#
+# Bare benchmark box (no ops stack): run a local Prometheus with
+# scripts/storage-bench/prometheus-box.yml, then
+#   PROM=http://127.0.0.1:9090 SEL='job="author"' MOUNT=/mnt/<arm> \
+#     scripts/storage-bench/collect-metrics.sh <arm>
+# SEL must single out the author: without it the peers' import histograms
+# (their DBs sit on the fast disk) blend into the percentiles. MOUNT switches
+# the disk-free row from kubelet to node_exporter.
 set -euo pipefail
 
 PROM="${PROM:?set PROM to the Prometheus base URL}"
@@ -21,13 +29,24 @@ CHAIN="${CHAIN:-bulletin}"
 NS="${NS:-bulletin}"
 WINDOW="${WINDOW:-10m}"
 AT="${AT:-}"
+MOUNT="${MOUNT:-}"
 OUT="${ARM}.metrics.txt"
 
 q() { curl -sG "$PROM/api/v1/query" --data-urlencode "query=$1" \
         ${AT:+--data-urlencode "time=$AT"} \
         | python3 -c 'import sys,json;d=json.load(sys.stdin)["data"]["result"];print(d[0]["value"][1] if d else "NA")'; }
 
-SEL="chain=~\"$CHAIN\""
+# Series selector for the node under test. Default matches the ops stack's
+# chain label; on the box set SEL='job="author"' (label from prometheus-box.yml).
+SEL="${SEL-chain=~\"$CHAIN\"}"
+# For queries that add their own labels; empty SEL must not leave a trailing comma.
+SEL_AND="${SEL:+,$SEL}"
+
+if [ -n "$MOUNT" ]; then
+  DISK_Q="min(node_filesystem_avail_bytes{mountpoint=\"$MOUNT\"} / node_filesystem_size_bytes{mountpoint=\"$MOUNT\"})"
+else
+  DISK_Q="min(kubelet_volume_stats_available_bytes{namespace=\"$NS\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$NS\"})"
+fi
 
 {
   echo "arm: $ARM   window: $WINDOW   at: ${AT:-now}   $(date -u +%FT%TZ)"
@@ -38,7 +57,8 @@ SEL="chain=~\"$CHAIN\""
   # in the two stock histograms above.
   echo "own import p99 (s):      $(q "histogram_quantile(0.99, sum(rate(substrate_dev_seal_block_import_time_bucket{$SEL}[$WINDOW])) by (le))")"
   echo "inherent build p99 (s):  $(q "histogram_quantile(0.99, sum(rate(substrate_dev_seal_inherent_data_time_bucket{$SEL}[$WINDOW])) by (le))")"
-  echo "best-block rate (1/s):   $(q "sum(rate(substrate_block_height{status=\"best\",$SEL}[$WINDOW]))")"
-  echo "disk free ratio:         $(q "min(kubelet_volume_stats_available_bytes{namespace=\"$NS\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$NS\"})")"
+  echo "best-block rate (1/s):   $(q "sum(rate(substrate_block_height{status=\"best\"$SEL_AND}[$WINDOW]))")"
+  echo "disk free ratio:         $(q "$DISK_Q")"
+  # Exporter lives in the ops stack only; NA is expected on a bare box.
   echo "permanent storage ratio: $(q "max(bulletin_permanent_storage_used_ratio{$SEL})")"
 } | tee "$OUT"

--- a/scripts/storage-bench/prometheus-box.yml
+++ b/scripts/storage-bench/prometheus-box.yml
@@ -1,0 +1,23 @@
+# Minimal Prometheus config for the bare benchmark box, so collect-metrics.sh
+# works without the ops stack:
+#   prometheus --config.file=scripts/storage-bench/prometheus-box.yml \
+#     --storage.tsdb.path=./prom-data
+#
+# Ports: author started with --prometheus-port 9615, peers with 9616+;
+# node_exporter (only needed for the disk-free row, MOUNT=/mnt/<arm>) on its
+# default 9100. The job label is the selector collect-metrics.sh filters on:
+# SEL='job="author"' keeps the peers' series (DBs on the fast disk) out of the
+# author's percentiles.
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: author
+    static_configs:
+      - targets: ["127.0.0.1:9615"]
+  - job_name: peers
+    static_configs:
+      - targets: ["127.0.0.1:9616", "127.0.0.1:9617", "127.0.0.1:9618"]
+  - job_name: node
+    static_configs:
+      - targets: ["127.0.0.1:9100"]


### PR DESCRIPTION
Stacked on #764, for #749. On the bare box every query returned NA: adds `prometheus-box.yml` (raw `/metrics` cannot answer quantile queries), makes `SEL` overridable (`job="author"` keeps the peers' fast-disk series out of the author's percentiles), and `MOUNT` switches the disk row to node_exporter.