### PR TITLE
docs: add Grafana HOP dashboard

### DIFF
--- a/utils/monitoring/README.md
+++ b/utils/monitoring/README.md
@@ -3,6 +3,9 @@
 Grafana dashboard models for the Bulletin networks. Edit here, then re-import.
 
 - `bulletin-paseo-dashboard.json` — Paseo Next V2
+- `bulletin-hop-dashboard.json`: HOP pool, promotion and RPC health (`substrate_hop_*`) for all
+  Bulletin networks; the `chain` variable lists whichever chains expose the metrics. Needs
+  collators built with polkadot-sdk#12662 and `--enable-hop`.
 
 Import: [Grafana](https://grafana.teleport.parity.io/dashboard/new?orgId=1&from=now-6h&to=now&timezone=browser)
 → New → New dashboard → Import dashboard → upload or paste JSON → Load → Overwrite.

--- a/utils/monitoring/bulletin-hop-dashboard.json
+++ b/utils/monitoring/bulletin-hop-dashboard.json
@@ -599,6 +599,165 @@
           "legendFormat": "{{node}} {{method}}"
         }
       ]
+    },
+    {
+      "type": "row",
+      "title": "HOP endpoints (blackbox probe of external collators)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      }
+    },
+    {
+      "type": "state-timeline",
+      "title": "hop_poolStatus reachable per collator",
+      "description": "Blackbox probe from parity-mgmt against each collator's public RPC (devops-cloud-infra#4270); alerts go to the Bulletin Collator Monitoring Matrix room. 0 = node or RPC down, or --enable-hop missing. Mainnet only: Parity scrapes no mainnet collator, so this is the only Parity-side HOP signal there.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 14,
+        "x": 0,
+        "y": 44
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "down"
+                },
+                "1": {
+                  "text": "up"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "options": {
+        "showValue": "never",
+        "mergeValues": true,
+        "rowHeight": 0.8
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (instance) (probe_success{job=\"blackbox-bulletin-hop\", chain=~\"$chain\"})",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Collators with HOP up",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 4,
+        "x": 14,
+        "y": 44
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "green",
+                "value": 8
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(probe_success{job=\"blackbox-bulletin-hop\", chain=~\"$chain\"} == 1) or vector(0)"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Probe duration",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 44
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (instance) (probe_duration_seconds{job=\"blackbox-bulletin-hop\", chain=~\"$chain\"})",
+          "legendFormat": "{{instance}}"
+        }
+      ]
     }
   ]
 }

--- a/utils/monitoring/bulletin-hop-dashboard.json
+++ b/utils/monitoring/bulletin-hop-dashboard.json
@@ -1,0 +1,604 @@
+{
+  "title": "Bulletin HOP",
+  "uid": "bulletin-hop",
+  "tags": [
+    "bulletin",
+    "hop"
+  ],
+  "description": "sc-hop pool, promotion and RPC health (substrate_hop_* metrics, polkadot-sdk#12662) for every Bulletin network Parity scrapes. Only collators started with --enable-hop export these.",
+  "timezone": "utc",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "1m",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0
+      },
+      {
+        "name": "chain",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": "label_values(substrate_hop_pool_entries, chain)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
+        "name": "node",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": "label_values(substrate_hop_pool_entries{chain=~\"$chain\"}, node)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Pool",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Pool fill",
+      "description": "Bytes used / --hop-max-pool-size. Submits fail with pool_full at 100%.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (node) (substrate_hop_pool_bytes{chain=~\"$chain\", node=~\"$node\"} / substrate_hop_pool_max_bytes{chain=~\"$chain\", node=~\"$node\"})",
+          "legendFormat": "{{node}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Pool bytes",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 6,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (node) (substrate_hop_pool_bytes{chain=~\"$chain\", node=~\"$node\"})",
+          "legendFormat": "{{node}} used"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (node) (substrate_hop_pool_max_bytes{chain=~\"$chain\", node=~\"$node\"})",
+          "legendFormat": "{{node}} max"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Pool entries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 15,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (node) (substrate_hop_pool_entries{chain=~\"$chain\", node=~\"$node\"})",
+          "legendFormat": "{{node}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Inserted bytes rate",
+      "description": "Accounted size of accepted hop_submit blobs (includes per-recipient overhead).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (node) (rate(substrate_hop_pool_inserted_bytes_total{chain=~\"$chain\", node=~\"$node\"}[5m]))",
+          "legendFormat": "{{node}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Removals by reason",
+      "description": "acked = normal hand-off. expired_promoted = fell back to on-chain. expired_unpromoted = lost (upper bound). corrupt / startup_dropped = disk problems.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 8,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (node, reason) (increase(substrate_hop_pool_removed_total{chain=~\"$chain\", node=~\"$node\"}[$__rate_interval]))",
+          "legendFormat": "{{node}} {{reason}}"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Expired unpromoted (range)",
+      "description": "Entries that expired before any recipient claimed them and were not promoted on-chain. Upper bound on data loss; should stay at 0.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "decimals": 0
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(substrate_hop_pool_removed_total{chain=~\"$chain\", node=~\"$node\", reason=\"expired_unpromoted\"}[$__range]))"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Promotion",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Promotion backlog",
+      "description": "Unpromoted entries inside --hop-promotion-buffer-secs of expiry with attempts left, sampled every maintenance tick. Growing = promotion starved (tx pool, authorization, runtime API).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "custom": {
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (node) (substrate_hop_promotion_backlog{chain=~\"$chain\", node=~\"$node\"})",
+          "legendFormat": "{{node}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Promotions confirmed",
+      "description": "Entries whose on-chain promotion was observed in a block.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (node) (increase(substrate_hop_promotions_confirmed_total{chain=~\"$chain\", node=~\"$node\"}[$__rate_interval]))",
+          "legendFormat": "{{node}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Maintenance ticks (15m)",
+      "description": "Liveness of the hop-maintenance task. 0 = stalled (default --hop-check-interval is 300s, so expect ~3).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "custom": {
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (node) (increase(substrate_hop_maintenance_ticks_total{chain=~\"$chain\", node=~\"$node\"}[15m]))",
+          "legendFormat": "{{node}}"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "RPC",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "HOP calls by node/method",
+      "description": "From the RPC server (substrate_rpc_calls_*); hop_poolStatus excluded as probe noise.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (node, method) (increase(substrate_rpc_calls_started{chain=~\"$chain\", node=~\"$node\", method=~\"hop_.*\", method!=\"hop_poolStatus\"}[$__rate_interval]))",
+          "legendFormat": "{{node}} {{method}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HOP errors by method/reason",
+      "description": "reason = HopError variant. not_found on hop_ack is benign (entry already deleted after the final ack); pool_full, user_quota_exceeded, rate_limited, not_authorized are the ones to watch.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (node, method, reason) (increase(substrate_hop_rpc_errors_total{chain=~\"$chain\", node=~\"$node\"}[$__rate_interval]))",
+          "legendFormat": "{{node}} {{method}} {{reason}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HOP error ratio by method",
+      "description": "Errors / calls per method. Both sides are keyed by the wire method name.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (node, method) (rate(substrate_hop_rpc_errors_total{chain=~\"$chain\", node=~\"$node\"}[5m])) / clamp_min(sum by (node, method) (rate(substrate_rpc_calls_started{chain=~\"$chain\", node=~\"$node\", method=~\"hop_.*\", method!=\"hop_poolStatus\"}[5m])), 1e-9)",
+          "legendFormat": "{{node}} {{method}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HOP call p95 latency by node/method",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "µs"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, node, method) (rate(substrate_rpc_calls_time_bucket{chain=~\"$chain\", node=~\"$node\", method=~\"hop_.*\", method!=\"hop_poolStatus\"}[5m])))",
+          "legendFormat": "{{node}} {{method}}"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Grafana dashboard for HOP, built on the `substrate_hop_*` metrics from polkadot-sdk#12662 (split out of #771).

- `bulletin-hop-dashboard.json`: pool fill / bytes / entries / inserted rate, removals by reason (`expired_unpromoted` is the data-loss upper bound), promotion backlog and confirmed promotions, maintenance-task liveness, HOP RPC errors by method/reason joined with `substrate_rpc_calls_*` for error ratio and p95 latency
- chain-agnostic: the `chain` variable lists every Bulletin chain that exposes the metrics. Paseo collators will be the first (they're Parity's); mainnet HOP runs on external collators, so it shows there only if their metrics reach Parity (paritytech/polkadot-bulletin-chain#772)
- `HOP endpoints` row: per-collator `hop_poolStatus` reachability from the blackbox probe in paritytech/devops-cloud-infra#4270 (mainnet, has data today)

Paseo gets data first: paritytech/devops-cloud-infra#4274 moves our Paseo collators to a master build with #12662, so `next-bulletin-paseo` shows up as soon as it's applied. Otherwise the `substrate_hop_*` panels stay empty until collators run a node with #12662 (next stable2606 patch, publish 2026-09-10) and `--enable-hop`.


