### PR TITLE
sdk: add enable_auto_renew / disable_auto_renew to both SDKs

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -98,7 +98,8 @@ The SDK book contains comprehensive guides including:
 
 Both SDKs provide:
 
-- ✅ **Authorization operations** (authorizeAccount, authorizePreimage, renew)
+- ✅ **Authorization operations** (authorizeAccount, authorizePreimage)
+- ✅ **Data renewal** (renew, forceRenew, enableAutoRenew, disableAutoRenew)
 - ✅ **Store transaction submission**
 - ✅ **Automatic chunking** with configurable chunk size (default 1 MiB)
 - ✅ **DAG-PB manifests** (IPFS-compatible)

--- a/sdk/rust/src/transaction.rs
+++ b/sdk/rust/src/transaction.rs
@@ -524,6 +524,48 @@ impl TransactionClient {
 		Ok(RenewReceipt { entry, block_hash: result.block_hash })
 	}
 
+	/// Register recurring auto-renewal for stored content.
+	///
+	/// The first cycle is prepaid at registration; each later cycle charges
+	/// the owner's authorization when it fires.
+	///
+	/// Returns [`Error::RenewalUnavailable`] on a chain without the renewal pallet.
+	pub async fn enable_auto_renew(
+		&self,
+		content_hash: ContentHash,
+		signer: &Keypair,
+		wait_for: WaitFor,
+	) -> Result<()> {
+		self.ensure_renewal_available()?;
+		let tx = bulletin::tx().data_renewal().enable_auto_renew(content_hash);
+		self.submit_and_watch(&tx, signer, wait_for, None, |e| {
+			Error::RenewalFailed(format!("Enable auto-renew failed: {e}"))
+		})
+		.await?;
+		Ok(())
+	}
+
+	/// Disable auto-renewal for stored content.
+	///
+	/// A signed caller must own the registration, and its prepaid cycle must
+	/// already have fired; Root bypasses both checks.
+	///
+	/// Returns [`Error::RenewalUnavailable`] on a chain without the renewal pallet.
+	pub async fn disable_auto_renew(
+		&self,
+		content_hash: ContentHash,
+		signer: &Keypair,
+		wait_for: WaitFor,
+	) -> Result<()> {
+		self.ensure_renewal_available()?;
+		let tx = bulletin::tx().data_renewal().disable_auto_renew(content_hash);
+		self.submit_and_watch(&tx, signer, wait_for, None, |e| {
+			Error::RenewalFailed(format!("Disable auto-renew failed: {e}"))
+		})
+		.await?;
+		Ok(())
+	}
+
 	/// Refresh an account authorization (extends expiry).
 	///
 	/// Requires authorizer origin (typically sudo).

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -73,7 +73,7 @@ The SDK book contains:
 - Automatic chunking (default 1 MiB, configurable)
 - DAG-PB manifest generation (IPFS-compatible)
 - Authorization management (`authorizeAccount`, `authorizePreimage`)
-- Data renewal (`renew`)
+- Data renewal (`renew`, `forceRenew`, `enableAutoRenew`, `disableAutoRenew`)
 - Progress tracking callbacks
 - Builder pattern API
 - Mock client for testing

--- a/sdk/typescript/src/async-client.ts
+++ b/sdk/typescript/src/async-client.ts
@@ -120,10 +120,19 @@ type RenewalPallet = {
     args: { block: number; index: number } | { entry: TransactionRef },
   ): PapiTransaction
   force_renew?(args: { entry: TransactionRef }): PapiTransaction
+  enable_auto_renew?(args: { content_hash: string }): PapiTransaction
+  disable_auto_renew?(args: { content_hash: string }): PapiTransaction
 }
 
-/** Where the runtime's renewal extrinsics live and which call shape they take. */
-type RenewalResolution = { pallet: RenewalPallet; shape: RenewShape }
+/**
+ * Where the runtime's renewal extrinsics live, which call shape they take,
+ * and whether it carries the auto-renewal pair.
+ */
+type RenewalResolution = {
+  pallet: RenewalPallet
+  shape: RenewShape
+  autoRenew: boolean
+}
 
 /** The slice of PAPI's `getStaticApis()` result the renewal resolution reads. */
 type StaticApisCompat = {
@@ -389,6 +398,8 @@ export interface BulletinClientInterface {
   authorizePreimage(contentHash: Uint8Array, maxSize: bigint): AuthCallBuilder
   renew(ref: TransactionRefInput): CallBuilder
   forceRenew(ref: TransactionRefInput): CallBuilder
+  enableAutoRenew(contentHash: Uint8Array): CallBuilder
+  disableAutoRenew(contentHash: Uint8Array): CallBuilder
   refreshAccountAuthorization(who: string): AuthCallBuilder
   refreshPreimageAuthorization(contentHash: Uint8Array): AuthCallBuilder
   removeExpiredAccountAuthorization(who: string): CallBuilder
@@ -1322,11 +1333,17 @@ export class AsyncBulletinClient implements BulletinClientInterface {
       const transactionStorage = this.api.tx.TransactionStorage
       if (!this.api.getStaticApis) {
         if (dataRenewal?.renew) {
-          return { pallet: dataRenewal, shape: "transactionRef" }
+          return {
+            pallet: dataRenewal,
+            shape: "transactionRef",
+            autoRenew: !!dataRenewal.enable_auto_renew,
+          }
         }
+        const storagePallet = transactionStorage as RenewalPallet
         return {
-          pallet: transactionStorage,
+          pallet: storagePallet,
           shape: transactionStorage.force_renew ? "transactionRef" : "legacy",
+          autoRenew: !!storagePallet.enable_auto_renew,
         }
       }
       let compat: StaticApisCompat["compat"]["tx"]
@@ -1342,16 +1359,25 @@ export class AsyncBulletinClient implements BulletinClientInterface {
       }
       // `DataRenewal` has only ever taken `TransactionRef` arguments.
       if (dataRenewal && (compat.DataRenewal?.renew?.level ?? 0) > 0) {
-        return { pallet: dataRenewal, shape: "transactionRef" }
+        return {
+          pallet: dataRenewal,
+          shape: "transactionRef",
+          autoRenew: (compat.DataRenewal?.enable_auto_renew?.level ?? 0) > 0,
+        }
       }
       const storageCompat = compat.TransactionStorage
       if ((storageCompat?.force_renew?.level ?? 0) > 0) {
-        return { pallet: transactionStorage, shape: "transactionRef" }
+        return {
+          pallet: transactionStorage,
+          shape: "transactionRef",
+          autoRenew: (storageCompat?.enable_auto_renew?.level ?? 0) > 0,
+        }
       }
       return {
         pallet: transactionStorage,
         shape:
           (storageCompat?.renew?.level ?? 0) > 0 ? "legacy" : "unsupported",
+        autoRenew: false,
       }
     })()
     const resolved = this.renewalPromise
@@ -1420,6 +1446,58 @@ export class AsyncBulletinClient implements BulletinClientInterface {
       return this.submitTx(
         tx,
         "Failed to force renew",
+        ErrorCode.TRANSACTION_FAILED,
+        options,
+      )
+    })
+  }
+
+  /**
+   * Register recurring auto-renewal for stored content.
+   *
+   * The first cycle is prepaid at registration; each later cycle charges the
+   * owner's authorization when it fires.
+   */
+  enableAutoRenew(contentHash: Uint8Array): CallBuilder {
+    return new CallBuilder(async (options) => {
+      const { pallet, autoRenew } = await this.resolveRenewal()
+      const enableAutoRenew = pallet.enable_auto_renew
+      if (!autoRenew || !enableAutoRenew) {
+        throw new BulletinError(
+          "enable_auto_renew is not supported by this runtime",
+          ErrorCode.UNSUPPORTED_OPERATION,
+        )
+      }
+      const tx = enableAutoRenew({ content_hash: Binary.toHex(contentHash) })
+      return this.submitTx(
+        tx,
+        "Failed to enable auto-renew",
+        ErrorCode.TRANSACTION_FAILED,
+        options,
+      )
+    })
+  }
+
+  /**
+   * Disable auto-renewal for stored content.
+   *
+   * A signed caller must own the registration, and its prepaid cycle must
+   * already have fired; Root bypasses both checks.
+   */
+  disableAutoRenew(contentHash: Uint8Array): CallBuilder {
+    return new CallBuilder(async (options) => {
+      const { pallet, autoRenew } = await this.resolveRenewal()
+      const disableAutoRenew = pallet.disable_auto_renew
+      if (!autoRenew || !disableAutoRenew) {
+        throw new BulletinError(
+          "disable_auto_renew is not supported by this runtime",
+          ErrorCode.UNSUPPORTED_OPERATION,
+        )
+      }
+      const tx = disableAutoRenew({ content_hash: Binary.toHex(contentHash) })
+      return this.submitTx(
+        tx,
+        "Failed to disable auto-renew",
         ErrorCode.TRANSACTION_FAILED,
         options,
       )

--- a/sdk/typescript/src/mock-client.ts
+++ b/sdk/typescript/src/mock-client.ts
@@ -65,6 +65,8 @@ export type MockOperation =
     }
   | { type: "renew"; entry: TransactionRef }
   | { type: "force_renew"; entry: TransactionRef }
+  | { type: "enable_auto_renew"; contentHash: Uint8Array }
+  | { type: "disable_auto_renew"; contentHash: Uint8Array }
   | { type: "store_preimage_auth"; dataSize: number; cid: string }
   | { type: "remove_expired_account_authorization"; who: string }
   | {
@@ -334,6 +336,20 @@ export class MockBulletinClient implements BulletinClientInterface {
         type: "force_renew",
         entry: toTransactionRef(ref),
       })
+      return mockReceipt()
+    })
+  }
+
+  enableAutoRenew(contentHash: Uint8Array): CallBuilder {
+    return new CallBuilder(async () => {
+      this.operations.push({ type: "enable_auto_renew", contentHash })
+      return mockReceipt()
+    })
+  }
+
+  disableAutoRenew(contentHash: Uint8Array): CallBuilder {
+    return new CallBuilder(async () => {
+      this.operations.push({ type: "disable_auto_renew", contentHash })
       return mockReceipt()
     })
   }

--- a/sdk/typescript/test/unit/renew-shape.test.ts
+++ b/sdk/typescript/test/unit/renew-shape.test.ts
@@ -63,15 +63,23 @@ const submitFn = async () => ({
 // the call.
 const staticApis = (levels: {
   dataRenewalRenew?: number
+  dataRenewalEnableAutoRenew?: number
   renew?: number
   forceRenew?: number
+  enableAutoRenew?: number
 }) => ({
   compat: {
     tx: {
-      DataRenewal: { renew: { level: levels.dataRenewalRenew ?? 0 } },
+      DataRenewal: {
+        renew: { level: levels.dataRenewalRenew ?? 0 },
+        enable_auto_renew: {
+          level: levels.dataRenewalEnableAutoRenew ?? 0,
+        },
+      },
       TransactionStorage: {
         renew: { level: levels.renew ?? 1 },
         force_renew: { level: levels.forceRenew ?? 0 },
+        enable_auto_renew: { level: levels.enableAutoRenew ?? 0 },
       },
     },
   },
@@ -420,6 +428,110 @@ describe("forceRenew", () => {
         message: expect.stringContaining("probe"),
       },
     )
+  })
+})
+
+describe("auto-renew", () => {
+  const hashHex = `0x${"01".repeat(32)}`
+
+  it("submits enable_auto_renew({content_hash}) on DataRenewal without getStaticApis", async () => {
+    let arg: unknown
+    const client = createClient(
+      {},
+      {
+        dataRenewal: {
+          renew: () => mockTx,
+          enable_auto_renew: (a: unknown) => {
+            arg = a
+            return mockTx
+          },
+        },
+      },
+    )
+
+    await client.enableAutoRenew(hashInput).send()
+    expect(arg).toEqual({ content_hash: hashHex })
+  })
+
+  it("submits disable_auto_renew on DataRenewal when compat reports it present", async () => {
+    let arg: unknown
+    const client = createClient(
+      {},
+      {
+        dataRenewal: {
+          renew: () => mockTx,
+          enable_auto_renew: () => mockTx,
+          disable_auto_renew: (a: unknown) => {
+            arg = a
+            return mockTx
+          },
+        },
+        getStaticApis: async () =>
+          staticApis({ dataRenewalRenew: 1, dataRenewalEnableAutoRenew: 1 }),
+      },
+    )
+
+    await client.disableAutoRenew(hashInput).send()
+    expect(arg).toEqual({ content_hash: hashHex })
+  })
+
+  it("submits enable_auto_renew on TransactionStorage on pre-split runtimes that carry it", async () => {
+    let arg: unknown
+    const client = createClient(
+      {
+        renew: () => mockTx,
+        force_renew: () => mockTx,
+        enable_auto_renew: (a: unknown) => {
+          arg = a
+          return mockTx
+        },
+      },
+      {
+        getStaticApis: async () =>
+          staticApis({ forceRenew: 1, enableAutoRenew: 1 }),
+      },
+    )
+
+    await client.enableAutoRenew(hashInput).send()
+    expect(arg).toEqual({ content_hash: hashHex })
+  })
+
+  it("rejects when compat reports enable_auto_renew Incompatible", async () => {
+    // Entries exist (real PAPI proxies always do); only compat levels reveal
+    // the live runtime lacks the auto-renew pair.
+    let called = false
+    const client = createClient(
+      {},
+      {
+        dataRenewal: {
+          renew: () => mockTx,
+          enable_auto_renew: () => {
+            called = true
+            return mockTx
+          },
+        },
+        getStaticApis: async () => staticApis({ dataRenewalRenew: 1 }),
+      },
+    )
+
+    await expect(
+      client.enableAutoRenew(hashInput).send(),
+    ).rejects.toMatchObject({
+      code: ErrorCode.UNSUPPORTED_OPERATION,
+      message: "enable_auto_renew is not supported by this runtime",
+    })
+    expect(called).toBe(false)
+  })
+
+  it("rejects on legacy runtimes with no auto-renew entries", async () => {
+    const client = createClient({ renew: () => mockTx })
+
+    await expect(
+      client.disableAutoRenew(hashInput).send(),
+    ).rejects.toMatchObject({
+      code: ErrorCode.UNSUPPORTED_OPERATION,
+      message: "disable_auto_renew is not supported by this runtime",
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

The SDKs expose `renew` and `force_renew` but not the auto-renewal pair. This adds `enable_auto_renew` / `disable_auto_renew` to both SDKs, completing coverage of the `DataRenewal` pallet's user-facing calls.

**Rust** (`TransactionClient`):
- `enable_auto_renew(content_hash, signer, wait_for)` and `disable_auto_renew(content_hash, signer, wait_for)`, submitting on the `DataRenewal` pallet behind the existing `ensure_renewal_available` guard (`Error::RenewalUnavailable` on chains without the pallet).

**TypeScript** (`AsyncBulletinClient`):
- `enableAutoRenew(contentHash)` / `disableAutoRenew(contentHash)` CallBuilders, taking the 32-byte content hash and encoding it as PAPI SizedHex.
- The cached renewal resolution now also reports whether the resolved pallet carries the auto-renew pair — compat levels via `getStaticApis()` on real clients, entry presence on mock/hand-rolled api objects — so both methods reject with `UNSUPPORTED_OPERATION` on runtimes that lack the calls (including pre-`TransactionRef` legacy runtimes).
- `MockBulletinClient` records the new operations.

READMEs updated to list the full renewal surface.

## Testing

- `cargo check` / `cargo clippy -p bulletin-sdk-rust --all-targets --all-features` clean; `cargo test -p bulletin-sdk-rust` passes.
- TS: `tsc --noEmit`, biome, and `npm run test:unit` (116 tests) pass; new renew-shape tests pin auto-renew resolution and argument encoding across DataRenewal / pre-split / legacy runtimes.

Companion docs PR updates the SDK book renewal pages.