### PR TITLE
docs: align SDK book renewal pages with DataRenewal pallet and auto-renew API

### DIFF
--- a/docs/book/src/concepts/renewal.md
+++ b/docs/book/src/concepts/renewal.md
@@ -69,21 +69,21 @@ With `enable_auto_renew` the chain tracks this for you and re-registers the data
 
 ## Raw Runtime Call
 
-`renew` and `force_renew` take an `entry: TransactionRef` (a tagged enum). `enable_auto_renew` / `disable_auto_renew` instead take the `content_hash` directly. A raw runtime call (e.g. via PAPI):
+On current runtimes the renewal extrinsics live on the **`DataRenewal`** pallet (pre-split runtimes carried them on `TransactionStorage`). `renew` and `force_renew` take an `entry: TransactionRef` (a tagged enum). `enable_auto_renew` / `disable_auto_renew` instead take the `content_hash` directly. A raw runtime call (e.g. via PAPI):
 
 ```typescript
-api.tx.TransactionStorage.renew({
+api.tx.DataRenewal.renew({
   entry: { type: "Position", value: { block, index } }
 });
 
 // force_renew takes the same `entry`; fixed-size hashes are passed as
 // 0x-prefixed hex (PAPI SizedHex):
-api.tx.TransactionStorage.force_renew({
+api.tx.DataRenewal.force_renew({
   entry: { type: "ContentHash", value: contentHashHex }
 });
 
 // enable_auto_renew / disable_auto_renew take a content hash, not an `entry`:
-api.tx.TransactionStorage.enable_auto_renew({ content_hash: contentHashHex });
+api.tx.DataRenewal.enable_auto_renew({ content_hash: contentHashHex });
 ```
 
 ## When to Renew
@@ -100,9 +100,9 @@ Only the on-chain guarantee expires: the CID stays valid, and validators may sti
 
 ## SDK Support
 
-Both SDKs provide a `renew` helper:
-- **Rust SDK**: `prepare_renew()`, `RenewalTracker` — See [Rust SDK: Renewal](../rust/renewal.md)
-- **TypeScript SDK**: `client.renew()` — See [TypeScript SDK: Renewal](../typescript/renewal.md)
+Both SDKs expose the full renewal surface:
+- **Rust SDK**: `TransactionClient::{renew, force_renew, enable_auto_renew, disable_auto_renew}`, plus the offline `prepare_renew()` and `RenewalTracker` helpers — See [Rust SDK: Renewal](../rust/renewal.md)
+- **TypeScript SDK**: `client.renew()`, `client.forceRenew()`, `client.enableAutoRenew()`, `client.disableAutoRenew()` — See [TypeScript SDK: Renewal](../typescript/renewal.md)
 
 ## Next Steps
 

--- a/docs/book/src/rust/api-reference.md
+++ b/docs/book/src/rust/api-reference.md
@@ -56,6 +56,8 @@ impl TransactionClient {
 |--------|---------|-------------|
 | `renew(entry, signer, wait_for)` | `Result<RenewReceipt>` | Schedule a one-shot renewal (fires at the retention boundary); `entry` is `impl Into<TransactionRef<u32>>` — a `(block, index)` tuple or a `ContentHash` |
 | `force_renew(entry, signer, wait_for)` | `Result<RenewReceipt>` | Renew immediately at dispatch time (same `entry` conversions) |
+| `enable_auto_renew(content_hash, signer, wait_for)` | `Result<()>` | Register recurring auto-renewal; first cycle prepaid, later cycles charge the owner's authorization |
+| `disable_auto_renew(content_hash, signer, wait_for)` | `Result<()>` | Disable auto-renewal; refused while prepaid (`CannotDisablePrepaidAutoRenewal`) and for non-owners |
 
 ---
 

--- a/docs/book/src/rust/renewal.md
+++ b/docs/book/src/rust/renewal.md
@@ -4,7 +4,7 @@ Extending the retention of stored data with the Rust SDK.
 
 > **Prerequisites**: Read [Data Renewal Concepts](../concepts/renewal.md) first to understand the renewal flow.
 
-> **Note**: `TransactionClient::renew` schedules a one-shot renewal that fires at the retention boundary; `TransactionClient::force_renew` (same arguments) renews immediately. Recurring `enable_auto_renew` is not exposed by the SDK — call it via subxt (see [concepts](../concepts/renewal.md)).
+> **Note**: `TransactionClient::renew` schedules a one-shot renewal that fires at the retention boundary; `TransactionClient::force_renew` (same arguments) renews immediately. `enable_auto_renew` / `disable_auto_renew` manage recurring renewal — see [Auto-Renewal](#auto-renewal).
 
 ## Two Clients
 
@@ -56,6 +56,25 @@ println!("Renewed {:?} in block {}", receipt.entry, receipt.block_hash);
 ```
 
 `RenewReceipt` has `entry` (the `TransactionRef` that was renewed) and `block_hash`.
+
+## Auto-Renewal
+
+`enable_auto_renew` registers the content — by content hash, not a `TransactionRef` — for recurring renewal at each retention cycle. The first cycle is prepaid at registration; each later cycle charges the owner's authorization when it fires:
+
+```rust
+tx_client
+    .enable_auto_renew(content_hash, &signer, WaitFor::Finalized)
+    .await?;
+
+// Later, stop renewing:
+tx_client
+    .disable_auto_renew(content_hash, &signer, WaitFor::Finalized)
+    .await?;
+```
+
+`disable_auto_renew` is refused with `CannotDisablePrepaidAutoRenewal` while the registration is still prepaid — it only succeeds after the first cycle has consumed the prepayment. A signed caller must also own the registration (`NotAutoRenewalOwner`).
+
+Only one renewal registration can exist per content hash: enabling auto-renew on content that already has a scheduled `renew` (or vice versa) rejects with `RenewalAlreadyEnabled`.
 
 ## Storing and Tracking
 

--- a/docs/book/src/typescript/api-reference.md
+++ b/docs/book/src/typescript/api-reference.md
@@ -36,6 +36,8 @@ class AsyncBulletinClient implements BulletinClientInterface {
 | `authorizePreimage(contentHash, maxSize)` | `AuthCallBuilder` | Authorize a specific content hash |
 | `renew(ref)` | `CallBuilder` | Schedule a one-shot renewal; `ref` is `{ block, index }` or a content hash (legacy immediate renew on pre-`TransactionRef` runtimes) |
 | `forceRenew(ref)` | `CallBuilder` | Renew immediately; rejects with `UNSUPPORTED_OPERATION` on runtimes without `force_renew` |
+| `enableAutoRenew(contentHash)` | `CallBuilder` | Register recurring auto-renewal for a 32-byte content hash; rejects with `UNSUPPORTED_OPERATION` on runtimes without the auto-renew extrinsics |
+| `disableAutoRenew(contentHash)` | `CallBuilder` | Disable auto-renewal; refused on-chain while prepaid (`CannotDisablePrepaidAutoRenewal`) and for non-owners |
 | `refreshAccountAuthorization(who)` | `AuthCallBuilder` | Refresh an account authorization expiry |
 | `refreshPreimageAuthorization(contentHash)` | `AuthCallBuilder` | Refresh a preimage authorization expiry |
 | `removeExpiredAccountAuthorization(who)` | `CallBuilder` | Remove an expired account authorization |

--- a/docs/book/src/typescript/renewal.md
+++ b/docs/book/src/typescript/renewal.md
@@ -4,7 +4,7 @@ Extending the retention of stored data with the TypeScript SDK.
 
 > **Prerequisites**: Read [Data Renewal Concepts](../concepts/renewal.md) first to understand the renewal flow.
 
-> **Note**: `client.renew(ref)` takes a `{ block, index }` position or a 32-byte content hash (`Uint8Array`) — the SDK infers the `TransactionRef` variant from the shape. It schedules a one-shot renewal that fires at the retention boundary; `client.forceRenew(ref)` renews immediately. Recurring `enable_auto_renew` is not exposed by the SDK — use a [raw PAPI transaction](#raw-runtime-renewal).
+> **Note**: `client.renew(ref)` takes a `{ block, index }` position or a 32-byte content hash (`Uint8Array`) — the SDK infers the `TransactionRef` variant from the shape. It schedules a one-shot renewal that fires at the retention boundary; `client.forceRenew(ref)` renews immediately. Recurring renewal is managed with `client.enableAutoRenew(contentHash)` / `client.disableAutoRenew(contentHash)` — see [Auto-Renewal](#auto-renewal).
 >
 > On chains still running the pre-`TransactionRef` runtime, positions fall back to the legacy `renew` extrinsic (which renews immediately); content hashes and `forceRenew` error there.
 
@@ -33,6 +33,23 @@ await client.renew({ block: blockNumber, index }).send();
 
 `store().send()` returns a `StoreResult` (`cid`, `size`, `blockNumber`, `extrinsicIndex`).
 `renew(ref).send()` returns a `TransactionReceipt` (`blockHash`, `txHash`, `blockNumber`).
+
+## Auto-Renewal
+
+`enableAutoRenew` registers the content — by 32-byte content hash (`Uint8Array`), not a position — for recurring renewal at each retention cycle. The first cycle is prepaid at registration; each later cycle charges the owner's authorization when it fires:
+
+```typescript
+await client.enableAutoRenew(contentHash).send();
+
+// Later, stop renewing:
+await client.disableAutoRenew(contentHash).send();
+```
+
+`disableAutoRenew` is refused with `CannotDisablePrepaidAutoRenewal` while the registration is still prepaid — it only succeeds after the first cycle has consumed the prepayment. A signed caller must also own the registration (`NotAutoRenewalOwner`).
+
+Only one renewal registration can exist per content hash: enabling auto-renew on content that already has a scheduled `renew` (or vice versa) rejects with `RenewalAlreadyEnabled`.
+
+Both methods reject with `UNSUPPORTED_OPERATION` on runtimes that don't carry the auto-renew extrinsics.
 
 ## Querying the Retention Period
 
@@ -88,25 +105,23 @@ for (const item of await tracker.getItemsNeedingRenewal(api)) {
 
 ## Raw Runtime Renewal
 
-Against the **current** runtime, bypassing the SDK client: `renew` / `force_renew` take an `entry: TransactionRef`, `enable_auto_renew` a `content_hash`:
+Against the **current** runtime, bypassing the SDK client. The renewal extrinsics live on the `DataRenewal` pallet (pre-split runtimes carried them on `TransactionStorage`): `renew` / `force_renew` take an `entry: TransactionRef`, `enable_auto_renew` a `content_hash`:
 
 ```typescript
 // One-shot scheduled renewal
-api.tx.TransactionStorage.renew({
+api.tx.DataRenewal.renew({
   entry: { type: "Position", value: { block, index } },
 });
 
 // Immediate renewal (emits Renewed with a new index)
-api.tx.TransactionStorage.force_renew({
+api.tx.DataRenewal.force_renew({
   entry: { type: "Position", value: { block, index } },
 });
 
 // Recurring auto-renewal (takes the content hash directly, not an `entry`;
 // fixed-size hashes are passed as 0x-prefixed hex)
-api.tx.TransactionStorage.enable_auto_renew({ content_hash: contentHashHex });
+api.tx.DataRenewal.enable_auto_renew({ content_hash: contentHashHex });
 ```
-
-`disable_auto_renew` is refused while the registration is still prepaid (`CannotDisablePrepaidAutoRenewal`) — it only succeeds after the first cycle has consumed the prepayment.
 
 The raw `store` extrinsic takes only `{ data }`; use `store_with_cid_config` for a non-default CID:
 


### PR DESCRIPTION
## Summary

Brings the SDK book's renewal documentation in line with the current runtime and SDK:

- **Stale pallet name**: the raw-call examples in `concepts/renewal.md` and `typescript/renewal.md` still targeted `api.tx.TransactionStorage.*`; the renewal extrinsics moved to the `DataRenewal` pallet in #571. Examples updated, with a note about the pre-split location.
- **Auto-renew SDK coverage**: the Rust and TypeScript renewal guides said recurring auto-renewal is "not exposed by the SDK". #776 adds `enable_auto_renew` / `disable_auto_renew` (`enableAutoRenew` / `disableAutoRenew`) to both SDKs; the guides now document them — prepaid-disable rule (`CannotDisablePrepaidAutoRenewal`), owner check (`NotAutoRenewalOwner`), one-registration-per-content-hash (`RenewalAlreadyEnabled`), and `UNSUPPORTED_OPERATION` on runtimes without the calls.
- **API references**: `enable_auto_renew` / `disable_auto_renew` rows added to both `api-reference.md` tables.
- **Concepts page**: SDK Support section now lists the full renewal surface of both SDKs.

Depends on #776 (documents the SDK methods it adds); the pallet-name fixes stand on their own.

`mdbook build` passes.