### PR TITLE
dashboards: add HOP metrics to Bulletin Paseo

### DIFF
--- a/pallets/transaction-storage/src/tests.rs
+++ b/pallets/transaction-storage/src/tests.rs
@@ -921,7 +921,8 @@ fn try_state_detects_zero_authorization_allowance() {
 		// Authorization SCALE layout: extent(AuthorizationExtent), expiration(u64)
 		// AuthorizationExtent SCALE layout: transactions(u32), transactions_allowance(u32),
 		// bytes(u64), bytes_allowance(u64), extra(`()`, zero bytes)
-		let corrupted_auth = (0u32, 0u32, 0u64, 0u64, 100u64); // all zero counters, bytes_allowance=0, expiration=100
+		// all zero counters, bytes_allowance=0, expiration=100
+		let corrupted_auth = (0u32, 0u32, 0u64, 0u64, 100u64);
 		let key = Authorizations::hashed_key_for(AuthorizationScope::Account(1u64));
 		unhashed::put_raw(&key, &corrupted_auth.encode());
 

--- a/utils/monitoring/README.md
+++ b/utils/monitoring/README.md
@@ -2,7 +2,7 @@
 
 Grafana dashboard models for the Bulletin networks. Edit here, then re-import.
 
-- `bulletin-paseo-dashboard.json` — Paseo Next V2
+- `bulletin-paseo-dashboard.json` — Paseo Next V2: liveness, IPFS, bitswap, HOP (`substrate_hop_*`)
 
 Import: [Grafana](https://grafana.teleport.parity.io/dashboard/new?orgId=1&from=now-6h&to=now&timezone=browser)
 → New → New dashboard → Import dashboard → upload or paste JSON → Load → Overwrite.

--- a/utils/monitoring/bulletin-paseo-dashboard.json
+++ b/utils/monitoring/bulletin-paseo-dashboard.json
@@ -7,7 +7,6 @@
   ],
   "timezone": "utc",
   "schemaVersion": 39,
-  "version": 1,
   "refresh": "1m",
   "time": {
     "from": "now-6h",
@@ -30,6 +29,22 @@
           "uid": "${datasource}"
         },
         "query": "label_values(substrate_block_height{chain=~\"next-bulletin-paseo\"}, chain)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
+        "name": "node",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": "label_values(substrate_hop_pool_entries{chain=~\"$chain\"}, node)",
         "refresh": 2,
         "includeAll": true,
         "multi": true,
@@ -529,7 +544,7 @@
     },
     {
       "type": "row",
-      "title": "HOP RPC (substrate_rpc_calls_*)",
+      "title": "Pool",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -538,43 +553,9 @@
       }
     },
     {
-      "type": "timeseries",
-      "title": "HOP calls by node/method",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 59
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "decimals": 0,
-          "custom": {
-            "drawStyle": "bars",
-            "fillOpacity": 60
-          }
-        }
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum by (method, node) (increase(substrate_rpc_calls_started{chain=~\"$chain\", method=~\"hop_.*\", method!=\"hop_poolStatus\", node!~\".*rpc.*\"}[$__rate_interval]))",
-          "legendFormat": "{{node}} {{method}}"
-        }
-      ]
-    },
-    {
       "type": "stat",
-      "title": "HOP calls total (range)",
+      "title": "Pool fill",
+      "description": "Bytes used / --hop-max-pool-size. Submits fail with pool_full at 100%.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -582,16 +563,33 @@
       "gridPos": {
         "h": 8,
         "w": 6,
-        "x": 12,
+        "x": 0,
         "y": 59
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
-          "decimals": 0
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          }
         }
       },
       "options": {
+        "colorMode": "background",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -605,24 +603,124 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (method, node) (increase(substrate_rpc_calls_started{chain=~\"$chain\", method=~\"hop_.*\", method!=\"hop_poolStatus\", node!~\".*rpc.*\"}[$__range]))",
-          "legendFormat": "{{node}} {{method}}"
+          "expr": "max by (node) (substrate_hop_pool_bytes{chain=~\"$chain\", node=~\"$node\"} / substrate_hop_pool_max_bytes{chain=~\"$chain\", node=~\"$node\"})",
+          "legendFormat": "{{node}}"
         }
       ]
     },
     {
       "type": "timeseries",
-      "title": "HOP call errors by node/method",
-      "description": "is_error=true completions per node.",
+      "title": "Pool bytes",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
-        "x": 18,
+        "w": 9,
+        "x": 6,
         "y": 59
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (node) (substrate_hop_pool_bytes{chain=~\"$chain\", node=~\"$node\"})",
+          "legendFormat": "{{node}} used"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (node) (substrate_hop_pool_max_bytes{chain=~\"$chain\", node=~\"$node\"})",
+          "legendFormat": "{{node}} max"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Pool entries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 15,
+        "y": 59
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (node) (substrate_hop_pool_entries{chain=~\"$chain\", node=~\"$node\"})",
+          "legendFormat": "{{node}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Inserted bytes rate",
+      "description": "Accounted size of accepted hop_submit blobs (includes per-recipient overhead).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 67
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (node) (rate(substrate_hop_pool_inserted_bytes_total{chain=~\"$chain\", node=~\"$node\"}[5m]))",
+          "legendFormat": "{{node}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Removals by reason",
+      "description": "acked = normal hand-off. expired_promoted = fell back to on-chain. expired_unpromoted = lost (upper bound). corrupt / startup_dropped = disk problems.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 8,
+        "y": 67
       },
       "fieldConfig": {
         "defaults": {
@@ -641,7 +739,319 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (method, node) (increase(substrate_rpc_calls_finished{chain=~\"$chain\", method=~\"hop_.*\", method!=\"hop_poolStatus\", node!~\".*rpc.*\", is_error=\"true\"}[$__rate_interval]))",
+          "expr": "sum by (node, reason) (increase(substrate_hop_pool_removed_total{chain=~\"$chain\", node=~\"$node\"}[$__rate_interval]))",
+          "legendFormat": "{{node}} {{reason}}"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Expired unpromoted (range)",
+      "description": "Entries that expired before any recipient claimed them and were not promoted on-chain. Upper bound on data loss; should stay at 0.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 67
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "decimals": 0
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(substrate_hop_pool_removed_total{chain=~\"$chain\", node=~\"$node\", reason=\"expired_unpromoted\"}[$__range]))"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Promotion",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 75
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Promotion backlog",
+      "description": "Unpromoted entries inside --hop-promotion-buffer-secs of expiry with attempts left, sampled every maintenance tick. Growing = promotion starved (tx pool, authorization, runtime API).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 76
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "custom": {
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (node) (substrate_hop_promotion_backlog{chain=~\"$chain\", node=~\"$node\"})",
+          "legendFormat": "{{node}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Promotions confirmed",
+      "description": "Entries whose on-chain promotion was observed in a block.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 76
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (node) (increase(substrate_hop_promotions_confirmed_total{chain=~\"$chain\", node=~\"$node\"}[$__rate_interval]))",
+          "legendFormat": "{{node}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Maintenance ticks (15m)",
+      "description": "Liveness of the hop-maintenance task. 0 = stalled (default --hop-check-interval is 300s, so expect ~3).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 76
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "custom": {
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (node) (increase(substrate_hop_maintenance_ticks_total{chain=~\"$chain\", node=~\"$node\"}[15m]))",
+          "legendFormat": "{{node}}"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "RPC",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 84
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "HOP calls by node/method",
+      "description": "From the RPC server (substrate_rpc_calls_*); hop_poolStatus excluded as probe noise.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 85
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (node, method) (increase(substrate_rpc_calls_started{chain=~\"$chain\", node=~\"$node\", method=~\"hop_.*\", method!=\"hop_poolStatus\"}[$__rate_interval]))",
+          "legendFormat": "{{node}} {{method}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HOP errors by method/reason",
+      "description": "reason = HopError variant. not_found on hop_ack is benign (entry already deleted after the final ack); pool_full, user_quota_exceeded, rate_limited, not_authorized are the ones to watch.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 85
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (node, method, reason) (increase(substrate_hop_rpc_errors_total{chain=~\"$chain\", node=~\"$node\"}[$__rate_interval]))",
+          "legendFormat": "{{node}} {{method}} {{reason}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HOP error ratio by method",
+      "description": "Errors / calls per method, excluding benign not_found and already_claimed (normal terminal states after a final ack).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 93
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "clamp_max(sum by (node, method) (rate(substrate_hop_rpc_errors_total{chain=~\"$chain\", node=~\"$node\", reason!~\"not_found|already_claimed\"}[5m])) / clamp_min(sum by (node, method) (rate(substrate_rpc_calls_started{chain=~\"$chain\", node=~\"$node\", method=~\"hop_.*\", method!=\"hop_poolStatus\"}[5m])), 1e-9), 1) or vector(0)",
           "legendFormat": "{{node}} {{method}}"
         }
       ]
@@ -656,8 +1066,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 67
+        "x": 12,
+        "y": 93
       },
       "fieldConfig": {
         "defaults": {
@@ -671,10 +1081,11 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le, method, node) (rate(substrate_rpc_calls_time_bucket{chain=~\"$chain\", method=~\"hop_.*\", method!=\"hop_poolStatus\", node!~\".*rpc.*\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, node, method) (rate(substrate_rpc_calls_time_bucket{chain=~\"$chain\", node=~\"$node\", method=~\"hop_.*\", method!=\"hop_poolStatus\"}[5m])))",
           "legendFormat": "{{node}} {{method}}"
         }
       ]
     }
-  ]
+  ],
+  "description": "Bulletin Paseo: chain liveness, IPFS, bitswap, and full HOP (substrate_hop_* pool/promotion/RPC, polkadot-sdk#12662)."
 }

--- a/utils/monitoring/bulletin-paseo-dashboard.json
+++ b/utils/monitoring/bulletin-paseo-dashboard.json
@@ -798,7 +798,7 @@
     },
     {
       "type": "row",
-      "title": "Promotion",
+      "title": "HOP promotion",
       "gridPos": {
         "h": 1,
         "w": 24,

--- a/utils/monitoring/bulletin-paseo-dashboard.json
+++ b/utils/monitoring/bulletin-paseo-dashboard.json
@@ -943,7 +943,7 @@
     },
     {
       "type": "row",
-      "title": "RPC",
+      "title": "HOP RPCs",
       "gridPos": {
         "h": 1,
         "w": 24,

--- a/zombienet-sdk-tests/tests/parachain_sync_storage.rs
+++ b/zombienet-sdk-tests/tests/parachain_sync_storage.rs
@@ -1134,7 +1134,8 @@ async fn parachain_ldb_storage_verification_test() -> Result<()> {
 	);
 
 	// Calculate when both stores should have expired
-	let expiration_block = second_store_block + LDB_TEST_RETENTION_PERIOD as u64 + 2; // +2 for safety margin
+	// +2 for safety margin
+	let expiration_block = second_store_block + LDB_TEST_RETENTION_PERIOD as u64 + 2;
 
 	tracing::info!(
 		"Waiting for block {} (second_store_block {} + retention {} + margin 2)",


### PR DESCRIPTION
Extends the Bulletin Paseo dashboard (uid `bulletin-paseo`) with the full HOP metric set from [`sc-hop`: add Prometheus metrics (polkadot-sdk#12662)](https://github.com/paritytech/polkadot-sdk/pull/12662), so pool, promotion and RPC health sit next to the existing liveness, IPFS and bitswap panels.

These metrics started flowing on Paseo after [devops-cloud-infra#4274](https://github.com/paritytech/devops-cloud-infra/pull/4274) bumped the bulletin-next collators to the master image with HOP metrics.

Added rows:
- Pool: fill %, bytes vs max, entries, inserted-bytes rate, removals by reason, expired-unpromoted (data-loss upper bound)
- Promotion: backlog, promotions confirmed, maintenance-tick liveness
- RPC: calls, errors by reason, error ratio (benign not_found/already_claimed excluded, clamped 0 to 100%), p95 latency

Adds a `node` template variable to scope panels per collator.

Verify against live Paseo data: https://grafana.teleport.parity.io/d/bulletin-paseo-new/bulletin-paseo-new?orgId=1&from=now-6h&to=now&timezone=utc&var-datasource=PC96415006F908B67&var-chain=$__all&var-node=$__all&refresh=1m
