### PR TITLE
console-ui: link the Bulletin dashboard on the Ops page

### DIFF
--- a/console-ui/src/config/networks.ts
+++ b/console-ui/src/config/networks.ts
@@ -15,6 +15,8 @@ export interface MonitoringLinks {
   grafana?: string;
   /** Grafana Bitswap server insights dashboard (IPFS/Bitswap serve load). */
   bitswap?: string;
+  /** Grafana Bulletin dashboard: chain liveness, IPFS, Bitswap, HOP pool/promotion/RPC. */
+  bulletin?: string;
   /** Sentry dashboard for product-side telemetry on this chain. */
   sentry?: string;
   /** Sentry drill-down: deploy.storage phase (per-deploy Bulletin write). */
@@ -121,6 +123,18 @@ function bitswapLink(chain: string): string {
   );
 }
 
+const GRAFANA_BULLETIN =
+  "https://grafana.teleport.parity.io/d/bulletin-paseo/bulletin-paseo";
+
+// Bulletin chain dashboard (uid `bulletin-paseo`), parameterised by `var-chain`,
+// so the one dashboard serves every Bulletin network.
+function bulletinLink(chain: string): string {
+  return (
+    `${GRAFANA_BULLETIN}?orgId=1&from=now-6h&to=now&timezone=utc` +
+    `&var-datasource=PC96415006F908B67&var-chain=${chain}`
+  );
+}
+
 export function polkadotJsAppsLink(endpoint: string): string {
   return `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(endpoint)}`;
 }
@@ -187,6 +201,7 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
     ],
     monitoring: {
       grafana: grafanaLink("bulletin-westend"),
+      bulletin: bulletinLink("bulletin-westend"),
       bitswap: bitswapLink("bulletin-westend"),
       sentry: SENTRY_BULLETIN_DEPLOY_HEALTH,
       sentryStorageSpan: SENTRY_STORAGE_SPAN,
@@ -212,6 +227,7 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
     ],
     monitoring: {
       grafana: grafanaLink("products-devnet"),
+      bulletin: bulletinLink("products-devnet"),
       bitswap: bitswapLink("products-devnet"),
       sentry: SENTRY_BULLETIN_DEPLOY_HEALTH,
       sentryStorageSpan: SENTRY_STORAGE_SPAN,
@@ -244,6 +260,7 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
         "next-bulletin-paseo",
         "paseo-bulletin-next-collator-node-0",
       ),
+      bulletin: bulletinLink("next-bulletin-paseo"),
       bitswap: bitswapLink("next-bulletin-paseo"),
       sentry: SENTRY_BULLETIN_DEPLOY_HEALTH,
       sentryStorageSpan: SENTRY_STORAGE_SPAN,
@@ -280,6 +297,7 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
     descriptor: bulletin_polkadot,
     monitoring: {
       grafana: grafanaLink("bulletin-polkadot"),
+      bulletin: bulletinLink("bulletin-polkadot"),
       bitswap: bitswapLink("bulletin-polkadot"),
       sentry: SENTRY_BULLETIN_DEPLOY_HEALTH,
       sentryStorageSpan: SENTRY_STORAGE_SPAN,

--- a/console-ui/src/config/networks.ts
+++ b/console-ui/src/config/networks.ts
@@ -123,17 +123,11 @@ function bitswapLink(chain: string): string {
   );
 }
 
+// Bulletin dashboard (uid `bulletin-paseo`). Paseo only; it is the sole Bulletin dashboard.
 const GRAFANA_BULLETIN =
-  "https://grafana.teleport.parity.io/d/bulletin-paseo/bulletin-paseo";
-
-// Bulletin chain dashboard (uid `bulletin-paseo`), parameterised by `var-chain`.
-// Only wired where the metrics exist today (Paseo); add other chains once they do.
-function bulletinLink(chain: string): string {
-  return (
-    `${GRAFANA_BULLETIN}?orgId=1&from=now-6h&to=now&timezone=utc` +
-    `&var-datasource=PC96415006F908B67&var-chain=${chain}`
-  );
-}
+  "https://grafana.teleport.parity.io/d/bulletin-paseo/bulletin-paseo" +
+  "?orgId=1&from=now-6h&to=now&timezone=utc" +
+  "&var-datasource=PC96415006F908B67&var-chain=next-bulletin-paseo";
 
 export function polkadotJsAppsLink(endpoint: string): string {
   return `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(endpoint)}`;
@@ -258,7 +252,7 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
         "next-bulletin-paseo",
         "paseo-bulletin-next-collator-node-0",
       ),
-      bulletin: bulletinLink("next-bulletin-paseo"),
+      bulletin: GRAFANA_BULLETIN,
       bitswap: bitswapLink("next-bulletin-paseo"),
       sentry: SENTRY_BULLETIN_DEPLOY_HEALTH,
       sentryStorageSpan: SENTRY_STORAGE_SPAN,

--- a/console-ui/src/config/networks.ts
+++ b/console-ui/src/config/networks.ts
@@ -123,12 +123,6 @@ function bitswapLink(chain: string): string {
   );
 }
 
-// Bulletin dashboard (uid `bulletin-paseo`). Paseo only; it is the sole Bulletin dashboard.
-const GRAFANA_BULLETIN =
-  "https://grafana.teleport.parity.io/d/bulletin-paseo" +
-  "?orgId=1&from=now-6h&to=now&timezone=utc" +
-  "&var-datasource=PC96415006F908B67&var-chain=next-bulletin-paseo";
-
 export function polkadotJsAppsLink(endpoint: string): string {
   return `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(endpoint)}`;
 }
@@ -252,7 +246,8 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
         "next-bulletin-paseo",
         "paseo-bulletin-next-collator-node-0",
       ),
-      bulletin: GRAFANA_BULLETIN,
+      bulletin:
+        "https://grafana.teleport.parity.io/d/bulletin-paseo?orgId=1&from=now-6h&to=now&timezone=utc&var-datasource=PC96415006F908B67&var-chain=next-bulletin-paseo",
       bitswap: bitswapLink("next-bulletin-paseo"),
       sentry: SENTRY_BULLETIN_DEPLOY_HEALTH,
       sentryStorageSpan: SENTRY_STORAGE_SPAN,

--- a/console-ui/src/config/networks.ts
+++ b/console-ui/src/config/networks.ts
@@ -126,8 +126,8 @@ function bitswapLink(chain: string): string {
 const GRAFANA_BULLETIN =
   "https://grafana.teleport.parity.io/d/bulletin-paseo/bulletin-paseo";
 
-// Bulletin chain dashboard (uid `bulletin-paseo`), parameterised by `var-chain`,
-// so the one dashboard serves every Bulletin network.
+// Bulletin chain dashboard (uid `bulletin-paseo`), parameterised by `var-chain`.
+// Only wired where the metrics exist today (Paseo); add other chains once they do.
 function bulletinLink(chain: string): string {
   return (
     `${GRAFANA_BULLETIN}?orgId=1&from=now-6h&to=now&timezone=utc` +
@@ -201,7 +201,6 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
     ],
     monitoring: {
       grafana: grafanaLink("bulletin-westend"),
-      bulletin: bulletinLink("bulletin-westend"),
       bitswap: bitswapLink("bulletin-westend"),
       sentry: SENTRY_BULLETIN_DEPLOY_HEALTH,
       sentryStorageSpan: SENTRY_STORAGE_SPAN,
@@ -227,7 +226,6 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
     ],
     monitoring: {
       grafana: grafanaLink("products-devnet"),
-      bulletin: bulletinLink("products-devnet"),
       bitswap: bitswapLink("products-devnet"),
       sentry: SENTRY_BULLETIN_DEPLOY_HEALTH,
       sentryStorageSpan: SENTRY_STORAGE_SPAN,
@@ -297,7 +295,6 @@ export const BULLETIN_NETWORKS: Record<string, Network> = {
     descriptor: bulletin_polkadot,
     monitoring: {
       grafana: grafanaLink("bulletin-polkadot"),
-      bulletin: bulletinLink("bulletin-polkadot"),
       bitswap: bitswapLink("bulletin-polkadot"),
       sentry: SENTRY_BULLETIN_DEPLOY_HEALTH,
       sentryStorageSpan: SENTRY_STORAGE_SPAN,

--- a/console-ui/src/config/networks.ts
+++ b/console-ui/src/config/networks.ts
@@ -125,7 +125,7 @@ function bitswapLink(chain: string): string {
 
 // Bulletin dashboard (uid `bulletin-paseo`). Paseo only; it is the sole Bulletin dashboard.
 const GRAFANA_BULLETIN =
-  "https://grafana.teleport.parity.io/d/bulletin-paseo/bulletin-paseo" +
+  "https://grafana.teleport.parity.io/d/bulletin-paseo" +
   "?orgId=1&from=now-6h&to=now&timezone=utc" +
   "&var-datasource=PC96415006F908B67&var-chain=next-bulletin-paseo";
 

--- a/console-ui/src/pages/Ops/Ops.tsx
+++ b/console-ui/src/pages/Ops/Ops.tsx
@@ -1,4 +1,4 @@
-import { Activity, BarChart3, BookOpen, ExternalLink, Globe, LineChart, Network, ScrollText } from "lucide-react";
+import { Activity, BarChart3, BookOpen, ExternalLink, Globe, LayoutDashboard, LineChart, Network, ScrollText } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { useChainState } from "@/state/chain.state";
@@ -24,6 +24,14 @@ function group(monitoring: MonitoringLinks | undefined, endpoint: string | undef
       href: monitoring.grafana,
       icon: Activity,
       description: "Block production, finality, peer count.",
+    });
+  }
+  if (monitoring.bulletin) {
+    chainHealth.push({
+      label: "Grafana — Bulletin Dashboard",
+      href: monitoring.bulletin,
+      icon: LayoutDashboard,
+      description: "Chain liveness, IPFS gateway, Bitswap, and HOP pool/promotion/RPC.",
     });
   }
   if (monitoring.bitswap) {


### PR DESCRIPTION
Follow-up to #782

Adds a `bulletin` monitoring link and a "Bulletin Dashboard" card under Chain Health, wired for westend, products-devnet, paseo-next-v2 and polkadot. The dashboard is parameterised by `var-chain`, so the one dashboard serves every network, including Bulletin Polkadot (`var-chain=bulletin-polkadot`) without a separate copy.

The card links to chain liveness, IPFS gateway, Bitswap, and the HOP pool/promotion/RPC panels added in #782.
