### PR TITLE
Bump bulletin-polkadot external runtime ref to v2.5.0

### DIFF
--- a/scripts/runtimes-matrix.json
+++ b/scripts/runtimes-matrix.json
@@ -48,7 +48,7 @@
     },
     "external_runtime": {
       "repo": "https://github.com/polkadot-fellows/runtimes.git",
-      "ref": "b3f18b26b80a2255dab06f78f70416358df64d61",
+      "ref": "3936c7e4d42b449b964e41bd7b69d5f1db1e3a1f",
       "path": "./system-parachains/bulletin/bulletin-polkadot"
     }
   },


### PR DESCRIPTION
 Updates the `bulletin-polkadot` entry in `scripts/runtimes-matrix.json` to track the polkadot-fellows/runtimes v2.5.0 release.

  - Ref: `b3f18b26b80a2255dab06f78f70416358df64d61` -> `3936c7e4d42b449b964e41bd7b69d5f1db1e3a1f`
  - Tag: https://github.com/polkadot-fellows/runtimes/releases/tag/v2.5.0
