### PR TITLE
Deduplicate HOP RPC signing into bulletin-hop-rpc-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,6 +2016,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "blake2",
+ "bulletin-hop-rpc-client",
  "bytes",
  "cid",
  "futures",
@@ -2034,6 +2035,15 @@ dependencies = [
  "twox-hash 2.1.2",
  "zombienet-orchestrator",
  "zombienet-sdk",
+]
+
+[[package]]
+name = "bulletin-hop-rpc-client"
+version = "0.1.0"
+dependencies = [
+ "blake2",
+ "hex",
+ "pallet-bulletin-hop-promotion",
 ]
 
 [[package]]
@@ -2142,6 +2152,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "blake2",
+ "bulletin-hop-rpc-client",
  "bytes",
  "cid",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ bulletin-transaction-storage-primitives = { version = "0.1.0", path = "pallets/t
 bulletin-westend-runtime = { path = "runtimes/bulletin-westend" }
 pallet-bulletin-data-renewal = { version = "0.1.0", path = "pallets/data-renewal", default-features = false }
 pallet-bulletin-hop-promotion = { version = "0.1.0", path = "pallets/hop-promotion", default-features = false }
+bulletin-hop-rpc-client = { path = "hop-rpc-client" }
 pallet-bulletin-transaction-storage = { version = "0.1.0", path = "pallets/transaction-storage", default-features = false }
 pallet-bulletin-transaction-storage-runtime-api = { version = "0.1.0", path = "pallets/transaction-storage/runtime-api", default-features = false }
 
@@ -132,6 +133,7 @@ members = [
 	"runtimes/bulletin-paseo",
 	"runtimes/bulletin-westend",
 	"runtimes/bulletin-westend/integration-tests",
+	"hop-rpc-client",
 	"sdk/rust",
 	"stress-test",
 	"zombienet-sdk-tests",

--- a/hop-rpc-client/Cargo.toml
+++ b/hop-rpc-client/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bulletin-hop-rpc-client"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+description = "Shared HOP JSON-RPC signing and SCALE encoding for Bulletin test tooling"
+publish = false
+
+[dependencies]
+blake2 = "0.10"
+hex.workspace = true
+pallet-bulletin-hop-promotion = { workspace = true, default-features = false, features = ["std"] }
+
+[dev-dependencies]
+pallet-bulletin-hop-promotion = { workspace = true, features = ["std"] }

--- a/hop-rpc-client/src/lib.rs
+++ b/hop-rpc-client/src/lib.rs
@@ -1,0 +1,104 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared HOP JSON-RPC signing payloads and `MultiSigner` / `MultiSignature` SCALE
+//! encoding used by Bulletin stress and zombienet test drivers.
+
+pub use pallet_bulletin_hop_promotion::HOP_SUBMIT_CONTEXT;
+
+/// Domain separator for `hop_claim` / `hop_ack` recipient signatures.
+pub const HOP_CLAIM_CONTEXT: &[u8] = b"hop-claim-v1:";
+
+pub fn blake2_256(data: &[u8]) -> [u8; 32] {
+	use blake2::{digest::consts::U32, Blake2b, Digest};
+	let mut hasher = Blake2b::<U32>::new();
+	hasher.update(data);
+	let result = hasher.finalize();
+	let mut output = [0u8; 32];
+	output.copy_from_slice(&result);
+	output
+}
+
+/// `blake2_256(HOP_SUBMIT_CONTEXT || blake2_256(data) || submit_timestamp.to_le_bytes())`.
+pub fn submit_signing_payload(data: &[u8], submit_timestamp_ms: u64) -> [u8; 32] {
+	let data_hash = blake2_256(data);
+	pallet_bulletin_hop_promotion::signing_payload(&data_hash, submit_timestamp_ms)
+}
+
+/// `blake2_256(context || hash)` — recipients sign this for claim/ack operations.
+pub fn op_signing_payload(context: &[u8], hash: &[u8]) -> [u8; 32] {
+	let mut buf = Vec::with_capacity(context.len() + hash.len());
+	buf.extend_from_slice(context);
+	buf.extend_from_slice(hash);
+	blake2_256(&buf)
+}
+
+/// SCALE-encoded `MultiSigner::Ed25519(pubkey)`.
+pub fn scale_multi_signer_ed25519(public_key: &[u8; 32]) -> Vec<u8> {
+	let mut buf = Vec::with_capacity(33);
+	buf.push(0x00);
+	buf.extend_from_slice(public_key);
+	buf
+}
+
+/// SCALE-encoded `MultiSignature::Ed25519(sig)`.
+pub fn scale_multi_signature_ed25519(signature: &[u8; 64]) -> Vec<u8> {
+	let mut buf = Vec::with_capacity(65);
+	buf.push(0x00);
+	buf.extend_from_slice(signature);
+	buf
+}
+
+/// SCALE-encoded `MultiSigner::Sr25519(pubkey)`.
+pub fn scale_multi_signer_sr25519(public_key: &[u8; 32]) -> Vec<u8> {
+	sr25519_scale(public_key)
+}
+
+/// SCALE-encoded `MultiSignature::Sr25519(sig)`.
+pub fn scale_multi_signature_sr25519(signature: &[u8; 64]) -> Vec<u8> {
+	sr25519_scale(signature)
+}
+
+/// SCALE variant index 1 + raw bytes (Sr25519 signer or signature).
+pub fn sr25519_scale(bytes: &[u8]) -> Vec<u8> {
+	let mut out = Vec::with_capacity(1 + bytes.len());
+	out.push(1u8);
+	out.extend_from_slice(bytes);
+	out
+}
+
+pub fn hex0x(bytes: &[u8]) -> String {
+	format!("0x{}", hex::encode(bytes))
+}
+
+pub fn now_ms() -> u64 {
+	use std::time::{SystemTime, UNIX_EPOCH};
+	SystemTime::now()
+		.duration_since(UNIX_EPOCH)
+		.map(|d| d.as_millis() as u64)
+		.unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn submit_signing_payload_matches_pallet() {
+		let data = b"hop-payload-test";
+		let ts = 1_700_000_000_123u64;
+		let data_hash = blake2_256(data);
+		assert_eq!(
+			submit_signing_payload(data, ts),
+			pallet_bulletin_hop_promotion::signing_payload(&data_hash, ts),
+		);
+	}
+
+	#[test]
+	fn sr25519_scale_prefixes_variant_index() {
+		let key = [7u8; 32];
+		let encoded = scale_multi_signer_sr25519(&key);
+		assert_eq!(encoded[0], 1);
+		assert_eq!(&encoded[1..], &key);
+	}
+}

--- a/stress-test/Cargo.toml
+++ b/stress-test/Cargo.toml
@@ -58,6 +58,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 hex = { workspace = true }
 rand = "0.8"
+bulletin-hop-rpc-client = { workspace = true }
 
 [build-dependencies]
 prost-build = "0.13"

--- a/stress-test/src/hop.rs
+++ b/stress-test/src/hop.rs
@@ -2,28 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{Context, Result};
+use bulletin_hop_rpc_client::{
+	blake2_256, hex0x, now_ms, op_signing_payload, scale_multi_signature_ed25519,
+	scale_multi_signer_ed25519, scale_multi_signature_sr25519, scale_multi_signer_sr25519,
+	submit_signing_payload, HOP_CLAIM_CONTEXT,
+};
 use ed25519_dalek::{Signer, SigningKey};
 use jsonrpsee::{core::client::ClientT, rpc_params, ws_client::WsClient};
 use rand::rngs::OsRng;
 use serde::Deserialize;
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::Instant;
 use subxt_signer::sr25519::Keypair;
-
-use crate::client;
-
-/// Domain-separator prefix the runtime uses when verifying `hop_submit` signatures.
-const HOP_SUBMIT_CONTEXT: &[u8] = b"hop-submit-v1:";
-
-/// Domain-separator prefix the runtime uses when verifying `hop_claim` signatures.
-const HOP_CLAIM_CONTEXT: &[u8] = b"hop-claim-v1:";
-
-/// `blake2_256(context || hash)` — recipients sign this for claim/ack operations.
-fn op_signing_payload(context: &[u8], hash: &[u8]) -> [u8; 32] {
-	let mut buf = Vec::with_capacity(context.len() + hash.len());
-	buf.extend_from_slice(context);
-	buf.extend_from_slice(hash);
-	client::blake2b_256(&buf)
-}
 
 // ---------------------------------------------------------------------------
 // Types matching the HOP RPC responses
@@ -64,66 +53,19 @@ impl RecipientKeypair {
 	}
 
 	/// SCALE-encoded `MultiSigner::Ed25519(pubkey)`.
-	/// MultiSigner enum variant 0 = Ed25519, so: `[0x00] ++ pubkey[32]`.
 	pub fn scale_multi_signer(&self) -> Vec<u8> {
-		let mut buf = Vec::with_capacity(33);
-		buf.push(0x00); // Ed25519 variant
-		buf.extend_from_slice(&self.public_bytes());
-		buf
+		scale_multi_signer_ed25519(&self.public_bytes())
 	}
 
 	/// Sign `msg` and return SCALE-encoded `MultiSignature::Ed25519(sig)`.
-	/// MultiSignature enum variant 0 = Ed25519, so: `[0x00] ++ sig[64]`.
 	pub fn sign_multi_signature(&self, msg: &[u8]) -> Vec<u8> {
 		let sig = self.signing_key.sign(msg);
-		let mut buf = Vec::with_capacity(65);
-		buf.push(0x00); // Ed25519 variant
-		buf.extend_from_slice(&sig.to_bytes());
-		buf
+		scale_multi_signature_ed25519(&sig.to_bytes())
 	}
 }
 
 // ---------------------------------------------------------------------------
 // Submitter helpers (sr25519, must be authorized by the runtime)
-// ---------------------------------------------------------------------------
-
-/// SCALE-encoded `MultiSigner::Sr25519(pubkey)`. Variant index 1, then 32-byte key.
-fn submitter_multi_signer(submitter: &Keypair) -> Vec<u8> {
-	let mut buf = Vec::with_capacity(33);
-	buf.push(0x01);
-	buf.extend_from_slice(&submitter.public_key().0);
-	buf
-}
-
-/// SCALE-encoded `MultiSignature::Sr25519(sig)`. Variant index 1, then 64-byte sig.
-fn submitter_multi_signature(submitter: &Keypair, msg: &[u8]) -> Vec<u8> {
-	let sig = submitter.sign(msg).0;
-	let mut buf = Vec::with_capacity(65);
-	buf.push(0x01);
-	buf.extend_from_slice(&sig);
-	buf
-}
-
-/// `blake2_256(HOP_SUBMIT_CONTEXT || blake2_256(data) || submit_timestamp.to_le_bytes())`
-/// — must match the runtime pallet's reconstruction byte-for-byte.
-fn submit_signing_payload(data: &[u8], submit_timestamp: u64) -> [u8; 32] {
-	let data_hash = client::blake2b_256(data);
-	let mut buf = Vec::with_capacity(HOP_SUBMIT_CONTEXT.len() + 32 + 8);
-	buf.extend_from_slice(HOP_SUBMIT_CONTEXT);
-	buf.extend_from_slice(&data_hash);
-	buf.extend_from_slice(&submit_timestamp.to_le_bytes());
-	client::blake2b_256(&buf)
-}
-
-fn now_ms() -> u64 {
-	SystemTime::now()
-		.duration_since(UNIX_EPOCH)
-		.expect("clock is past UNIX_EPOCH")
-		.as_millis() as u64
-}
-
-// ---------------------------------------------------------------------------
-// RPC helpers
 // ---------------------------------------------------------------------------
 
 /// Submit data to HOP pool. Returns (content_hash, submit_result, latency).
@@ -136,17 +78,17 @@ pub async fn hop_submit(
 	recipients: &[RecipientKeypair],
 	submitter: &Keypair,
 ) -> Result<([u8; 32], SubmitResult, std::time::Duration)> {
-	let data_hex = format!("0x{}", hex::encode(data));
+	let data_hex = hex0x(data);
 	let recipient_hexes: Vec<String> = recipients
 		.iter()
-		.map(|r| format!("0x{}", hex::encode(r.scale_multi_signer())))
+		.map(|r| hex0x(&r.scale_multi_signer()))
 		.collect();
 
 	let submit_timestamp = now_ms();
 	let payload = submit_signing_payload(data, submit_timestamp);
 	let signature_hex =
-		format!("0x{}", hex::encode(submitter_multi_signature(submitter, &payload)));
-	let signer_hex = format!("0x{}", hex::encode(submitter_multi_signer(submitter)));
+		hex0x(&scale_multi_signature_sr25519(&submitter.sign(&payload).0));
+	let signer_hex = hex0x(&scale_multi_signer_sr25519(&submitter.public_key().0));
 
 	let start = Instant::now();
 	let result: SubmitResult = ws
@@ -157,7 +99,7 @@ pub async fn hop_submit(
 		.await?;
 	let latency = start.elapsed();
 
-	let hash = client::blake2b_256(data);
+	let hash = blake2_256(data);
 	Ok((hash, result, latency))
 }
 
@@ -167,10 +109,10 @@ pub async fn hop_claim(
 	hash: &[u8],
 	recipient: &RecipientKeypair,
 ) -> Result<(Vec<u8>, std::time::Duration)> {
-	let hash_hex = format!("0x{}", hex::encode(hash));
+	let hash_hex = hex0x(hash);
 	let payload = op_signing_payload(HOP_CLAIM_CONTEXT, hash);
 	let signature = recipient.sign_multi_signature(&payload);
-	let sig_hex = format!("0x{}", hex::encode(&signature));
+	let sig_hex = hex0x(&signature);
 
 	let start = Instant::now();
 	let data_hex: String = ws.request("hop_claim", rpc_params![hash_hex, sig_hex]).await?;

--- a/zombienet-sdk-tests/Cargo.toml
+++ b/zombienet-sdk-tests/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "time"] }
 tracing = { workspace = true, default-features = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 twox-hash = "2"
+bulletin-hop-rpc-client = { workspace = true }
 
 # Zombienet SDK
 zombienet-sdk = "0.3.13"

--- a/zombienet-sdk-tests/tests/utils/hop_rpc.rs
+++ b/zombienet-sdk-tests/tests/utils/hop_rpc.rs
@@ -1,43 +1,18 @@
 // Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Raw `hop_submit` JSON-RPC client. Mirrors the on-chain construction of
-//! `MultiSigner`/`MultiSignature` + the submit signing payload so the test driver
-//! can stand in for `sc-hop`'s SDK side without pulling it in.
+//! Raw `hop_submit` JSON-RPC client. Uses [`bulletin_hop_rpc_client`] for signing payloads
+//! and SCALE encoding so stress-test and zombienet drivers share one implementation.
 
-use super::crypto::blake2_256;
+use bulletin_hop_rpc_client::{
+	hex0x, scale_multi_signature_sr25519, scale_multi_signer_sr25519, submit_signing_payload,
+};
 use anyhow::{anyhow, Result};
 use subxt::{
 	backend::rpc::RpcClient,
 	ext::subxt_rpcs::client::{rpc_params, RpcParams},
 };
 use subxt_signer::sr25519::Keypair;
-
-/// Must remain byte-identical to `pallet-bulletin-hop-promotion::HOP_SUBMIT_CONTEXT`.
-const HOP_SUBMIT_CONTEXT: &[u8] = b"hop-submit-v1:";
-
-/// `blake2_256(HOP_SUBMIT_CONTEXT || blake2_256(data) || submit_timestamp_ms.to_le_bytes())` —
-/// must remain byte-identical to the pallet's reconstruction.
-fn submit_signing_payload(data_hash: &[u8; 32], submit_timestamp_ms: u64) -> [u8; 32] {
-	let mut buf = Vec::with_capacity(HOP_SUBMIT_CONTEXT.len() + 32 + 8);
-	buf.extend_from_slice(HOP_SUBMIT_CONTEXT);
-	buf.extend_from_slice(data_hash);
-	buf.extend_from_slice(&submit_timestamp_ms.to_le_bytes());
-	blake2_256(&buf)
-}
-
-/// SCALE: variant index 1 + raw bytes. Used for both `MultiSigner::Sr25519`
-/// (1 + 32 bytes) and `MultiSignature::Sr25519` (1 + 64 bytes).
-fn sr25519_scale(bytes: &[u8]) -> Vec<u8> {
-	let mut out = Vec::with_capacity(1 + bytes.len());
-	out.push(1u8);
-	out.extend_from_slice(bytes);
-	out
-}
-
-fn hex0x(bytes: &[u8]) -> String {
-	format!("0x{}", hex::encode(bytes))
-}
 
 /// Submit `data` to a collator's HOP data pool via the `hop_submit` JSON-RPC. Returns
 /// the pool's entry count after insertion.
@@ -52,11 +27,10 @@ pub async fn hop_submit(
 		.await
 		.map_err(|e| anyhow!("connect {ws_uri}: {e}"))?;
 
-	let data_hash = blake2_256(data);
-	let payload = submit_signing_payload(&data_hash, submit_timestamp_ms);
-	let signature_scale = sr25519_scale(&signer.sign(&payload).0);
-	let signer_scale = sr25519_scale(&signer.public_key().0);
-	let recipients_hex: Vec<String> = recipients.iter().map(|r| hex0x(&sr25519_scale(r))).collect();
+	let payload = submit_signing_payload(data, submit_timestamp_ms);
+	let signature_scale = scale_multi_signature_sr25519(&signer.sign(&payload).0);
+	let signer_scale = scale_multi_signer_sr25519(&signer.public_key().0);
+	let recipients_hex: Vec<String> = recipients.iter().map(|r| hex0x(&scale_multi_signer_sr25519(r))).collect();
 
 	let mut params: RpcParams = rpc_params![hex0x(data), recipients_hex];
 	for p in [hex0x(&signature_scale), hex0x(&signer_scale)] {
@@ -75,13 +49,8 @@ pub async fn hop_submit(
 		.ok_or_else(|| anyhow!("hop_submit response missing poolStatus.entryCount: {value}"))
 }
 
-/// Wall-clock now in milliseconds since the unix epoch. Bound into the submit
-/// signing payload; the runtime rejects promotions whose timestamp falls outside
-/// `SubmitTimestampTolerance` of on-chain time.
-pub fn now_ms() -> u64 {
-	use std::time::{SystemTime, UNIX_EPOCH};
-	SystemTime::now()
-		.duration_since(UNIX_EPOCH)
-		.map(|d| d.as_millis() as u64)
-		.unwrap_or(0)
+pub fn content_hash(data: &[u8]) -> [u8; 32] {
+	bulletin_hop_rpc_client::blake2_256(data)
 }
+
+pub use bulletin_hop_rpc_client::now_ms;


### PR DESCRIPTION
## Summary

- Add workspace crate \ulletin-hop-rpc-client\ with shared HOP submit/claim signing payloads and \MultiSigner\/\MultiSignature\ SCALE encoding (reusing \pallet-bulletin-hop-promotion::signing_payload\).
- Rewire \stress-test/src/hop.rs\ and \zombienet-sdk-tests/tests/utils/hop_rpc.rs\ to consume the shared implementation.

Fixes #589.

## Duplication removed

Both crates previously duplicated \hop_submit\ signing payload construction and sr25519 SCALE encoding. The shared crate now owns that logic; each consumer keeps only its RPC transport wrapper (jsonrpsee vs subxt).

## Tests

\\\
cargo test -p bulletin-hop-rpc-client
# 2 passed
\\\


Made with [Cursor](https://cursor.com)