### PR TITLE
Clarify Bulletin Chain README and docs path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # Polkadot Bulletin Chain
 
-> [!WARNING]                                                                                                                            
+The Bulletin Chain is a parachain providing distributed data storage and retrieval infrastructure for the Polkadot ecosystem. It stores arbitrary data with proof-of-storage guarantees and makes it accessible via IPFS, with data retention managed over a configurable period (default ~14 days). It is run using Polkadot SDK's `polkadot-omni-node`.
+
+> [!WARNING]
 > This is a reference implementation provided for research, experimentation, and developer education. This code has not been fully audited. It is actively under development and may contain bugs, vulnerabilities, or incomplete features. It is not recommended for production use without independent review. Use at your own risk.
 
-The Bulletin Chain is a parachain providing distributed data storage and retrieval infrastructure for the Polkadot ecosystem. It stores arbitrary data with proof-of-storage guarantees and makes it accessible via IPFS, with data retention managed over a configurable period (default ~14 days). It is run using Polkadot SDK's `polkadot-omni-node`.
+## Documentation
+
+- [Start building with Bulletin Chain](https://docs.polkadot.com/chain-interactions/store-data/bulletin-chain/)
+- [Bulletin Chain Console](https://paritytech.github.io/polkadot-bulletin-chain/)
 
 [![License: GPL-3.0-only](https://img.shields.io/badge/license-GPL--3.0--only-blue.svg)](LICENSE)
 [![Security: unaudited](https://img.shields.io/badge/security-unaudited-red.svg)](https://github.com/paritytech/polkadot-bulletin-chain/security) 


### PR DESCRIPTION
Updates the README to make the project's purpose clear before the experimental warning and adds the canonical Polkadot developer documentation alongside the Bulletin Chain Console. Existing technical documentation and project details remain unchanged.