### PR TITLE
stress-test: HOP features/improvements

### DIFF
--- a/stress-test/README.md
+++ b/stress-test/README.md
@@ -241,17 +241,40 @@ for block-capacity variants (`1KB` ... `2MB`, `mixed`), or a scenario slug other
 (`sequential-upload`, `renew`, `hop-submit-100KB`, `hop-full-cycle`, `hop-group`,
 `hop-pool-fill`, `hop-mixed`, `bitswap-b2-c<concurrency>`, `bitswap-bulk-read`).
 
+The write path is counted along two axes. The `tx_offered_*`, `tx_accepted_*`, `tx_abandoned_*`
+and `tx_confirmed_*` families count **unique transactions** — each is incremented exactly once per
+extrinsic — while `submit_attempts_total` counts **RPC calls**, so a transaction that needed five
+tries contributes one `offered` and five `attempts`:
+
+```text
+attempts >= offered                          # equality means no retries at all
+retries per transaction = attempts / offered - 1
+offered = accepted + abandoned + in-flight   # in-flight = still being retried by a worker
+```
+
+`abandoned` does not mean lost data in every case: `reason="already_imported"` means the node
+already had the transaction and only this worker stopped tracking it. Every write-path
+`_bytes_total` counts uncompressed **payload** bytes so offered / accepted / abandoned / confirmed
+bytes are directly comparable; wire size is exposed separately as
+`bulletin_stress_tx_accepted_encoded_bytes_total`.
+
 Live metrics (updated at event time while a run is in flight):
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `bulletin_stress_tx_submitted_total` | counter | `variant` | Store extrinsics accepted by the node RPC (block-capacity pipeline) |
-| `bulletin_stress_tx_submitted_bytes_total` | counter | `variant` | Encoded extrinsic bytes accepted (offered load) |
-| `bulletin_stress_tx_errors_total` | counter | `variant`, `class` | Submission error/retry events (`pool_full`, `banned`, `exhausts_resources`, `dropped`, `already_imported`, `stale_nonce`, `future_nonce`, `connection_dead`, `other`) |
+| `bulletin_stress_tx_offered_total` | counter | `variant` | Store extrinsics the tool started trying to place, once per extrinsic (block-capacity pipeline) |
+| `bulletin_stress_tx_offered_bytes_total` | counter | `variant` | Uncompressed payload bytes offered |
+| `bulletin_stress_tx_accepted_total` | counter | `variant` | Store extrinsics accepted into a transaction pool, once per extrinsic |
+| `bulletin_stress_tx_accepted_bytes_total` | counter | `variant` | Uncompressed payload bytes accepted into a pool |
+| `bulletin_stress_tx_accepted_encoded_bytes_total` | counter | `variant` | SCALE-encoded extrinsic bytes accepted (wire size, incl. signature/call overhead) |
+| `bulletin_stress_tx_abandoned_total` | counter | `variant`, `reason` | Store extrinsics the worker stopped tracking, once per extrinsic (`dropped`, `already_imported`, `stale_nonce`, `future_nonce`, `connection_dead`, `other`) |
+| `bulletin_stress_tx_abandoned_bytes_total` | counter | `variant`, `reason` | Uncompressed payload bytes of abandoned extrinsics |
+| `bulletin_stress_submit_attempts_total` | counter | `variant`, `outcome` | Submission RPC calls, one per call (`accepted`, `pool_full`, `banned`, `exhausts_resources`, `dropped`, `already_imported`, `stale_nonce`, `future_nonce`, `connection_dead`, `other`) |
 | `bulletin_stress_tx_confirmed_total` | counter | `variant` | Store transactions confirmed in finalized blocks |
 | `bulletin_stress_tx_confirmed_bytes_total` | counter | `variant` | Uncompressed payload bytes confirmed in finalized blocks |
 | `bulletin_stress_blocks_observed_total` | counter | `variant` | Finalized blocks observed by the block monitor (including empty ones) |
 | `bulletin_stress_block_txs` | histogram | `variant` | Store transactions per observed block (block-fullness distribution; buckets up to the 512-tx cap) |
+| `bulletin_stress_block_bytes` | histogram | `variant` | Uncompressed payload bytes per observed block (buckets 64 KB → 12 MB, tight around the 8–9 MB band); Substrate exposes no block-size-in-bytes metric, so this is the only per-block size distribution |
 | `bulletin_stress_latency_seconds` | histogram | `variant`, `kind` | End-to-end latency (`inclusion`, `finalization`, `retrieval`) |
 | `bulletin_stress_reads_total` | counter | `variant`, `outcome` | Bitswap read attempts (`success` / `failure`) |
 | `bulletin_stress_read_bytes_total` | counter | `variant` | Bytes downloaded via Bitswap |

--- a/stress-test/README.md
+++ b/stress-test/README.md
@@ -241,28 +241,28 @@ for block-capacity variants (`1KB` ... `2MB`, `mixed`), or a scenario slug other
 (`sequential-upload`, `renew`, `hop-submit-100KB`, `hop-full-cycle`, `hop-group`,
 `hop-pool-fill`, `hop-mixed`, `bitswap-b2-c<concurrency>`, `bitswap-bulk-read`).
 
-The write path is counted along two axes. The `tx_offered_*`, `tx_accepted_*`, `tx_abandoned_*`
-and `tx_confirmed_*` families count **unique transactions** — each is incremented exactly once per
-extrinsic — while `submit_attempts_total` counts **RPC calls**, so a transaction that needed five
-tries contributes one `offered` and five `attempts`:
+The write path uses two separate counts. `tx_offered_*`, `tx_accepted_*`, `tx_abandoned_*` and
+`tx_confirmed_*` count **unique transactions** and increment once per extrinsic.
+`submit_attempts_total` counts **RPC calls**. A transaction that required five calls adds one to
+`offered` and five to `attempts`:
 
 ```text
-attempts >= offered                          # equality means no retries at all
+attempts >= offered                          # equal means no retries
 retries per transaction = attempts / offered - 1
-offered = accepted + abandoned + in-flight   # in-flight = still being retried by a worker
+offered = accepted + abandoned + in-flight   # in-flight = a worker is still retrying it
 ```
 
-`abandoned` does not mean lost data in every case: `reason="already_imported"` means the node
-already had the transaction and only this worker stopped tracking it. Every write-path
-`_bytes_total` counts uncompressed **payload** bytes so offered / accepted / abandoned / confirmed
-bytes are directly comparable; wire size is exposed separately as
+An abandoned transaction is not always lost data. `reason="already_imported"` means the node
+already contains the transaction and this worker stopped tracking it. Every write-path
+`_bytes_total` counts uncompressed **payload** bytes, so offered, accepted, abandoned and
+confirmed bytes are directly comparable. Wire size uses a separate metric,
 `bulletin_stress_tx_accepted_encoded_bytes_total`.
 
 Live metrics (updated at event time while a run is in flight):
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `bulletin_stress_tx_offered_total` | counter | `variant` | Store extrinsics the tool started trying to place, once per extrinsic (block-capacity pipeline) |
+| `bulletin_stress_tx_offered_total` | counter | `variant` | Store extrinsics the tool started submitting, once per extrinsic (block-capacity pipeline) |
 | `bulletin_stress_tx_offered_bytes_total` | counter | `variant` | Uncompressed payload bytes offered |
 | `bulletin_stress_tx_accepted_total` | counter | `variant` | Store extrinsics accepted into a transaction pool, once per extrinsic |
 | `bulletin_stress_tx_accepted_bytes_total` | counter | `variant` | Uncompressed payload bytes accepted into a pool |
@@ -274,7 +274,7 @@ Live metrics (updated at event time while a run is in flight):
 | `bulletin_stress_tx_confirmed_bytes_total` | counter | `variant` | Uncompressed payload bytes confirmed in finalized blocks |
 | `bulletin_stress_blocks_observed_total` | counter | `variant` | Finalized blocks observed by the block monitor (including empty ones) |
 | `bulletin_stress_block_txs` | histogram | `variant` | Store transactions per observed block (block-fullness distribution; buckets up to the 512-tx cap) |
-| `bulletin_stress_block_bytes` | histogram | `variant` | Uncompressed payload bytes per observed block (buckets 64 KB → 12 MB, tight around the 8–9 MB band); Substrate exposes no block-size-in-bytes metric, so this is the only per-block size distribution |
+| `bulletin_stress_block_bytes` | histogram | `variant` | Uncompressed payload bytes per observed block (buckets 64 KB to 12 MB, narrow between 8 MB and 9 MB). Substrate has no block-size-in-bytes metric, so this is the only per-block size distribution |
 | `bulletin_stress_latency_seconds` | histogram | `variant`, `kind` | End-to-end latency (`inclusion`, `finalization`, `retrieval`) |
 | `bulletin_stress_reads_total` | counter | `variant`, `outcome` | Bitswap read attempts (`success` / `failure`) |
 | `bulletin_stress_read_bytes_total` | counter | `variant` | Bytes downloaded via Bitswap |

--- a/stress-test/src/client.rs
+++ b/stress-test/src/client.rs
@@ -100,6 +100,40 @@ pub async fn connect_ws(ws_url: &str) -> Result<jsonrpsee::ws_client::WsClient> 
 	Ok(client)
 }
 
+/// `connect_ws` with linear backoff, for long-running loops that own one connection.
+///
+/// `WsClient` never reconnects: once the transport dies - the node restarts, the ingress
+/// drops the stream - every later request fails with `RestartNeeded` forever. A DNS blip
+/// at dial time is just as terminal. Either one silently takes a worker out for the whole
+/// run unless it redials, so long-lived workers must call this rather than `connect_ws`.
+pub async fn connect_ws_retry(
+	ws_url: &str,
+	attempts: usize,
+) -> Result<jsonrpsee::ws_client::WsClient> {
+	let attempts = attempts.max(1);
+	let mut last_err = None;
+	for attempt in 1..=attempts {
+		match connect_ws(ws_url).await {
+			Ok(client) => {
+				if attempt > 1 {
+					tracing::info!("connected to {ws_url} on attempt {attempt}/{attempts}");
+				}
+				return Ok(client);
+			},
+			Err(e) => {
+				if attempt < attempts {
+					tracing::warn!(
+						"connect to {ws_url} failed (attempt {attempt}/{attempts}): {e}; retrying"
+					);
+					tokio::time::sleep(std::time::Duration::from_secs(attempt.min(5) as u64)).await;
+				}
+				last_err = Some(e);
+			},
+		}
+	}
+	Err(last_err.expect("at least one attempt is made")).context(format!("connecting to {ws_url}"))
+}
+
 /// Compute blake2b-256 hash (same as the runtime's `content_hash` for `store` calls).
 pub fn blake2b_256(data: &[u8]) -> [u8; 32] {
 	use blake2::digest::{consts::U32, Digest};

--- a/stress-test/src/client.rs
+++ b/stress-test/src/client.rs
@@ -100,12 +100,13 @@ pub async fn connect_ws(ws_url: &str) -> Result<jsonrpsee::ws_client::WsClient> 
 	Ok(client)
 }
 
-/// `connect_ws` with linear backoff, for long-running loops that own one connection.
+/// `connect_ws` with linear backoff. Use this in loops that keep one connection for the
+/// whole run.
 ///
-/// `WsClient` never reconnects: once the transport dies - the node restarts, the ingress
-/// drops the stream - every later request fails with `RestartNeeded` forever. A DNS blip
-/// at dial time is just as terminal. Either one silently takes a worker out for the whole
-/// run unless it redials, so long-lived workers must call this rather than `connect_ws`.
+/// `WsClient` does not reconnect. After the node restarts or the connection drops, every
+/// later request on that client fails with `RestartNeeded`. A DNS failure at connect time
+/// has the same effect: the worker never connects. Both cases stop the worker for the rest
+/// of the run unless it connects again.
 pub async fn connect_ws_retry(
 	ws_url: &str,
 	attempts: usize,

--- a/stress-test/src/hop.rs
+++ b/stress-test/src/hop.rs
@@ -21,24 +21,24 @@ const HOP_CLAIM_CONTEXT: &[u8] = b"hop-claim-v1:";
 /// Distinct from the claim context: a claim signature is not a valid ack signature.
 const HOP_ACK_CONTEXT: &[u8] = b"hop-ack-v1:";
 
-// Numeric codes from `sc-hop`'s `HopError -> ErrorObjectOwned` mapping. Classify on
-// these rather than on `Display` text: the codes are the RPC contract, and matching
-// substrings of the message conflates errors whose wording happens to overlap.
+// Numeric codes from the `HopError -> ErrorObjectOwned` mapping in `sc-hop`. Match on these
+// codes, not on the `Display` text. Two different errors can contain the same substring, so
+// substring matching classifies them incorrectly.
 
-/// `HopError::PoolFull` — the node's pool is at `--hop-max-pool-size`. Node-wide, so it
-/// clears only as entries are acked or expire; rotating accounts does not help.
+/// `HopError::PoolFull`. The node pool reached `--hop-max-pool-size`. The limit applies to
+/// the whole node, so no other account can submit until entries are acked or expire.
 pub const HOP_ERR_POOL_FULL: i32 = 1002;
 
-/// `HopError::NotFound`. Acking an entry that is already gone - fully acked by every
-/// recipient, or expired - is a benign terminal state rather than a failure.
+/// `HopError::NotFound`. The entry no longer exists, either because every recipient acked it
+/// or because it expired. Treat this as success when acking.
 const HOP_ERR_NOT_FOUND: i32 = 1004;
 
-/// `HopError::UserQuotaExceeded` — `--hop-max-user-size` is spent for this
-/// `(node, account)` pair. Another account still has its own budget on the same node.
+/// `HopError::UserQuotaExceeded`. This account used up `--hop-max-user-size` on this node.
+/// Other accounts still have their own quota on the same node.
 pub const HOP_ERR_USER_QUOTA: i32 = 1011;
 
-/// `HopError::RateLimited` — the per-account token bucket is empty. Transient, and
-/// per account, so another account can submit immediately.
+/// `HopError::RateLimited`. The rate limit for this account is exceeded. The limit is per
+/// account, so another account can submit immediately.
 pub const HOP_ERR_RATE_LIMITED: i32 = 1020;
 
 /// `blake2_256(context || hash)` — recipients sign this for claim/ack operations.
@@ -207,9 +207,10 @@ pub async fn hop_claim(
 
 /// Acknowledge claimed data. Returns latency.
 ///
-/// Claiming only reads: the node holds the entry until *every* recipient has acked, so a
-/// claim without an ack leaves the payload occupying both the pool and the submitter's
-/// per-user byte budget until it expires. Callers that claim should ack.
+/// A claim only reads the entry. The node keeps the entry until every recipient acks it. If
+/// the caller claims without acking, the payload stays in the pool and continues to count
+/// against the submitter's per-user byte quota until the entry expires. Callers that claim
+/// should also ack.
 pub async fn hop_ack(
 	ws: &WsClient,
 	hash: &[u8],
@@ -255,11 +256,12 @@ pub fn error_code(err: &anyhow::Error) -> Option<i32> {
 	}
 }
 
-/// Whether the WS transport itself failed, as opposed to the node rejecting the call.
+/// Returns true when the WebSocket connection failed, rather than the node rejecting the
+/// call.
 ///
-/// `WsClient` does not reconnect, so a caller that keeps one connection for the length of
-/// a run must redial when this returns true; retrying on the same client only repeats the
-/// same failure.
+/// `WsClient` does not reconnect. A caller that keeps one connection for the whole run must
+/// connect again when this returns true. Retrying on the same client produces the same
+/// failure.
 pub fn is_transport_error(err: &anyhow::Error) -> bool {
 	use jsonrpsee::core::ClientError;
 	matches!(

--- a/stress-test/src/hop.rs
+++ b/stress-test/src/hop.rs
@@ -17,6 +17,14 @@ const HOP_SUBMIT_CONTEXT: &[u8] = b"hop-submit-v1:";
 /// Domain-separator prefix the runtime uses when verifying `hop_claim` signatures.
 const HOP_CLAIM_CONTEXT: &[u8] = b"hop-claim-v1:";
 
+/// Domain-separator prefix the runtime uses when verifying `hop_ack` signatures.
+/// Distinct from the claim context: a claim signature is not a valid ack signature.
+const HOP_ACK_CONTEXT: &[u8] = b"hop-ack-v1:";
+
+/// `HopError::NotFound`. Acking an entry that is already gone - fully acked by every
+/// recipient, or expired - is a benign terminal state rather than a failure.
+const HOP_ERR_NOT_FOUND: i32 = 1004;
+
 /// `blake2_256(context || hash)` — recipients sign this for claim/ack operations.
 fn op_signing_payload(context: &[u8], hash: &[u8]) -> [u8; 32] {
 	let mut buf = Vec::with_capacity(context.len() + hash.len());
@@ -179,6 +187,38 @@ pub async fn hop_claim(
 	let data = hex::decode(data_hex.strip_prefix("0x").unwrap_or(&data_hex))
 		.context("decoding claimed data")?;
 	Ok((data, latency))
+}
+
+/// Acknowledge claimed data. Returns latency.
+///
+/// Claiming only reads: the node holds the entry until *every* recipient has acked, so a
+/// claim without an ack leaves the payload occupying both the pool and the submitter's
+/// per-user byte budget until it expires. Callers that claim should ack.
+pub async fn hop_ack(
+	ws: &WsClient,
+	hash: &[u8],
+	recipient: &RecipientKeypair,
+) -> Result<std::time::Duration> {
+	let hash_hex = format!("0x{}", hex::encode(hash));
+	let payload = op_signing_payload(HOP_ACK_CONTEXT, hash);
+	let signature = recipient.sign_multi_signature(&payload);
+	let sig_hex = format!("0x{}", hex::encode(&signature));
+
+	let start = Instant::now();
+	let outcome = ws.request::<(), _>("hop_ack", rpc_params![hash_hex, sig_hex]).await;
+	let latency = start.elapsed();
+
+	match outcome {
+		Ok(()) => Ok(latency),
+		Err(err) => {
+			let err = anyhow::Error::new(err);
+			if error_code(&err) == Some(HOP_ERR_NOT_FOUND) {
+				Ok(latency)
+			} else {
+				Err(err).context("hop_ack")
+			}
+		},
+	}
 }
 
 /// Get pool status.

--- a/stress-test/src/hop.rs
+++ b/stress-test/src/hop.rs
@@ -21,9 +21,25 @@ const HOP_CLAIM_CONTEXT: &[u8] = b"hop-claim-v1:";
 /// Distinct from the claim context: a claim signature is not a valid ack signature.
 const HOP_ACK_CONTEXT: &[u8] = b"hop-ack-v1:";
 
+// Numeric codes from `sc-hop`'s `HopError -> ErrorObjectOwned` mapping. Classify on
+// these rather than on `Display` text: the codes are the RPC contract, and matching
+// substrings of the message conflates errors whose wording happens to overlap.
+
+/// `HopError::PoolFull` — the node's pool is at `--hop-max-pool-size`. Node-wide, so it
+/// clears only as entries are acked or expire; rotating accounts does not help.
+pub const HOP_ERR_POOL_FULL: i32 = 1002;
+
 /// `HopError::NotFound`. Acking an entry that is already gone - fully acked by every
 /// recipient, or expired - is a benign terminal state rather than a failure.
 const HOP_ERR_NOT_FOUND: i32 = 1004;
+
+/// `HopError::UserQuotaExceeded` — `--hop-max-user-size` is spent for this
+/// `(node, account)` pair. Another account still has its own budget on the same node.
+pub const HOP_ERR_USER_QUOTA: i32 = 1011;
+
+/// `HopError::RateLimited` — the per-account token bucket is empty. Transient, and
+/// per account, so another account can submit immediately.
+pub const HOP_ERR_RATE_LIMITED: i32 = 1020;
 
 /// `blake2_256(context || hash)` — recipients sign this for claim/ack operations.
 fn op_signing_payload(context: &[u8], hash: &[u8]) -> [u8; 32] {
@@ -237,6 +253,21 @@ pub fn error_code(err: &anyhow::Error) -> Option<i32> {
 		Some(jsonrpsee::core::ClientError::Call(obj)) => Some(obj.code()),
 		_ => None,
 	}
+}
+
+/// Whether the WS transport itself failed, as opposed to the node rejecting the call.
+///
+/// `WsClient` does not reconnect, so a caller that keeps one connection for the length of
+/// a run must redial when this returns true; retrying on the same client only repeats the
+/// same failure.
+pub fn is_transport_error(err: &anyhow::Error) -> bool {
+	use jsonrpsee::core::ClientError;
+	matches!(
+		err.downcast_ref::<ClientError>(),
+		Some(
+			ClientError::RestartNeeded(_) | ClientError::Transport(_) | ClientError::RequestTimeout
+		)
+	)
 }
 
 // ---------------------------------------------------------------------------

--- a/stress-test/src/main.rs
+++ b/stress-test/src/main.rs
@@ -41,6 +41,16 @@ struct Cli {
 	#[arg(long, default_value = "//Alice", global = true)]
 	authorizer_seed: String,
 
+	/// Number of distinct HOP submitter accounts to derive and authorize.
+	///
+	/// The node caps pool bytes per `(node, submitter)` pair via `--hop-max-user-size`, so
+	/// filling a pool larger than that cap needs several submitters: at a 256 MiB cap and a
+	/// 10 GiB pool, 40. Only `pool-fill` spreads across them; the other scenarios use the
+	/// first, since each of their writers already targets a different node and so already
+	/// has its own quota.
+	#[arg(long, default_value = "1", global = true)]
+	hop_submitters: usize,
+
 	/// Number of unique items per size (for bitswap read tests)
 	#[arg(long, default_value = "512", global = true)]
 	iterations: u32,
@@ -401,12 +411,13 @@ async fn run_once(cli: &Cli, ws_urls: &[String], cancel: &Arc<AtomicBool>) -> Re
 			}
 		},
 		Commands::Hop { ref scenario, items, payload_size, concurrency, recipients, duration } =>
-			match authorize_hop_submitter(&client, &authorizer_signer, &nonce_tracker).await {
+			match authorize_hop_submitters(&client, &authorizer_signer, &nonce_tracker, cli.hop_submitters)
+					.await {
 				Err(e) => {
 					tracing::error!("Failed to authorize HOP submitter: {e}");
 					command_error = Some(e);
 				},
-				Ok(submitter) =>
+				Ok(submitters) =>
 					if let Err(e) = scenarios::hop::run_hop_sweep(
 						&ws_url_refs,
 						scenario,
@@ -415,7 +426,7 @@ async fn run_once(cli: &Cli, ws_urls: &[String], cancel: &Arc<AtomicBool>) -> Re
 						concurrency,
 						recipients,
 						duration,
-						&submitter,
+						&submitters,
 						&mut all_results,
 						&flush,
 						cancel,
@@ -491,12 +502,13 @@ async fn run_once(cli: &Cli, ws_urls: &[String], cancel: &Arc<AtomicBool>) -> Re
 				}
 			}
 			if command_error.is_none() && !cancel.load(Ordering::Relaxed) {
-				match authorize_hop_submitter(&client, &authorizer_signer, &nonce_tracker).await {
+				match authorize_hop_submitters(&client, &authorizer_signer, &nonce_tracker, cli.hop_submitters)
+					.await {
 					Err(e) => {
 						tracing::error!("Failed to authorize HOP submitter: {e}");
 						command_error = Some(e);
 					},
-					Ok(submitter) =>
+					Ok(submitters) =>
 						if let Err(e) = scenarios::hop::run_hop_sweep(
 							&ws_url_refs,
 							"all",
@@ -505,7 +517,7 @@ async fn run_once(cli: &Cli, ws_urls: &[String], cancel: &Arc<AtomicBool>) -> Re
 							4,
 							10,
 							30,
-							&submitter,
+							&submitters,
 							&mut all_results,
 							&flush,
 							cancel,
@@ -675,29 +687,49 @@ async fn run_bitswap(
 /// HOP's `can_account_promote` reads from
 /// `pallet-bulletin-transaction-storage::AccountAuthorization`. The numeric extents (`u32::MAX`
 /// txs, ~1 GiB) only bound the storage pallet; HOP just needs an unexpired entry to exist.
-async fn authorize_hop_submitter(
+async fn authorize_hop_submitters(
 	client: &subxt::OnlineClient<client::BulletinConfig>,
 	authorizer: &subxt_signer::sr25519::Keypair,
 	nonce_tracker: &accounts::NonceTracker,
-) -> Result<Keypair> {
-	let submitter_uri: subxt_signer::SecretUri =
-		"//HopSubmitter".parse().expect("static submitter seed is valid");
-	let submitter = Keypair::from_uri(&submitter_uri)
-		.map_err(|e| anyhow::anyhow!("Failed to create HOP submitter keypair: {e}"))?;
-	let submitter_id = submitter.public_key().to_account_id();
+	count: usize,
+) -> Result<Vec<Keypair>> {
+	let count = count.max(1);
+	// Index 0 keeps the original `//HopSubmitter` derivation so a single-submitter run
+	// authorizes the same account it always has.
+	let submitters = (0..count)
+		.map(|i| {
+			let uri = if i == 0 {
+				"//HopSubmitter".to_string()
+			} else {
+				format!("//HopSubmitter/{i}")
+			};
+			let uri: subxt_signer::SecretUri =
+				uri.parse().expect("derived submitter seed is valid");
+			Keypair::from_uri(&uri)
+				.map_err(|e| anyhow::anyhow!("Failed to create HOP submitter keypair: {e}"))
+		})
+		.collect::<Result<Vec<_>>>()?;
+	let submitter_ids: Vec<_> =
+		submitters.iter().map(|k| k.public_key().to_account_id()).collect();
 	tracing::info!(
-		"Authorizing HOP submitter {submitter_id} via TransactionStorage::authorize_account"
+		"Authorizing {} HOP submitter(s) via TransactionStorage::authorize_account: {}",
+		submitter_ids.len(),
+		submitter_ids
+			.iter()
+			.map(|id| id.to_string())
+			.collect::<Vec<_>>()
+			.join(", ")
 	);
 	authorize::authorize_account_batch(
 		client,
 		authorizer,
 		nonce_tracker,
-		&[submitter_id],
+		&submitter_ids,
 		u32::MAX,
 		1024 * 1024 * 1024,
 	)
 	.await?;
-	Ok(submitter)
+	Ok(submitters)
 }
 
 /// Resolve P2P multiaddrs from CLI args or RPC auto-discovery.

--- a/stress-test/src/main.rs
+++ b/stress-test/src/main.rs
@@ -204,6 +204,15 @@ enum Commands {
 		/// still acking.
 		#[arg(long)]
 		writers: Option<usize>,
+
+		/// Fraction of claimed entries the mixed scenario acks, 0.0..=1.0.
+		///
+		/// An ack releases the entry, so at 1.0 the pools stay near empty no matter how
+		/// many writers run - outflow matches inflow exactly. Lower it to leave the
+		/// balance resident until `--hop-retention-secs` expires it, which grows the
+		/// pools while still exercising claim and ack.
+		#[arg(long, default_value = "1.0")]
+		ack_ratio: f64,
 	},
 	/// Run all test suites (block-capacity + bitswap + hop)
 	Full,
@@ -427,6 +436,7 @@ async fn run_once(cli: &Cli, ws_urls: &[String], cancel: &Arc<AtomicBool>) -> Re
 			recipients,
 			duration,
 			writers,
+			ack_ratio,
 		} => match authorize_hop_submitters(
 			&client,
 			&authorizer_signer,
@@ -449,6 +459,7 @@ async fn run_once(cli: &Cli, ws_urls: &[String], cancel: &Arc<AtomicBool>) -> Re
 					recipients,
 					duration,
 					writers,
+					ack_ratio,
 					&submitters,
 					&mut all_results,
 					&flush,
@@ -547,6 +558,7 @@ async fn run_once(cli: &Cli, ws_urls: &[String], cancel: &Arc<AtomicBool>) -> Re
 							10,
 							30,
 							None,
+							1.0,
 							&submitters,
 							&mut all_results,
 							&flush,

--- a/stress-test/src/main.rs
+++ b/stress-test/src/main.rs
@@ -195,6 +195,15 @@ enum Commands {
 		/// Duration in seconds (for mixed scenario)
 		#[arg(long, default_value = "30")]
 		duration: u64,
+
+		/// Writer tasks for the mixed scenario; readers get the rest of `--concurrency`.
+		///
+		/// Writers pick the node, so all nodes are exercised only with at least one writer
+		/// per node. Defaults to half of `--concurrency`, which leaves claims tracking
+		/// submits and the pool near empty; skew toward writers to make the pool grow while
+		/// still acking.
+		#[arg(long)]
+		writers: Option<usize>,
 	},
 	/// Run all test suites (block-capacity + bitswap + hop)
 	Full,
@@ -410,39 +419,47 @@ async fn run_once(cli: &Cli, ws_urls: &[String], cancel: &Arc<AtomicBool>) -> Re
 				command_error = Some(e);
 			}
 		},
-		Commands::Hop { ref scenario, items, payload_size, concurrency, recipients, duration } =>
-			match authorize_hop_submitters(
-				&client,
-				&authorizer_signer,
-				&nonce_tracker,
-				cli.hop_submitters,
-			)
-			.await
-			{
-				Err(e) => {
-					tracing::error!("Failed to authorize HOP submitter: {e}");
+		Commands::Hop {
+			ref scenario,
+			items,
+			payload_size,
+			concurrency,
+			recipients,
+			duration,
+			writers,
+		} => match authorize_hop_submitters(
+			&client,
+			&authorizer_signer,
+			&nonce_tracker,
+			cli.hop_submitters,
+		)
+		.await
+		{
+			Err(e) => {
+				tracing::error!("Failed to authorize HOP submitter: {e}");
+				command_error = Some(e);
+			},
+			Ok(submitters) =>
+				if let Err(e) = scenarios::hop::run_hop_sweep(
+					&ws_url_refs,
+					scenario,
+					items,
+					payload_size,
+					concurrency,
+					recipients,
+					duration,
+					writers,
+					&submitters,
+					&mut all_results,
+					&flush,
+					cancel,
+				)
+				.await
+				{
+					tracing::error!("HOP command failed: {e}");
 					command_error = Some(e);
 				},
-				Ok(submitters) =>
-					if let Err(e) = scenarios::hop::run_hop_sweep(
-						&ws_url_refs,
-						scenario,
-						items,
-						payload_size,
-						concurrency,
-						recipients,
-						duration,
-						&submitters,
-						&mut all_results,
-						&flush,
-						cancel,
-					)
-					.await
-					{
-						tracing::error!("HOP command failed: {e}");
-						command_error = Some(e);
-					},
-			},
+		},
 		Commands::Renew { store_count, chunk_size, target_blocks } => {
 			if let Err(e) = scenarios::renew::run_renew_stress(
 				&client,
@@ -529,6 +546,7 @@ async fn run_once(cli: &Cli, ws_urls: &[String], cancel: &Arc<AtomicBool>) -> Re
 							4,
 							10,
 							30,
+							None,
 							&submitters,
 							&mut all_results,
 							&flush,

--- a/stress-test/src/main.rs
+++ b/stress-test/src/main.rs
@@ -411,8 +411,14 @@ async fn run_once(cli: &Cli, ws_urls: &[String], cancel: &Arc<AtomicBool>) -> Re
 			}
 		},
 		Commands::Hop { ref scenario, items, payload_size, concurrency, recipients, duration } =>
-			match authorize_hop_submitters(&client, &authorizer_signer, &nonce_tracker, cli.hop_submitters)
-					.await {
+			match authorize_hop_submitters(
+				&client,
+				&authorizer_signer,
+				&nonce_tracker,
+				cli.hop_submitters,
+			)
+			.await
+			{
 				Err(e) => {
 					tracing::error!("Failed to authorize HOP submitter: {e}");
 					command_error = Some(e);
@@ -502,8 +508,14 @@ async fn run_once(cli: &Cli, ws_urls: &[String], cancel: &Arc<AtomicBool>) -> Re
 				}
 			}
 			if command_error.is_none() && !cancel.load(Ordering::Relaxed) {
-				match authorize_hop_submitters(&client, &authorizer_signer, &nonce_tracker, cli.hop_submitters)
-					.await {
+				match authorize_hop_submitters(
+					&client,
+					&authorizer_signer,
+					&nonce_tracker,
+					cli.hop_submitters,
+				)
+				.await
+				{
 					Err(e) => {
 						tracing::error!("Failed to authorize HOP submitter: {e}");
 						command_error = Some(e);
@@ -698,27 +710,19 @@ async fn authorize_hop_submitters(
 	// authorizes the same account it always has.
 	let submitters = (0..count)
 		.map(|i| {
-			let uri = if i == 0 {
-				"//HopSubmitter".to_string()
-			} else {
-				format!("//HopSubmitter/{i}")
-			};
+			let uri =
+				if i == 0 { "//HopSubmitter".to_string() } else { format!("//HopSubmitter/{i}") };
 			let uri: subxt_signer::SecretUri =
 				uri.parse().expect("derived submitter seed is valid");
 			Keypair::from_uri(&uri)
 				.map_err(|e| anyhow::anyhow!("Failed to create HOP submitter keypair: {e}"))
 		})
 		.collect::<Result<Vec<_>>>()?;
-	let submitter_ids: Vec<_> =
-		submitters.iter().map(|k| k.public_key().to_account_id()).collect();
+	let submitter_ids: Vec<_> = submitters.iter().map(|k| k.public_key().to_account_id()).collect();
 	tracing::info!(
 		"Authorizing {} HOP submitter(s) via TransactionStorage::authorize_account: {}",
 		submitter_ids.len(),
-		submitter_ids
-			.iter()
-			.map(|id| id.to_string())
-			.collect::<Vec<_>>()
-			.join(", ")
+		submitter_ids.iter().map(|id| id.to_string()).collect::<Vec<_>>().join(", ")
 	);
 	authorize::authorize_account_batch(
 		client,

--- a/stress-test/src/main.rs
+++ b/stress-test/src/main.rs
@@ -41,13 +41,13 @@ struct Cli {
 	#[arg(long, default_value = "//Alice", global = true)]
 	authorizer_seed: String,
 
-	/// Number of distinct HOP submitter accounts to derive and authorize.
+	/// Number of HOP submitter accounts to derive and authorize.
 	///
-	/// The node caps pool bytes per `(node, submitter)` pair via `--hop-max-user-size`, so
-	/// filling a pool larger than that cap needs several submitters: at a 256 MiB cap and a
-	/// 10 GiB pool, 40. Only `pool-fill` spreads across them; the other scenarios use the
-	/// first, since each of their writers already targets a different node and so already
-	/// has its own quota.
+	/// `--hop-max-user-size` limits pool bytes per `(node, submitter)` pair. Filling a pool
+	/// larger than that limit requires several accounts. A 256 MiB limit and a 10 GiB pool
+	/// require 40. Only `pool-fill` and `mixed` use more than one account. The other
+	/// scenarios use the first account, because each of their writers submits to a different
+	/// node and therefore has a separate quota.
 	#[arg(long, default_value = "1", global = true)]
 	hop_submitters: usize,
 
@@ -196,21 +196,19 @@ enum Commands {
 		#[arg(long, default_value = "30")]
 		duration: u64,
 
-		/// Writer tasks for the mixed scenario; readers get the rest of `--concurrency`.
+		/// Writer tasks for the mixed scenario. Readers use the rest of `--concurrency`.
 		///
-		/// Writers pick the node, so all nodes are exercised only with at least one writer
-		/// per node. Defaults to half of `--concurrency`, which leaves claims tracking
-		/// submits and the pool near empty; skew toward writers to make the pool grow while
-		/// still acking.
+		/// Each writer submits to one node, so the scenario covers all nodes only with at
+		/// least one writer per node. Defaults to half of `--concurrency`.
 		#[arg(long)]
 		writers: Option<usize>,
 
-		/// Fraction of claimed entries the mixed scenario acks, 0.0..=1.0.
+		/// Fraction of claimed entries the mixed scenario acks, 0.0 to 1.0.
 		///
-		/// An ack releases the entry, so at 1.0 the pools stay near empty no matter how
-		/// many writers run - outflow matches inflow exactly. Lower it to leave the
-		/// balance resident until `--hop-retention-secs` expires it, which grows the
-		/// pools while still exercising claim and ack.
+		/// An ack releases the entry. At 1.0 the submit rate and the release rate are equal,
+		/// so the pool stays at 0 entries regardless of the writer count. A lower value
+		/// leaves the remaining entries in the pool until `--hop-retention-secs` expires
+		/// them, which increases pool size while the scenario still runs claim and ack.
 		#[arg(long, default_value = "1.0")]
 		ack_ratio: f64,
 	},
@@ -736,8 +734,8 @@ async fn authorize_hop_submitters(
 	count: usize,
 ) -> Result<Vec<Keypair>> {
 	let count = count.max(1);
-	// Index 0 keeps the original `//HopSubmitter` derivation so a single-submitter run
-	// authorizes the same account it always has.
+	// Index 0 uses the `//HopSubmitter` derivation, so a run with one submitter authorizes
+	// the same account as before this flag existed.
 	let submitters = (0..count)
 		.map(|i| {
 			let uri =

--- a/stress-test/src/metrics.rs
+++ b/stress-test/src/metrics.rs
@@ -15,6 +15,36 @@
 //! sweep, scenario slugs like `hop-full-cycle` otherwise) so one metric shape serves every test
 //! variant. Tests construct a throwaway recorder with [`PrometheusMetrics::for_tests`].
 //!
+//! # Write-path model
+//!
+//! The write path is counted along two independent axes.
+//!
+//! **Unique transactions.** `tx_offered_*` (the tool starts trying to place this extrinsic),
+//! `tx_accepted_*` (a pool took it), `tx_abandoned_*` (the worker stopped trying) and
+//! `tx_confirmed_*` (it appeared in a finalized block) are incremented **exactly once per
+//! extrinsic**, so each is a count of transactions, never of events.
+//!
+//! **Attempts.** `submit_attempts_total` is incremented once per `author_submitExtrinsic` RPC
+//! call, with `outcome=accepted` or the failure class, so one transaction that needed five tries
+//! contributes five samples.
+//!
+//! The two axes give these invariants:
+//!
+//! ```text
+//! attempts >= offered                          // equality ⇒ no retries at all
+//! retries per transaction = attempts / offered - 1
+//! offered = accepted + abandoned + in-flight    // in-flight = still inside StoreWorker::submit
+//! ```
+//!
+//! Abandoned is not a synonym for lost data: `reason="already_imported"` means the node already
+//! had the transaction, and it is grouped under abandoned only because this worker stops tracking
+//! it from that point on.
+//!
+//! Every write-path `_bytes_total` counts **uncompressed payload** bytes, so offered / accepted /
+//! abandoned / confirmed bytes are directly comparable and converge under zero loss. Wire size is
+//! kept separately as `tx_accepted_encoded_bytes_total` (SCALE-encoded extrinsic, i.e. payload
+//! plus signature and call overhead).
+//!
 //! [`serve`] binds a hyper exposition server for the global recorder's registry.
 
 use anyhow::{Context, Result};
@@ -36,11 +66,33 @@ use crate::report::{LatencyStats, ScenarioResult};
 const BLOCK_TXS_BUCKETS: &[f64] =
 	&[1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 192.0, 256.0, 384.0, 512.0];
 
+/// Buckets for the per-block payload-size histogram, in bytes. Coarse below 4 MB, then tight
+/// around the 8–9 MB band where production blocks (versi `bc-3000`: 8.4–8.8 MB) sit, so "full" and
+/// "short" blocks land in different buckets.
+const BLOCK_BYTES_BUCKETS: &[f64] = &[
+	65_536.0,
+	262_144.0,
+	1_048_576.0,
+	2_097_152.0,
+	4_194_304.0,
+	6_291_456.0,
+	7_340_032.0,
+	8_388_608.0,
+	8_912_896.0,
+	9_437_184.0,
+	10_485_760.0,
+	12_582_912.0,
+];
+
 /// Buckets for end-to-end latency histograms in seconds. Retrieval latencies are sub-second on a
 /// warm bitswap peer; inclusion latencies span multiple block intervals under pool saturation.
 const LATENCY_BUCKETS_SECS: &[f64] = &[
 	0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 3.0, 4.5, 6.0, 9.0, 12.0, 18.0, 24.0, 36.0, 60.0, 120.0,
 ];
+
+/// `outcome` label of `bulletin_stress_submit_attempts_total` for a successful submission RPC. The
+/// failure values are [`TxPoolError::metric_class`](crate::store::TxPoolError::metric_class).
+pub const OUTCOME_ACCEPTED: &str = "accepted";
 
 static METRICS: OnceLock<PrometheusMetrics> = OnceLock::new();
 
@@ -98,14 +150,22 @@ impl LatencyKind {
 /// Concrete Prometheus recorder shared by all scenarios of one process.
 pub struct PrometheusMetrics {
 	registry: Registry,
-	// Live write path (incremented at event time).
-	tx_submitted: CounterVec<U64>,
-	tx_submitted_bytes: CounterVec<U64>,
-	tx_errors: CounterVec<U64>,
+	// Live write path, unique transactions (each incremented exactly once per extrinsic).
+	tx_offered: CounterVec<U64>,
+	tx_offered_bytes: CounterVec<U64>,
+	tx_accepted: CounterVec<U64>,
+	tx_accepted_bytes: CounterVec<U64>,
+	tx_accepted_encoded_bytes: CounterVec<U64>,
+	tx_abandoned: CounterVec<U64>,
+	tx_abandoned_bytes: CounterVec<U64>,
 	tx_confirmed: CounterVec<U64>,
 	tx_confirmed_bytes: CounterVec<U64>,
+	// Live write path, one increment per RPC call.
+	submit_attempts: CounterVec<U64>,
+	// Observed blocks.
 	blocks_observed: CounterVec<U64>,
 	block_txs: HistogramVec,
+	block_bytes: HistogramVec,
 	// Live latency distributions.
 	latency: HistogramVec,
 	// Live read path (bitswap).
@@ -178,24 +238,58 @@ impl PrometheusMetrics {
 		let r = Registry::new();
 
 		Ok(Self {
-			tx_submitted: counter_vec(
+			tx_offered: counter_vec(
 				&r,
-				"bulletin_stress_tx_submitted_total",
-				"Store extrinsics accepted by the node RPC, incremented at submission time.",
+				"bulletin_stress_tx_offered_total",
+				"Store extrinsics the tool started trying to place, counted once per extrinsic \
+				 before its first submission attempt (offered load).",
 				&["variant"],
 			)?,
-			tx_submitted_bytes: counter_vec(
+			tx_offered_bytes: counter_vec(
 				&r,
-				"bulletin_stress_tx_submitted_bytes_total",
-				"Encoded extrinsic bytes accepted by the node RPC (offered load).",
+				"bulletin_stress_tx_offered_bytes_total",
+				"Uncompressed payload bytes offered, counted once per extrinsic.",
 				&["variant"],
 			)?,
-			tx_errors: counter_vec(
+			tx_accepted: counter_vec(
 				&r,
-				"bulletin_stress_tx_errors_total",
-				"Submission error/retry events by class; retriable classes (pool_full, banned, ...) \
-				 are counted once per occurrence.",
-				&["variant", "class"],
+				"bulletin_stress_tx_accepted_total",
+				"Store extrinsics accepted into a node's transaction pool, counted once per \
+				 extrinsic (accepted ≤ offered).",
+				&["variant"],
+			)?,
+			tx_accepted_bytes: counter_vec(
+				&r,
+				"bulletin_stress_tx_accepted_bytes_total",
+				"Uncompressed payload bytes accepted into a transaction pool.",
+				&["variant"],
+			)?,
+			tx_accepted_encoded_bytes: counter_vec(
+				&r,
+				"bulletin_stress_tx_accepted_encoded_bytes_total",
+				"SCALE-encoded extrinsic bytes accepted into a transaction pool (wire size; \
+				 payload plus signature and call overhead).",
+				&["variant"],
+			)?,
+			tx_abandoned: counter_vec(
+				&r,
+				"bulletin_stress_tx_abandoned_total",
+				"Store extrinsics the worker stopped tracking, counted once per extrinsic, by \
+				 reason (already_imported means the node already had it, not data loss).",
+				&["variant", "reason"],
+			)?,
+			tx_abandoned_bytes: counter_vec(
+				&r,
+				"bulletin_stress_tx_abandoned_bytes_total",
+				"Uncompressed payload bytes of abandoned extrinsics, by reason.",
+				&["variant", "reason"],
+			)?,
+			submit_attempts: counter_vec(
+				&r,
+				"bulletin_stress_submit_attempts_total",
+				"Submission RPC calls, one increment per call, by outcome (accepted, pool_full, \
+				 banned, ...); attempts ≥ offered, the excess being retries.",
+				&["variant", "outcome"],
 			)?,
 			tx_confirmed: counter_vec(
 				&r,
@@ -222,6 +316,16 @@ impl PrometheusMetrics {
 				"Store transactions per observed finalized block (block fullness distribution).",
 				&["variant"],
 				BLOCK_TXS_BUCKETS,
+			)?,
+			block_bytes: histogram_vec(
+				&r,
+				"bulletin_stress_block_bytes",
+				"Uncompressed payload bytes per observed finalized block. Substrate/Cumulus expose \
+				 no block-size-in-bytes metric (only substrate_proposer_number_of_transactions and \
+				 substrate_block_height), so this is the only source of a per-block size \
+				 distribution.",
+				&["variant"],
+				BLOCK_BYTES_BUCKETS,
 			)?,
 			latency: histogram_vec(
 				&r,
@@ -340,23 +444,45 @@ impl PrometheusMetrics {
 
 	// ---- live write path ---------------------------------------------------
 
-	/// Record one accepted store submission of `bytes` encoded extrinsic bytes.
-	pub fn inc_submitted(&self, variant: &str, bytes: u64) {
-		self.tx_submitted.with_label_values(&[variant]).inc();
-		self.tx_submitted_bytes.with_label_values(&[variant]).inc_by(bytes);
+	/// Record one store extrinsic of `payload_bytes` offered to the network. Call once per
+	/// extrinsic, before its first submission attempt.
+	pub fn inc_offered(&self, variant: &str, payload_bytes: u64) {
+		self.tx_offered.with_label_values(&[variant]).inc();
+		self.tx_offered_bytes.with_label_values(&[variant]).inc_by(payload_bytes);
 	}
 
-	/// Record one submission error/retry event of the given class.
-	pub fn inc_error(&self, variant: &str, class: &'static str) {
-		self.tx_errors.with_label_values(&[variant, class]).inc();
+	/// Record one store extrinsic accepted into a transaction pool. Call once per extrinsic, on the
+	/// attempt that succeeded. `encoded_bytes` is the wire size of the same extrinsic.
+	pub fn inc_accepted(&self, variant: &str, payload_bytes: u64, encoded_bytes: u64) {
+		self.tx_accepted.with_label_values(&[variant]).inc();
+		self.tx_accepted_bytes.with_label_values(&[variant]).inc_by(payload_bytes);
+		self.tx_accepted_encoded_bytes
+			.with_label_values(&[variant])
+			.inc_by(encoded_bytes);
 	}
 
-	/// Record one finalized block observed by the block monitor.
+	/// Record one store extrinsic the worker gave up on. Call once per extrinsic, on the path that
+	/// stops retrying it.
+	pub fn inc_abandoned(&self, variant: &str, reason: &'static str, payload_bytes: u64) {
+		self.tx_abandoned.with_label_values(&[variant, reason]).inc();
+		self.tx_abandoned_bytes
+			.with_label_values(&[variant, reason])
+			.inc_by(payload_bytes);
+	}
+
+	/// Record one submission RPC call and how it ended ([`OUTCOME_ACCEPTED`] or an error class).
+	pub fn inc_submit_attempt(&self, variant: &str, outcome: &'static str) {
+		self.submit_attempts.with_label_values(&[variant, outcome]).inc();
+	}
+
+	/// Record one finalized block observed by the block monitor: its store transactions and their
+	/// uncompressed payload bytes, as both running totals and per-block distributions.
 	pub fn observe_confirmed_block(&self, variant: &str, tx_count: u64, payload_bytes: u64) {
 		self.tx_confirmed.with_label_values(&[variant]).inc_by(tx_count);
 		self.tx_confirmed_bytes.with_label_values(&[variant]).inc_by(payload_bytes);
 		self.blocks_observed.with_label_values(&[variant]).inc();
 		self.block_txs.with_label_values(&[variant]).observe(tx_count as f64);
+		self.block_bytes.with_label_values(&[variant]).observe(payload_bytes as f64);
 	}
 
 	// ---- latency ----------------------------------------------------------
@@ -475,8 +601,11 @@ mod tests {
 	fn registered_families_appear_in_encoded_output() {
 		let m = PrometheusMetrics::for_tests();
 		// Trigger one observation per family so each has a series.
-		m.inc_submitted("1KB", 1234);
-		m.inc_error("1KB", "pool_full");
+		m.inc_offered("1KB", 1024);
+		m.inc_submit_attempt("1KB", "pool_full");
+		m.inc_submit_attempt("1KB", OUTCOME_ACCEPTED);
+		m.inc_accepted("1KB", 1024, 1234);
+		m.inc_abandoned("1KB", "dropped", 1024);
 		m.observe_confirmed_block("1KB", 100, 100 * 1024);
 		m.observe_latency("hop-full-cycle", LatencyKind::Inclusion, Duration::from_secs(6));
 		m.inc_reads("bitswap-bulk-read", true, 3, 3 * 128 * 1024);
@@ -503,13 +632,19 @@ mod tests {
 
 		let txt = encode(&m);
 		for expected in [
-			"bulletin_stress_tx_submitted_total",
-			"bulletin_stress_tx_submitted_bytes_total",
-			"bulletin_stress_tx_errors_total",
+			"bulletin_stress_tx_offered_total",
+			"bulletin_stress_tx_offered_bytes_total",
+			"bulletin_stress_tx_accepted_total",
+			"bulletin_stress_tx_accepted_bytes_total",
+			"bulletin_stress_tx_accepted_encoded_bytes_total",
+			"bulletin_stress_tx_abandoned_total",
+			"bulletin_stress_tx_abandoned_bytes_total",
+			"bulletin_stress_submit_attempts_total",
 			"bulletin_stress_tx_confirmed_total",
 			"bulletin_stress_tx_confirmed_bytes_total",
 			"bulletin_stress_blocks_observed_total",
 			"bulletin_stress_block_txs",
+			"bulletin_stress_block_bytes",
 			"bulletin_stress_latency_seconds",
 			"bulletin_stress_reads_total",
 			"bulletin_stress_read_bytes_total",
@@ -527,23 +662,107 @@ mod tests {
 		}
 	}
 
+	/// Three transactions of a 1 KB variant: one accepted on its third attempt, one abandoned as
+	/// dropped on its second, one still inside `submit`. Checks that the unique-transaction
+	/// families count transactions (not events) while attempts counts RPC calls.
+	#[test]
+	fn unique_tx_counters_are_incremented_once_per_transaction() {
+		let m = PrometheusMetrics::for_tests();
+		for _ in 0..3 {
+			m.inc_offered("1KB", 1024);
+		}
+		// tx1: pool_full, pool_full, accepted.
+		m.inc_submit_attempt("1KB", "pool_full");
+		m.inc_submit_attempt("1KB", "pool_full");
+		m.inc_submit_attempt("1KB", OUTCOME_ACCEPTED);
+		m.inc_accepted("1KB", 1024, 1220);
+		// tx2: banned, dropped → abandoned.
+		m.inc_submit_attempt("1KB", "banned");
+		m.inc_submit_attempt("1KB", "dropped");
+		m.inc_abandoned("1KB", "dropped", 1024);
+		// tx3: one attempt so far, still retrying (in-flight).
+		m.inc_submit_attempt("1KB", "pool_full");
+
+		let txt = encode(&m);
+		// offered = accepted + abandoned + in-flight  →  3 = 1 + 1 + 1.
+		assert!(txt.contains("bulletin_stress_tx_offered_total{variant=\"1KB\"} 3"));
+		assert!(txt.contains("bulletin_stress_tx_accepted_total{variant=\"1KB\"} 1"));
+		assert!(txt
+			.contains("bulletin_stress_tx_abandoned_total{reason=\"dropped\",variant=\"1KB\"} 1"));
+		// attempts (6) >= offered (3): three retries across the three transactions.
+		assert!(txt.contains(
+			"bulletin_stress_submit_attempts_total{outcome=\"pool_full\",variant=\"1KB\"} 3"
+		));
+		assert!(txt.contains(
+			"bulletin_stress_submit_attempts_total{outcome=\"banned\",variant=\"1KB\"} 1"
+		));
+		assert!(txt.contains(
+			"bulletin_stress_submit_attempts_total{outcome=\"dropped\",variant=\"1KB\"} 1"
+		));
+		assert!(txt.contains(
+			"bulletin_stress_submit_attempts_total{outcome=\"accepted\",variant=\"1KB\"} 1"
+		));
+		// Payload bytes follow the same partition; encoded bytes carry the wire overhead.
+		assert!(txt.contains("bulletin_stress_tx_offered_bytes_total{variant=\"1KB\"} 3072"));
+		assert!(txt.contains("bulletin_stress_tx_accepted_bytes_total{variant=\"1KB\"} 1024"));
+		assert!(
+			txt.contains("bulletin_stress_tx_accepted_encoded_bytes_total{variant=\"1KB\"} 1220")
+		);
+		assert!(txt.contains(
+			"bulletin_stress_tx_abandoned_bytes_total{reason=\"dropped\",variant=\"1KB\"} 1024"
+		));
+	}
+
+	#[test]
+	fn abandon_reasons_are_separate_series() {
+		let m = PrometheusMetrics::for_tests();
+		m.inc_abandoned("1KB", "dropped", 1024);
+		m.inc_abandoned("1KB", "already_imported", 1024);
+		m.inc_abandoned("1KB", "already_imported", 1024);
+		m.inc_abandoned("32KB", "connection_dead", 32 * 1024);
+
+		let txt = encode(&m);
+		assert!(txt
+			.contains("bulletin_stress_tx_abandoned_total{reason=\"dropped\",variant=\"1KB\"} 1"));
+		assert!(txt.contains(
+			"bulletin_stress_tx_abandoned_total{reason=\"already_imported\",variant=\"1KB\"} 2"
+		));
+		assert!(txt.contains(
+			"bulletin_stress_tx_abandoned_total{reason=\"connection_dead\",variant=\"32KB\"} 1"
+		));
+		assert!(txt.contains(
+			"bulletin_stress_tx_abandoned_bytes_total{reason=\"connection_dead\",variant=\"32KB\"} 32768"
+		));
+	}
+
+	/// Cumulative count of `{family}_bucket{le="{le}"}` in the encoded output.
+	fn bucket_count(txt: &str, family: &str, le: &str) -> u64 {
+		let (prefix, le) = (format!("{family}_bucket"), format!("le=\"{le}\""));
+		txt.lines()
+			.find(|l| l.starts_with(&prefix) && l.contains(&le))
+			.and_then(|l| l.rsplit(' ').next())
+			.and_then(|v| v.parse().ok())
+			.unwrap_or_else(|| panic!("no {family} bucket {le} in:\n{txt}"))
+	}
+
 	#[test]
 	fn confirmed_block_updates_all_block_families() {
 		let m = PrometheusMetrics::for_tests();
 		m.observe_confirmed_block("1KB", 500, 512_000);
 		m.observe_confirmed_block("1KB", 0, 0);
+		// A near-full block, in the band the byte buckets resolve.
+		m.observe_confirmed_block("1KB", 480, 8_650_000);
 
 		let txt = encode(&m);
-		assert!(txt.contains("bulletin_stress_tx_confirmed_total{variant=\"1KB\"} 500"));
-		assert!(txt.contains("bulletin_stress_blocks_observed_total{variant=\"1KB\"} 2"));
-		// Both blocks fall in the +Inf bucket; the empty one also in the first (le="1").
-		let inf_line = txt
-			.lines()
-			.find(|l| {
-				l.starts_with("bulletin_stress_block_txs_bucket") && l.contains("le=\"+Inf\"")
-			})
-			.expect("+Inf bucket present");
-		assert!(inf_line.ends_with(" 2"), "unexpected +Inf bucket line: {inf_line}");
+		assert!(txt.contains("bulletin_stress_tx_confirmed_total{variant=\"1KB\"} 980"));
+		assert!(txt.contains("bulletin_stress_tx_confirmed_bytes_total{variant=\"1KB\"} 9162000"));
+		assert!(txt.contains("bulletin_stress_blocks_observed_total{variant=\"1KB\"} 3"));
+		// All blocks fall in the +Inf tx bucket; the empty one also in the first (le="1").
+		assert_eq!(bucket_count(&txt, "bulletin_stress_block_txs", "+Inf"), 3);
+		assert_eq!(bucket_count(&txt, "bulletin_stress_block_txs", "1"), 1);
+		// The 8.25 MiB block is above the 8 MiB bucket and at or below the 8.5 MiB one.
+		assert_eq!(bucket_count(&txt, "bulletin_stress_block_bytes", "8388608"), 2);
+		assert_eq!(bucket_count(&txt, "bulletin_stress_block_bytes", "8912896"), 3);
 	}
 
 	#[test]

--- a/stress-test/src/metrics.rs
+++ b/stress-test/src/metrics.rs
@@ -17,32 +17,31 @@
 //!
 //! # Write-path model
 //!
-//! The write path is counted along two independent axes.
+//! The write path uses two separate counts.
 //!
-//! **Unique transactions.** `tx_offered_*` (the tool starts trying to place this extrinsic),
-//! `tx_accepted_*` (a pool took it), `tx_abandoned_*` (the worker stopped trying) and
-//! `tx_confirmed_*` (it appeared in a finalized block) are incremented **exactly once per
-//! extrinsic**, so each is a count of transactions, never of events.
+//! **Unique transactions.** `tx_offered_*` (the tool started submitting this extrinsic),
+//! `tx_accepted_*` (a transaction pool accepted it), `tx_abandoned_*` (the worker stopped
+//! retrying it) and `tx_confirmed_*` (it appeared in a finalized block) increment **once per
+//! extrinsic**. Each counts transactions, not events.
 //!
-//! **Attempts.** `submit_attempts_total` is incremented once per `author_submitExtrinsic` RPC
-//! call, with `outcome=accepted` or the failure class, so one transaction that needed five tries
-//! contributes five samples.
+//! **Attempts.** `submit_attempts_total` increments once per `author_submitExtrinsic` RPC call,
+//! with `outcome=accepted` or the failure class. One transaction that required five calls
+//! produces five samples.
 //!
-//! The two axes give these invariants:
+//! This gives the following invariants:
 //!
 //! ```text
-//! attempts >= offered                          // equality ⇒ no retries at all
+//! attempts >= offered                          // equal means no retries
 //! retries per transaction = attempts / offered - 1
 //! offered = accepted + abandoned + in-flight    // in-flight = still inside StoreWorker::submit
 //! ```
 //!
-//! Abandoned is not a synonym for lost data: `reason="already_imported"` means the node already
-//! had the transaction, and it is grouped under abandoned only because this worker stops tracking
-//! it from that point on.
+//! An abandoned transaction is not always lost data. `reason="already_imported"` means the node
+//! already contains the transaction. It counts as abandoned because the worker stops tracking it.
 //!
-//! Every write-path `_bytes_total` counts **uncompressed payload** bytes, so offered / accepted /
-//! abandoned / confirmed bytes are directly comparable and converge under zero loss. Wire size is
-//! kept separately as `tx_accepted_encoded_bytes_total` (SCALE-encoded extrinsic, i.e. payload
+//! Every write-path `_bytes_total` counts **uncompressed payload** bytes, so offered, accepted,
+//! abandoned and confirmed bytes are directly comparable and equal when nothing is lost. Wire
+//! size uses a separate metric, `tx_accepted_encoded_bytes_total` (SCALE-encoded extrinsic: payload
 //! plus signature and call overhead).
 //!
 //! [`serve`] binds a hyper exposition server for the global recorder's registry.
@@ -66,9 +65,9 @@ use crate::report::{LatencyStats, ScenarioResult};
 const BLOCK_TXS_BUCKETS: &[f64] =
 	&[1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 192.0, 256.0, 384.0, 512.0];
 
-/// Buckets for the per-block payload-size histogram, in bytes. Coarse below 4 MB, then tight
-/// around the 8–9 MB band where production blocks (versi `bc-3000`: 8.4–8.8 MB) sit, so "full" and
-/// "short" blocks land in different buckets.
+/// Buckets for the per-block payload-size histogram, in bytes. Wide below 4 MB, narrow
+/// between 8 MB and 9 MB. A full block is close to the 9 MiB normal-class length limit, so
+/// narrow buckets there separate full blocks from partly filled ones.
 const BLOCK_BYTES_BUCKETS: &[f64] = &[
 	65_536.0,
 	262_144.0,

--- a/stress-test/src/pipeline.rs
+++ b/stress-test/src/pipeline.rs
@@ -32,7 +32,7 @@ use crate::{
 	accounts::NonceTracker,
 	authorize::{self, AUTHORIZE_BATCH_SIZE},
 	client::BulletinConfig,
-	metrics::metrics,
+	metrics::{metrics, OUTCOME_ACCEPTED},
 	report::BlockStats,
 	store::{
 		classify_tx_error, read_timestamp_at, sign_store_extrinsic_blocking,
@@ -51,7 +51,8 @@ struct SubmitCounters {
 	stale_nonces: AtomicU64,
 }
 
-/// Content hash → extrinsic size mapping (separate lock from counters to reduce contention).
+/// Content hash → uncompressed payload size mapping, filled on acceptance and drained by the block
+/// monitor to attribute payload bytes to blocks (separate lock from counters to reduce contention).
 type ContentHashMap = std::collections::HashMap<[u8; 32], u64>;
 
 /// Bounded capacity for the generator → reader `mpsc` (backpressure when full).
@@ -176,7 +177,13 @@ pub enum StressWorkItem {
 	/// processing further [`Store`](Self::Store) items.
 	AwaitPendingAuth,
 	/// Pre-signed `TransactionStorage::store` extrinsic for a one-shot account (nonce 0).
-	Store { account_id: AccountId32, extrinsic: Arc<Vec<u8>>, content_hash: [u8; 32] },
+	/// `payload_len` is the uncompressed payload size (the extrinsic itself is larger).
+	Store {
+		account_id: AccountId32,
+		extrinsic: Arc<Vec<u8>>,
+		content_hash: [u8; 32],
+		payload_len: u64,
+	},
 }
 
 /// One iteration of the sweep: account count and derivation prefix for `//{prefix}/{idx}`.
@@ -487,6 +494,9 @@ struct StoreWorkMsg {
 	account_id: AccountId32,
 	extrinsic: Arc<Vec<u8>>,
 	content_hash: [u8; 32],
+	/// Uncompressed payload size, the unit of every write-path `_bytes_total` metric (the encoded
+	/// `extrinsic` additionally carries signature and call overhead).
+	payload_len: u64,
 }
 
 /// Per-worker state for store submission.
@@ -503,8 +513,13 @@ struct StoreWorker {
 
 impl StoreWorker {
 	/// Submit one pre-signed store extrinsic; retries pool-full / banned / reconnect.
+	///
+	/// Metric-wise the extrinsic is offered exactly once here and leaves through exactly one of
+	/// `tx_accepted_*` or `tx_abandoned_*`; every iteration of the loop is one `submit_attempts`
+	/// sample.
 	async fn submit(&mut self, msg: &StoreWorkMsg) -> Result<()> {
 		let id = self.worker_id;
+		metrics().inc_offered(self.variant, msg.payload_len);
 		loop {
 			let result =
 				store_submit_pre_signed(self.client.as_ref(), msg.extrinsic.as_ref()).await;
@@ -514,8 +529,9 @@ impl StoreWorker {
 					let ext_len = msg.extrinsic.len() as u64;
 					let n = self.counters.submitted.fetch_add(1, Ordering::Relaxed) + 1;
 					self.counters.submitted_bytes.fetch_add(ext_len, Ordering::Relaxed);
-					metrics().inc_submitted(self.variant, ext_len);
-					self.content_hash_map.lock().unwrap().insert(msg.content_hash, ext_len);
+					metrics().inc_submit_attempt(self.variant, OUTCOME_ACCEPTED);
+					metrics().inc_accepted(self.variant, msg.payload_len, ext_len);
+					self.content_hash_map.lock().unwrap().insert(msg.content_hash, msg.payload_len);
 					self.consecutive_conn_errors = 0;
 					if n == 1 || n.is_multiple_of(256) {
 						tracing::debug!(
@@ -526,7 +542,7 @@ impl StoreWorker {
 				},
 				Err(e) => {
 					let class = classify_tx_error(&e);
-					metrics().inc_error(self.variant, class.metric_class());
+					metrics().inc_submit_attempt(self.variant, class.metric_class());
 					tracing::debug!(
 						"pipeline store: worker {id} class={class:?} account={} err={e:#}",
 						msg.account_id
@@ -569,6 +585,7 @@ impl StoreWorker {
 											"pipeline store: worker {id}: giving up reconnect"
 										);
 										self.counters.errors.fetch_add(1, Ordering::Relaxed);
+										self.abandon(msg, class);
 										return Err(anyhow::anyhow!(
 											"pipeline store: reconnect failed (worker {id})"
 										));
@@ -578,32 +595,44 @@ impl StoreWorker {
 						TxPoolError::TxDropped => {
 							self.consecutive_conn_errors = 0;
 							self.counters.pool_full_retries.fetch_add(1, Ordering::Relaxed);
+							self.abandon(msg, class);
 							return Ok(());
 						},
 						TxPoolError::AlreadyImported => {
 							self.consecutive_conn_errors = 0;
+							self.abandon(msg, class);
 							return Ok(());
 						},
 						TxPoolError::StaleNonce => {
 							self.consecutive_conn_errors = 0;
 							self.counters.stale_nonces.fetch_add(1, Ordering::Relaxed);
+							self.abandon(msg, class);
 							return Ok(());
 						},
 						TxPoolError::FutureNonce => {
 							self.consecutive_conn_errors = 0;
 							self.counters.errors.fetch_add(1, Ordering::Relaxed);
+							self.abandon(msg, class);
 							return Ok(());
 						},
 						TxPoolError::Other => {
 							self.consecutive_conn_errors = 0;
 							tracing::warn!("pipeline store: worker {id} (class={class:?}): {e:#}");
 							self.counters.errors.fetch_add(1, Ordering::Relaxed);
+							self.abandon(msg, class);
 							return Ok(());
 						},
 					}
 				},
 			}
 		}
+	}
+
+	/// Count one extrinsic this worker stops tracking; the error class doubles as the `reason`
+	/// label. Call on every path out of [`Self::submit`] that is not an acceptance, so that
+	/// `offered = accepted + abandoned + in-flight` holds.
+	fn abandon(&self, msg: &StoreWorkMsg, class: TxPoolError) {
+		metrics().inc_abandoned(self.variant, class.metric_class(), msg.payload_len);
 	}
 }
 
@@ -858,9 +887,9 @@ pub async fn run_block_capacity_pipeline(
 					}
 				}
 			},
-			StressWorkItem::Store { account_id, extrinsic, content_hash } => {
+			StressWorkItem::Store { account_id, extrinsic, content_hash, payload_len } => {
 				if let Err(e) = dispatch_store_to_workers(
-					StoreWorkMsg { account_id, extrinsic, content_hash },
+					StoreWorkMsg { account_id, extrinsic, content_hash, payload_len },
 					&worker_txs,
 					&mut store_worker_rr,
 				)
@@ -1072,6 +1101,7 @@ async fn build_store_work_items(
 					account_id,
 					extrinsic: Arc::new(encoded),
 					content_hash,
+					payload_len: payload_size as u64,
 				})
 			}
 		})

--- a/stress-test/src/scenarios/hop.rs
+++ b/stress-test/src/scenarios/hop.rs
@@ -36,6 +36,9 @@ const SUBMIT_PAYLOAD_SIZES: &[(usize, &str)] = &[
 const FULL_CYCLE_INDEX_BASE: u64 = 100_000_000;
 const GROUP_INDEX_BASE: u64 = 200_000_000;
 const POOL_FILL_INDEX_BASE: u64 = 300_000_000;
+
+/// Safety cap on entries submitted to a single node by `pool-fill`.
+const POOL_FILL_MAX_ENTRIES_PER_NODE: u64 = 100_000;
 const MIXED_INDEX_BASE: u64 = 400_000_000;
 
 // ---------------------------------------------------------------------------
@@ -279,6 +282,15 @@ pub async fn run_full_cycle(
 					}
 					claim_lats.push(latency);
 					claim_bytes += data.len() as u64;
+					// Claiming only reads; the node releases the entry once every
+					// recipient has acked. Without this the pool and the submitter's
+					// per-user byte budget stay occupied until expiry.
+					if let Err(e) = hop::hop_ack(&ws, &entry.hash, kp).await {
+						claim_errors += 1;
+						if claim_errors <= 5 {
+							tracing::warn!("ack error: {e}");
+						}
+					}
 				},
 				Err(e) => {
 					claim_errors += 1;
@@ -406,6 +418,14 @@ pub async fn run_group(
 						if data.len() != expected_len {
 							tracing::error!("Data length mismatch in group claim");
 						}
+						// The entry is released only once *all* recipients ack, which
+						// for this scenario means every spawned task acking its own.
+						if let Err(e) = hop::hop_ack(&ws, &hash, &kp).await {
+							errors.fetch_add(1, Ordering::Relaxed);
+							if errors.load(Ordering::Relaxed) <= 5 {
+								tracing::warn!("group ack error: {e}");
+							}
+						}
 					},
 					Err(e) => {
 						errors.fetch_add(1, Ordering::Relaxed);
@@ -469,83 +489,142 @@ pub async fn run_group(
 pub async fn run_pool_fill(
 	ws_urls: &[&str],
 	payload_size: usize,
-	submitter: &Keypair,
+	submitters: &[Keypair],
 	results: &mut Vec<ScenarioResult>,
 	on_result: &dyn Fn(&mut Vec<ScenarioResult>),
 	cancel: &Arc<AtomicBool>,
 ) -> Result<()> {
 	tracing::info!(
-		"S4: Pool fill — {} byte payloads until PoolFull or UserQuotaExceeded",
-		payload_size
+		"S4: Pool fill — {} byte payloads on {} node(s) with {} submitter(s), until PoolFull",
+		payload_size,
+		ws_urls.len(),
+		submitters.len()
 	);
-
-	let ws = client::connect_ws(ws_urls[0]).await?;
-
-	if let Ok(status) = hop::hop_pool_status(&ws).await {
-		tracing::info!(
-			"Initial pool: {} entries, {} / {} bytes",
-			status.entry_count,
-			status.total_bytes,
-			status.max_bytes
-		);
-	}
 
 	let start = Instant::now();
 	let mut submitted = 0u64;
 	let mut errors = 0u64;
 	let mut total_bytes = 0u64;
 	let mut lats = Vec::new();
-	let mut pool_full = false;
+	let mut any_pool_full = false;
 
-	for i in 0u64.. {
-		if cancel.load(Ordering::Relaxed) || i >= 100_000 {
-			if i >= 100_000 {
-				tracing::info!("Hit 100k entries safety cap");
-			}
+	// The node caps pool bytes per `(node, submitter)`, and pools are node-local, so each
+	// node is filled independently and each submitter contributes its own quota to it.
+	// UserQuotaExceeded therefore means "this account is done here", not "the pool is
+	// full" — only PoolFull ends a node.
+	for (node_idx, url) in ws_urls.iter().enumerate() {
+		if cancel.load(Ordering::Relaxed) {
 			break;
 		}
 
-		let data = hop::generate_payload(payload_size, POOL_FILL_INDEX_BASE + i);
-		let recipients = vec![RecipientKeypair::generate()];
-
-		match hop::hop_submit(&ws, &data, &recipients, submitter).await {
-			Ok((_hash, result, latency)) => {
-				submitted += 1;
-				total_bytes += payload_size as u64;
-				lats.push(latency);
-
-				if submitted.is_multiple_of(100) {
-					tracing::info!(
-						"  {} submitted, pool: {} entries, {} / {} bytes",
-						submitted,
-						result.pool_status.entry_count,
-						result.pool_status.total_bytes,
-						result.pool_status.max_bytes
-					);
-				}
-			},
+		let ws = match client::connect_ws(url).await {
+			Ok(ws) => ws,
 			Err(e) => {
-				let err_str = e.to_string();
-				// Check for PoolFull (1002) or UserQuotaExceeded (1013)
-				if err_str.contains("1002") || err_str.contains("Pool full") {
-					tracing::info!("PoolFull hit after {submitted} entries");
-					pool_full = true;
-					break;
-				}
-				if err_str.contains("1013") || err_str.contains("quota") {
-					tracing::info!("UserQuotaExceeded hit after {submitted} entries");
-					pool_full = true;
-					break;
-				}
+				tracing::warn!("pool-fill: cannot connect to {url}: {e}");
 				errors += 1;
-				if errors <= 5 {
-					tracing::warn!("pool-fill submit error [{i}]: {e}");
-				}
-				if errors > 10 {
-					tracing::error!("Too many errors, stopping");
-					break;
-				}
+				continue;
 			},
+		};
+
+		if let Ok(status) = hop::hop_pool_status(&ws).await {
+			tracing::info!(
+				"[{url}] initial pool: {} entries, {} / {} bytes",
+				status.entry_count,
+				status.total_bytes,
+				status.max_bytes
+			);
+		}
+
+		let mut node_submitted = 0u64;
+		let mut sub_idx = 0usize;
+		let mut node_pool_full = false;
+		let mut i = 0u64;
+
+		while sub_idx < submitters.len() {
+			if cancel.load(Ordering::Relaxed) || i >= POOL_FILL_MAX_ENTRIES_PER_NODE {
+				if i >= POOL_FILL_MAX_ENTRIES_PER_NODE {
+					tracing::info!("[{url}] hit the {POOL_FILL_MAX_ENTRIES_PER_NODE} entry cap");
+				}
+				break;
+			}
+
+			// Disjoint index space per node so payloads stay unique per pool.
+			let index = POOL_FILL_INDEX_BASE + (node_idx as u64) * 1_000_000 + i;
+			let data = hop::generate_payload(payload_size, index);
+			let recipients = vec![RecipientKeypair::generate()];
+
+			match hop::hop_submit(&ws, &data, &recipients, &submitters[sub_idx]).await {
+				Ok((_hash, result, latency)) => {
+					submitted += 1;
+					node_submitted += 1;
+					i += 1;
+					total_bytes += payload_size as u64;
+					lats.push(latency);
+
+					if node_submitted.is_multiple_of(100) {
+						tracing::info!(
+							"  [{url}] {} submitted (submitter {}/{}), pool: {} entries, {} / {} bytes",
+							node_submitted,
+							sub_idx + 1,
+							submitters.len(),
+							result.pool_status.entry_count,
+							result.pool_status.total_bytes,
+							result.pool_status.max_bytes
+						);
+					}
+				},
+				Err(e) => {
+					let err_str = e.to_string();
+					// PoolFull (1002): the node is full, nothing more to do here.
+					if err_str.contains("1002") || err_str.contains("Pool full") {
+						tracing::info!(
+							"[{url}] PoolFull after {node_submitted} entries \
+							 ({}/{} submitters used)",
+							sub_idx + 1,
+							submitters.len()
+						);
+						node_pool_full = true;
+						any_pool_full = true;
+						break;
+					}
+					// UserQuotaExceeded (1013): rotate to the next account and keep filling.
+					if err_str.contains("1013") || err_str.contains("quota") {
+						tracing::info!(
+							"[{url}] submitter {}/{} exhausted its quota after \
+							 {node_submitted} entries; rotating",
+							sub_idx + 1,
+							submitters.len()
+						);
+						sub_idx += 1;
+						continue;
+					}
+					errors += 1;
+					if errors <= 5 {
+						tracing::warn!("[{url}] pool-fill submit error [{i}]: {e}");
+					}
+					if errors > 10 {
+						tracing::error!("Too many errors, stopping");
+						break;
+					}
+				},
+			}
+		}
+
+		if !node_pool_full && sub_idx >= submitters.len() {
+			tracing::warn!(
+				"[{url}] all {} submitters exhausted without reaching PoolFull — \
+				 more submitters are needed to fill this pool",
+				submitters.len()
+			);
+		}
+
+		if let Ok(status) = hop::hop_pool_status(&ws).await {
+			tracing::info!(
+				"[{url}] final pool: {} entries, {} / {} bytes",
+				status.entry_count,
+				status.total_bytes,
+				status.max_bytes
+			);
 		}
 	}
 
@@ -560,7 +639,7 @@ pub async fn run_pool_fill(
 		name: format!(
 			"HOP pool-fill {}{}",
 			format_payload_label(payload_size),
-			if pool_full { " (full)" } else { "" }
+			if any_pool_full { " (full)" } else { "" }
 		),
 		variant: variant.into(),
 		duration,
@@ -576,21 +655,11 @@ pub async fn run_pool_fill(
 
 	result.print_text();
 
-	if let Ok(status) = hop::hop_pool_status(&ws).await {
-		tracing::info!(
-			"Final pool: {} entries, {} / {} bytes",
-			status.entry_count,
-			status.total_bytes,
-			status.max_bytes
-		);
-	}
-
 	results.push(result);
 	on_result(results);
 	Ok(())
 }
 
-// ---------------------------------------------------------------------------
 // S5: Mixed read/write
 // ---------------------------------------------------------------------------
 
@@ -710,6 +779,11 @@ pub async fn run_mixed(
 								count.fetch_add(1, Ordering::Relaxed);
 								bytes.fetch_add(data.len() as u64, Ordering::Relaxed);
 								lats.lock().await.push(latency);
+								// Entries carry a single recipient here, so this ack
+								// releases the entry and frees pool and per-user budget.
+								if hop::hop_ack(&ws, &entry.hash, kp).await.is_err() {
+									errors.fetch_add(1, Ordering::Relaxed);
+								}
 							},
 							Err(_) => {
 								errors.fetch_add(1, Ordering::Relaxed);
@@ -942,11 +1016,15 @@ pub async fn run_hop_sweep(
 	concurrency: usize,
 	num_recipients: usize,
 	duration_secs: u64,
-	submitter: &Keypair,
+	submitters: &[Keypair],
 	results: &mut Vec<ScenarioResult>,
 	on_result: &dyn Fn(&mut Vec<ScenarioResult>),
 	cancel: &Arc<AtomicBool>,
 ) -> Result<()> {
+	// Only pool-fill spreads across submitters; every other scenario's writers already
+	// target distinct nodes, and the node's per-user cap is per `(node, submitter)`, so
+	// each writer already has its own quota with a single account.
+	let submitter = submitters.first().expect("at least one HOP submitter is derived");
 	match scenario {
 		"submit-only" | "submit" => {
 			let sizes: Vec<(usize, &str)> = match payload_size {
@@ -991,7 +1069,7 @@ pub async fn run_hop_sweep(
 		},
 		"pool-fill" => {
 			let size = payload_size.unwrap_or(10 * 1024);
-			run_pool_fill(ws_urls, size, submitter, results, on_result, cancel).await?;
+			run_pool_fill(ws_urls, size, submitters, results, on_result, cancel).await?;
 		},
 		"mixed" => {
 			let size = payload_size.unwrap_or(10 * 1024);

--- a/stress-test/src/scenarios/hop.rs
+++ b/stress-test/src/scenarios/hop.rs
@@ -41,26 +41,26 @@ const POOL_FILL_INDEX_BASE: u64 = 300_000_000;
 const POOL_FILL_MAX_ENTRIES_PER_NODE: u64 = 100_000;
 const MIXED_INDEX_BASE: u64 = 400_000_000;
 
-/// Redial attempts before a worker gives up on its node.
+/// Connect attempts before a worker stops using a node.
 const CONNECT_ATTEMPTS: usize = 5;
 
-/// Backoff bounds for a full pool. Space frees up only as entries are acked or reach
-/// `--hop-retention-secs`, so retrying tightly just burns bandwidth re-sending payloads
-/// the node will reject; back off, but stay well under the retention window so a worker
-/// resumes promptly once entries start expiring.
+/// Backoff range for a full pool. The pool frees space only when entries are acked or reach
+/// `--hop-retention-secs`. Retrying without a delay re-sends payloads that the node rejects,
+/// which wastes bandwidth. The maximum stays below the retention period so a worker resumes
+/// soon after entries start to expire.
 const POOL_FULL_BACKOFF_START: Duration = Duration::from_secs(1);
 const POOL_FULL_BACKOFF_MAX: Duration = Duration::from_secs(30);
 
-/// How a submit failed, as far as the fill loops need to distinguish.
+/// Submit failure categories that the fill loops handle differently.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SubmitFailure {
-	/// Node-wide pool limit: back off, no account can help.
+	/// The node pool is full. No account can submit until the pool frees space.
 	PoolFull,
-	/// This `(node, account)` pair is spent: retire the account for this node.
+	/// This account used up its byte quota on this node. Other accounts still have quota.
 	QuotaExceeded,
-	/// This account's token bucket is empty: another account can submit now.
+	/// The rate limit for this account is exceeded. Other accounts can submit now.
 	RateLimited,
-	/// The connection died: redial before submitting again.
+	/// The connection failed. Connect again before the next submit.
 	Transport,
 	Other,
 }
@@ -79,9 +79,9 @@ fn classify_submit_error(err: &anyhow::Error) -> SubmitFailure {
 	}
 }
 
-/// Round-robin to the next account that still has quota on this node, starting after
-/// `from`. `from` itself is considered last, so a lone live account keeps being used.
-/// `None` means every account is spent here.
+/// Returns the next account with quota remaining on this node, searching from `from + 1` and
+/// wrapping around. `from` is checked last, so the function returns `from` when it is the only
+/// account with quota left. Returns `None` when all accounts used up their quota.
 fn next_live_submitter(retired: &[bool], from: usize) -> Option<usize> {
 	(1..=retired.len())
 		.map(|off| (from + off) % retired.len())
@@ -329,9 +329,9 @@ pub async fn run_full_cycle(
 					}
 					claim_lats.push(latency);
 					claim_bytes += data.len() as u64;
-					// Claiming only reads; the node releases the entry once every
-					// recipient has acked. Without this the pool and the submitter's
-					// per-user byte budget stay occupied until expiry.
+					// A claim only reads the entry. The node removes it after every
+					// recipient acks. Without the ack, the entry stays in the pool and
+					// counts against the submitter's byte quota until it expires.
 					if let Err(e) = hop::hop_ack(&ws, &entry.hash, kp).await {
 						claim_errors += 1;
 						if claim_errors <= 5 {
@@ -465,8 +465,8 @@ pub async fn run_group(
 						if data.len() != expected_len {
 							tracing::error!("Data length mismatch in group claim");
 						}
-						// The entry is released only once *all* recipients ack, which
-						// for this scenario means every spawned task acking its own.
+						// The node removes the entry only after all recipients ack. In
+						// this scenario each spawned task acks for one recipient.
 						if let Err(e) = hop::hop_ack(&ws, &hash, &kp).await {
 							errors.fetch_add(1, Ordering::Relaxed);
 							if errors.load(Ordering::Relaxed) <= 5 {
@@ -555,10 +555,10 @@ pub async fn run_pool_fill(
 	let mut lats = Vec::new();
 	let mut any_pool_full = false;
 
-	// The node caps pool bytes per `(node, submitter)`, and pools are node-local, so each
-	// node is filled independently and each submitter contributes its own quota to it.
-	// UserQuotaExceeded therefore means "this account is done here", not "the pool is
-	// full" — only PoolFull ends a node.
+	// The byte quota applies per `(node, submitter)` pair and each node has its own pool, so
+	// this loop fills one node at a time and every submitter adds its own quota to that node.
+	// UserQuotaExceeded means one account used up its quota on this node, not that the pool
+	// is full. Only PoolFull ends the loop for a node.
 	for (node_idx, url) in ws_urls.iter().enumerate() {
 		if cancel.load(Ordering::Relaxed) {
 			break;
@@ -584,16 +584,16 @@ pub async fn run_pool_fill(
 
 		let mut node_submitted = 0u64;
 		let mut sub_idx = 0usize;
-		// Accounts whose `(node, account)` quota is spent here. Rate limiting rotates
-		// among the rest; only quota exhaustion retires an account for this node.
+		// Accounts that used up their quota on this node. A rate limit switches to another
+		// account. Only an exceeded quota marks an account as retired for this node.
 		let mut retired = vec![false; submitters.len()];
 		let mut node_pool_full = false;
 		let mut i = 0u64;
-		// Per node: a node must not inherit the previous node's failures.
+		// Reset per node, so failures on one node do not affect the next node.
 		let mut node_errors = 0u64;
 		let mut throttled = 0u64;
-		// Consecutive rate-limited rotations. Once it reaches the number of live
-		// accounts every bucket is empty, so there is nothing left to rotate to.
+		// Number of consecutive rate limits since the last successful submit. When it
+		// reaches the number of accounts with quota left, every account is rate limited.
 		let mut throttle_streak = 0usize;
 
 		loop {
@@ -631,7 +631,7 @@ pub async fn run_pool_fill(
 					}
 				},
 				Err(e) => match classify_submit_error(&e) {
-					// The node itself is full: nothing more to do here.
+					// The pool for this node is full. Move to the next node.
 					SubmitFailure::PoolFull => {
 						tracing::info!(
 							"[{url}] PoolFull after {node_submitted} entries \
@@ -643,9 +643,9 @@ pub async fn run_pool_fill(
 						any_pool_full = true;
 						break;
 					},
-					// Rate limits are per account, so rotate rather than sleep: the other
-					// accounts' buckets are untouched. Only sleep once every live account
-					// has been tried and throttled in turn.
+					// Rate limits apply per account, so switch to another account instead
+					// of sleeping. Sleep only after every account with quota left returned
+					// a rate limit.
 					SubmitFailure::RateLimited => {
 						throttled += 1;
 						throttle_streak += 1;
@@ -660,8 +660,8 @@ pub async fn run_pool_fill(
 						}
 						continue;
 					},
-					// This account's byte quota is spent on this node; retire it and
-					// carry on with the next one.
+					// This account used up its byte quota on this node. Mark it retired and
+					// continue with the next account.
 					SubmitFailure::QuotaExceeded => {
 						retired[sub_idx] = true;
 						tracing::info!(
@@ -777,18 +777,16 @@ pub async fn run_mixed(
 	on_result: &dyn Fn(&mut Vec<ScenarioResult>),
 	cancel: &Arc<AtomicBool>,
 ) -> Result<()> {
-	// Writers choose the node (`ws_urls[w_idx % len]`); readers follow each entry's
-	// recorded URL. So every node is exercised only if there is at least one writer per
-	// node. An even split leaves claims tracking submits and the pool near empty, which
-	// measures lifecycle throughput; skewing toward writers makes the pool grow while
-	// still acking.
+	// Each writer submits to one node, `ws_urls[w_idx % len]`. Each reader uses the URL
+	// recorded with the entry. The scenario covers every node only with at least one writer
+	// per node.
 	let writer_count = writers.unwrap_or_else(|| std::cmp::max(1, concurrency / 2)).max(1);
 	let reader_count = std::cmp::max(1, concurrency.saturating_sub(writer_count));
 
-	// Acking releases the entry, so at ratio 1.0 inflow and outflow cancel and the pool
-	// cannot grow however many writers there are - it sits near empty while both sides
-	// stay busy. A ratio below 1.0 leaves the balance in the pool to age out at
-	// `--hop-retention-secs`, which is what makes a fill test out of a lifecycle test.
+	// An ack removes the entry. At ratio 1.0 the submit rate and the removal rate are equal,
+	// so the pool stays at 0 entries for any writer count. A ratio below 1.0 leaves the
+	// remaining entries in the pool until `--hop-retention-secs` expires them, which is what
+	// increases pool size.
 	let ack_ratio = ack_ratio.clamp(0.0, 1.0);
 	let ack_permille = (ack_ratio * 1000.0).round() as u64;
 
@@ -837,9 +835,10 @@ pub async fn run_mixed(
 	let mut writer_handles = Vec::new();
 	for w_idx in 0..writer_count {
 		let url = ws_urls[w_idx % ws_urls.len()].to_string();
-		// A writer owns a node, and the byte quota is per (node, submitter) — one account
-		// only covers --hop-max-user-size on that node. Carry every account and rotate on
-		// UserQuotaExceeded so a single writer can fill a pool larger than one quota.
+		// Each writer submits to one node and the byte quota applies per (node, submitter)
+		// pair, so one account covers only --hop-max-user-size on that node. Give every
+		// writer all accounts and switch on UserQuotaExceeded, so one writer can fill a pool
+		// larger than a single quota.
 		let writer_submitters: Vec<Keypair> = submitters.to_vec();
 		let pending = pending.clone();
 		let count = submit_count.clone();
@@ -859,8 +858,8 @@ pub async fn run_mixed(
 
 			let mut idx = MIXED_INDEX_BASE + (w_idx as u64) * 1_000_000;
 			let mut sub_idx = 0usize;
-			// Retired = this account's byte quota is spent on this node. Rate limiting
-			// rotates among the live accounts instead of retiring any of them.
+			// A retired account used up its byte quota on this node. A rate limit switches
+			// to another account and does not retire any account.
 			let mut retired = vec![false; writer_submitters.len()];
 			let mut throttle_streak = 0usize;
 			let mut pool_full_backoff = POOL_FULL_BACKOFF_START;
@@ -886,9 +885,10 @@ pub async fn run_mixed(
 						});
 					},
 					Err(e) => match classify_submit_error(&e) {
-						// Node-wide limit, so no account can help and retrying tightly
-						// only re-sends payloads the node will reject. Wait for acks or
-						// expiry to free space, escalating up to the cap.
+						// The limit applies to the whole node, so switching accounts does
+						// not help, and an immediate retry re-sends a payload the node
+						// rejects. Wait for acks or expiry to free space, increasing the
+						// delay up to POOL_FULL_BACKOFF_MAX.
 						SubmitFailure::PoolFull => {
 							if !pool_full_logged {
 								tracing::warn!(
@@ -902,9 +902,9 @@ pub async fn run_mixed(
 							pool_full_backoff = (pool_full_backoff * 2).min(POOL_FULL_BACKOFF_MAX);
 							continue;
 						},
-						// Buckets are per account, so another account can submit right
-						// now. Only sleep once every live account has been throttled in
-						// turn, which means the node-side budget really is spent.
+						// Rate limits apply per account, so another account can submit now.
+						// Sleep only after every account with quota left returned a rate
+						// limit.
 						SubmitFailure::RateLimited => {
 							throttle_streak += 1;
 							match next_live_submitter(&retired, sub_idx) {
@@ -918,7 +918,8 @@ pub async fn run_mixed(
 							}
 							continue;
 						},
-						// Quota spent on this node for this account: retire it and move on.
+						// This account used up its quota on this node. Mark it retired and
+						// continue with the next account.
 						SubmitFailure::QuotaExceeded => {
 							retired[sub_idx] = true;
 							match next_live_submitter(&retired, sub_idx) {
@@ -935,8 +936,8 @@ pub async fn run_mixed(
 							}
 							continue;
 						},
-						// The node restarted or the stream dropped. Redial: this client
-						// will fail every subsequent request otherwise.
+						// The node restarted or the connection dropped. Connect again,
+						// because every later request on this client fails otherwise.
 						SubmitFailure::Transport => {
 							tracing::warn!("Writer {w_idx} on {url}: connection lost: {e}");
 							match client::connect_ws_retry(&url, CONNECT_ATTEMPTS).await {
@@ -971,8 +972,9 @@ pub async fn run_mixed(
 		let writers_done = writers_done.clone();
 
 		reader_handles.push(tokio::spawn(async move {
-			// Bresenham over permille, so acks are spread across the claim stream rather
-			// than acking the first N of every thousand.
+			// Accumulate the ack ratio in permille and ack when the total reaches 1000.
+			// This spreads the acks over the claim sequence instead of acking the first N
+			// claims of every 1000.
 			let mut ack_credit = 0u64;
 			loop {
 				if cancel.load(Ordering::Relaxed) {
@@ -1001,10 +1003,11 @@ pub async fn run_mixed(
 								count.fetch_add(1, Ordering::Relaxed);
 								bytes.fetch_add(data.len() as u64, Ordering::Relaxed);
 								lats.lock().await.push(latency);
-								// Entries carry a single recipient here, so an ack
-								// releases the entry and frees pool and per-user budget.
-								// Skipping it is what lets the pool grow: the entry then
-								// occupies both until `--hop-retention-secs` expires it.
+								// Each entry has one recipient, so this ack removes the
+								// entry and frees the pool bytes and the per-user quota.
+								// Skipping the ack keeps the entry in the pool until
+								// `--hop-retention-secs` expires it, which increases pool
+								// size.
 								ack_credit += ack_permille;
 								if ack_credit >= 1000 {
 									ack_credit -= 1000;
@@ -1048,8 +1051,8 @@ pub async fn run_mixed(
 			}
 			let elapsed = start.elapsed().as_secs_f64();
 			let plen = p_ref.lock().await.len();
-			// submitted - acked is what stays resident in the pools, so the two counts
-			// together say whether the run is filling them or just cycling entries.
+			// submitted minus acked is the number of entries left in the pools. Both
+			// counts show whether the run increases pool size.
 			tracing::info!(
 				"[{:.0}s] submitted: {}, claimed: {}, acked: {}, pending: {}, errors: {}/{}",
 				elapsed,
@@ -1257,9 +1260,9 @@ pub async fn run_hop_sweep(
 	on_result: &dyn Fn(&mut Vec<ScenarioResult>),
 	cancel: &Arc<AtomicBool>,
 ) -> Result<()> {
-	// Only pool-fill spreads across submitters; every other scenario's writers already
-	// target distinct nodes, and the node's per-user cap is per `(node, submitter)`, so
-	// each writer already has its own quota with a single account.
+	// Only pool-fill and mixed use more than one submitter. In the other scenarios each
+	// writer submits to a different node, and the per-user limit applies per
+	// `(node, submitter)` pair, so one account gives each writer a separate quota.
 	let submitter = submitters.first().expect("at least one HOP submitter is derived");
 	match scenario {
 		"submit-only" | "submit" => {
@@ -1418,8 +1421,8 @@ mod tests {
 		let retired = vec![false; 3];
 		assert_eq!(next_live_submitter(&retired, 0), Some(1));
 		assert_eq!(next_live_submitter(&retired, 1), Some(2));
-		// Wraps rather than running off the end, so throttled accounts are revisited
-		// once their buckets have refilled.
+		// The search wraps around, so rate-limited accounts are used again after their
+		// rate limit resets.
 		assert_eq!(next_live_submitter(&retired, 2), Some(0));
 	}
 
@@ -1432,8 +1435,8 @@ mod tests {
 
 	#[test]
 	fn rotation_keeps_a_lone_live_submitter() {
-		// `from` is considered last, so the only account with quota left is returned
-		// instead of reporting exhaustion.
+		// The function checks `from` last, so it returns the only account with quota left
+		// instead of None.
 		let retired = vec![true, false, true];
 		assert_eq!(next_live_submitter(&retired, 1), Some(1));
 	}
@@ -1470,8 +1473,8 @@ mod tests {
 
 	#[test]
 	fn ack_decisions_are_spread_not_front_loaded() {
-		// Bresenham puts one ack in each group of four at 0.25, rather than acking the
-		// first 250 of every 1000 and then stalling.
+		// At ratio 0.25 the accumulator acks one claim in every four, instead of acking
+		// the first 250 claims of every 1000 and then none.
 		let mut credit = 0u64;
 		let mut acked_at = Vec::new();
 		for i in 0..12u64 {

--- a/stress-test/src/scenarios/hop.rs
+++ b/stress-test/src/scenarios/hop.rs
@@ -539,6 +539,9 @@ pub async fn run_pool_fill(
 		let mut sub_idx = 0usize;
 		let mut node_pool_full = false;
 		let mut i = 0u64;
+		// Per node: a node must not inherit the previous node's failures.
+		let mut node_errors = 0u64;
+		let mut throttled = 0u64;
 
 		while sub_idx < submitters.len() {
 			if cancel.load(Ordering::Relaxed) || i >= POOL_FILL_MAX_ENTRIES_PER_NODE {
@@ -587,6 +590,14 @@ pub async fn run_pool_fill(
 						any_pool_full = true;
 						break;
 					}
+					// RateLimited (1020): the node is asking us to slow down, which is the
+					// steady state once the submit burst is spent - the limit is 60/min. Wait
+					// and retry the same index rather than spending the error budget.
+					if err_str.contains("1020") || err_str.contains("Rate limited") {
+						throttled += 1;
+						tokio::time::sleep(Duration::from_secs(1)).await;
+						continue;
+					}
 					// UserQuotaExceeded (1013): rotate to the next account and keep filling.
 					if err_str.contains("1013") || err_str.contains("quota") {
 						tracing::info!(
@@ -599,11 +610,12 @@ pub async fn run_pool_fill(
 						continue;
 					}
 					errors += 1;
-					if errors <= 5 {
+					node_errors += 1;
+					if node_errors <= 5 {
 						tracing::warn!("[{url}] pool-fill submit error [{i}]: {e}");
 					}
-					if errors > 10 {
-						tracing::error!("Too many errors, stopping");
+					if node_errors > 10 {
+						tracing::error!("[{url}] too many errors, moving to the next node");
 						break;
 					}
 				},
@@ -616,6 +628,10 @@ pub async fn run_pool_fill(
 				 more submitters are needed to fill this pool",
 				submitters.len()
 			);
+		}
+
+		if throttled > 0 {
+			tracing::info!("[{url}] rate-limited {throttled} time(s) while filling");
 		}
 
 		if let Ok(status) = hop::hop_pool_status(&ws).await {

--- a/stress-test/src/scenarios/hop.rs
+++ b/stress-test/src/scenarios/hop.rs
@@ -684,21 +684,40 @@ pub async fn run_mixed(
 	ws_urls: &[&str],
 	payload_size: usize,
 	concurrency: usize,
+	writers: Option<usize>,
 	duration_secs: u64,
-	submitter: &Keypair,
+	submitters: &[Keypair],
 	results: &mut Vec<ScenarioResult>,
 	on_result: &dyn Fn(&mut Vec<ScenarioResult>),
 	cancel: &Arc<AtomicBool>,
 ) -> Result<()> {
+	// Writers choose the node (`ws_urls[w_idx % len]`); readers follow each entry's
+	// recorded URL. So every node is exercised only if there is at least one writer per
+	// node. An even split leaves claims tracking submits and the pool near empty, which
+	// measures lifecycle throughput; skewing toward writers makes the pool grow while
+	// still acking.
+	let writer_count = writers.unwrap_or_else(|| std::cmp::max(1, concurrency / 2)).max(1);
+	let reader_count = std::cmp::max(1, concurrency.saturating_sub(writer_count));
+
 	tracing::info!(
-		"S5: Mixed — {} byte payloads, concurrency {}, {}s duration",
+		"S5: Mixed — {} byte payloads, {} writer(s) / {} reader(s) over {} node(s) with {} \
+		 submitter(s), {}s duration",
 		payload_size,
-		concurrency,
+		writer_count,
+		reader_count,
+		ws_urls.len(),
+		submitters.len(),
 		duration_secs,
 	);
 
-	let writer_count = std::cmp::max(1, concurrency / 2);
-	let reader_count = std::cmp::max(1, concurrency - writer_count);
+	if writer_count < ws_urls.len() {
+		tracing::warn!(
+			"{} writer(s) for {} node(s): nodes {}.. will receive no submissions",
+			writer_count,
+			ws_urls.len(),
+			writer_count
+		);
+	}
 
 	let deadline = Instant::now() + Duration::from_secs(duration_secs);
 
@@ -723,13 +742,16 @@ pub async fn run_mixed(
 	let mut writer_handles = Vec::new();
 	for w_idx in 0..writer_count {
 		let url = ws_urls[w_idx % ws_urls.len()].to_string();
+		// A writer owns a node, and the byte quota is per (node, submitter) — one account
+		// only covers --hop-max-user-size on that node. Carry every account and rotate on
+		// UserQuotaExceeded so a single writer can fill a pool larger than one quota.
+		let writer_submitters: Vec<Keypair> = submitters.to_vec();
 		let pending = pending.clone();
 		let count = submit_count.clone();
 		let errors = submit_errors.clone();
 		let bytes = submit_bytes.clone();
 		let lats = submit_lats.clone();
 		let cancel = cancel.clone();
-		let submitter = submitter.clone();
 
 		writer_handles.push(tokio::spawn(async move {
 			let ws = match client::connect_ws(&url).await {
@@ -741,12 +763,22 @@ pub async fn run_mixed(
 			};
 
 			let mut idx = MIXED_INDEX_BASE + (w_idx as u64) * 1_000_000;
+			let mut sub_idx = 0usize;
 			while Instant::now() < deadline && !cancel.load(Ordering::Relaxed) {
+				if sub_idx >= writer_submitters.len() {
+					tracing::warn!(
+						"Writer {w_idx} on {url}: all {} submitter(s) exhausted their quota; \
+						 acks are not releasing bytes fast enough, or more are needed",
+						writer_submitters.len()
+					);
+					break;
+				}
+
 				let data = hop::generate_payload(payload_size, idx);
 				let recipients = vec![RecipientKeypair::generate()];
 				idx += 1;
 
-				match hop::hop_submit(&ws, &data, &recipients, &submitter).await {
+				match hop::hop_submit(&ws, &data, &recipients, &writer_submitters[sub_idx]).await {
 					Ok((hash, _result, latency)) => {
 						count.fetch_add(1, Ordering::Relaxed);
 						bytes.fetch_add(payload_size as u64, Ordering::Relaxed);
@@ -758,7 +790,19 @@ pub async fn run_mixed(
 							collator_url: url.clone(),
 						});
 					},
-					Err(_) => {
+					Err(e) => {
+						let err_str = e.to_string();
+						// Rate limited: backpressure, not failure — the node caps submits
+						// per minute, so wait and retry with the same account.
+						if err_str.contains("1020") || err_str.contains("Rate limited") {
+							tokio::time::sleep(Duration::from_secs(1)).await;
+							continue;
+						}
+						// Quota spent on this node for this account: move to the next.
+						if err_str.contains("1013") || err_str.contains("quota") {
+							sub_idx += 1;
+							continue;
+						}
 						errors.fetch_add(1, Ordering::Relaxed);
 					},
 				}
@@ -1032,6 +1076,7 @@ pub async fn run_hop_sweep(
 	concurrency: usize,
 	num_recipients: usize,
 	duration_secs: u64,
+	writers: Option<usize>,
 	submitters: &[Keypair],
 	results: &mut Vec<ScenarioResult>,
 	on_result: &dyn Fn(&mut Vec<ScenarioResult>),
@@ -1093,8 +1138,9 @@ pub async fn run_hop_sweep(
 				ws_urls,
 				size,
 				concurrency,
+				writers,
 				duration_secs,
-				submitter,
+				submitters,
 				results,
 				on_result,
 				cancel,
@@ -1158,8 +1204,9 @@ pub async fn run_hop_sweep(
 					ws_urls,
 					size,
 					concurrency,
+					writers,
 					duration_secs,
-					submitter,
+					submitters,
 					results,
 					on_result,
 					cancel,

--- a/stress-test/src/scenarios/hop.rs
+++ b/stress-test/src/scenarios/hop.rs
@@ -41,6 +41,53 @@ const POOL_FILL_INDEX_BASE: u64 = 300_000_000;
 const POOL_FILL_MAX_ENTRIES_PER_NODE: u64 = 100_000;
 const MIXED_INDEX_BASE: u64 = 400_000_000;
 
+/// Redial attempts before a worker gives up on its node.
+const CONNECT_ATTEMPTS: usize = 5;
+
+/// Backoff bounds for a full pool. Space frees up only as entries are acked or reach
+/// `--hop-retention-secs`, so retrying tightly just burns bandwidth re-sending payloads
+/// the node will reject; back off, but stay well under the retention window so a worker
+/// resumes promptly once entries start expiring.
+const POOL_FULL_BACKOFF_START: Duration = Duration::from_secs(1);
+const POOL_FULL_BACKOFF_MAX: Duration = Duration::from_secs(30);
+
+/// How a submit failed, as far as the fill loops need to distinguish.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubmitFailure {
+	/// Node-wide pool limit: back off, no account can help.
+	PoolFull,
+	/// This `(node, account)` pair is spent: retire the account for this node.
+	QuotaExceeded,
+	/// This account's token bucket is empty: another account can submit now.
+	RateLimited,
+	/// The connection died: redial before submitting again.
+	Transport,
+	Other,
+}
+
+fn classify_submit_error(err: &anyhow::Error) -> SubmitFailure {
+	match hop::error_code(err) {
+		Some(hop::HOP_ERR_POOL_FULL) => SubmitFailure::PoolFull,
+		Some(hop::HOP_ERR_USER_QUOTA) => SubmitFailure::QuotaExceeded,
+		Some(hop::HOP_ERR_RATE_LIMITED) => SubmitFailure::RateLimited,
+		_ =>
+			if hop::is_transport_error(err) {
+				SubmitFailure::Transport
+			} else {
+				SubmitFailure::Other
+			},
+	}
+}
+
+/// Round-robin to the next account that still has quota on this node, starting after
+/// `from`. `from` itself is considered last, so a lone live account keeps being used.
+/// `None` means every account is spent here.
+fn next_live_submitter(retired: &[bool], from: usize) -> Option<usize> {
+	(1..=retired.len())
+		.map(|off| (from + off) % retired.len())
+		.find(|&i| !retired[i])
+}
+
 // ---------------------------------------------------------------------------
 // S1: Submit throughput
 // ---------------------------------------------------------------------------
@@ -517,7 +564,7 @@ pub async fn run_pool_fill(
 			break;
 		}
 
-		let ws = match client::connect_ws(url).await {
+		let mut ws = match client::connect_ws_retry(url, CONNECT_ATTEMPTS).await {
 			Ok(ws) => ws,
 			Err(e) => {
 				tracing::warn!("pool-fill: cannot connect to {url}: {e}");
@@ -537,13 +584,19 @@ pub async fn run_pool_fill(
 
 		let mut node_submitted = 0u64;
 		let mut sub_idx = 0usize;
+		// Accounts whose `(node, account)` quota is spent here. Rate limiting rotates
+		// among the rest; only quota exhaustion retires an account for this node.
+		let mut retired = vec![false; submitters.len()];
 		let mut node_pool_full = false;
 		let mut i = 0u64;
 		// Per node: a node must not inherit the previous node's failures.
 		let mut node_errors = 0u64;
 		let mut throttled = 0u64;
+		// Consecutive rate-limited rotations. Once it reaches the number of live
+		// accounts every bucket is empty, so there is nothing left to rotate to.
+		let mut throttle_streak = 0usize;
 
-		while sub_idx < submitters.len() {
+		loop {
 			if cancel.load(Ordering::Relaxed) || i >= POOL_FILL_MAX_ENTRIES_PER_NODE {
 				if i >= POOL_FILL_MAX_ENTRIES_PER_NODE {
 					tracing::info!("[{url}] hit the {POOL_FILL_MAX_ENTRIES_PER_NODE} entry cap");
@@ -563,6 +616,7 @@ pub async fn run_pool_fill(
 					i += 1;
 					total_bytes += payload_size as u64;
 					lats.push(latency);
+					throttle_streak = 0;
 
 					if node_submitted.is_multiple_of(100) {
 						tracing::info!(
@@ -576,53 +630,84 @@ pub async fn run_pool_fill(
 						);
 					}
 				},
-				Err(e) => {
-					let err_str = e.to_string();
-					// PoolFull (1002): the node is full, nothing more to do here.
-					if err_str.contains("1002") || err_str.contains("Pool full") {
+				Err(e) => match classify_submit_error(&e) {
+					// The node itself is full: nothing more to do here.
+					SubmitFailure::PoolFull => {
 						tracing::info!(
 							"[{url}] PoolFull after {node_submitted} entries \
-							 ({}/{} submitters used)",
-							sub_idx + 1,
+							 ({}/{} submitters retired)",
+							retired.iter().filter(|r| **r).count(),
 							submitters.len()
 						);
 						node_pool_full = true;
 						any_pool_full = true;
 						break;
-					}
-					// RateLimited (1020): the node is asking us to slow down, which is the
-					// steady state once the submit burst is spent - the limit is 60/min. Wait
-					// and retry the same index rather than spending the error budget.
-					if err_str.contains("1020") || err_str.contains("Rate limited") {
+					},
+					// Rate limits are per account, so rotate rather than sleep: the other
+					// accounts' buckets are untouched. Only sleep once every live account
+					// has been tried and throttled in turn.
+					SubmitFailure::RateLimited => {
 						throttled += 1;
-						tokio::time::sleep(Duration::from_secs(1)).await;
+						throttle_streak += 1;
+						match next_live_submitter(&retired, sub_idx) {
+							Some(next) => sub_idx = next,
+							None => break,
+						}
+						let live = retired.iter().filter(|r| !**r).count();
+						if throttle_streak >= live {
+							throttle_streak = 0;
+							tokio::time::sleep(Duration::from_secs(1)).await;
+						}
 						continue;
-					}
-					// UserQuotaExceeded (1013): rotate to the next account and keep filling.
-					if err_str.contains("1013") || err_str.contains("quota") {
+					},
+					// This account's byte quota is spent on this node; retire it and
+					// carry on with the next one.
+					SubmitFailure::QuotaExceeded => {
+						retired[sub_idx] = true;
 						tracing::info!(
 							"[{url}] submitter {}/{} exhausted its quota after \
 							 {node_submitted} entries; rotating",
 							sub_idx + 1,
 							submitters.len()
 						);
-						sub_idx += 1;
+						match next_live_submitter(&retired, sub_idx) {
+							Some(next) => sub_idx = next,
+							None => break,
+						}
 						continue;
-					}
-					errors += 1;
-					node_errors += 1;
-					if node_errors <= 5 {
-						tracing::warn!("[{url}] pool-fill submit error [{i}]: {e}");
-					}
-					if node_errors > 10 {
-						tracing::error!("[{url}] too many errors, moving to the next node");
-						break;
-					}
+					},
+					SubmitFailure::Transport => {
+						tracing::warn!(
+							"[{url}] connection lost after {node_submitted} entries: {e}"
+						);
+						match client::connect_ws_retry(url, CONNECT_ATTEMPTS).await {
+							Ok(fresh) => {
+								ws = fresh;
+								continue;
+							},
+							Err(e) => {
+								tracing::error!("[{url}] redial failed: {e}; moving to next node");
+								errors += 1;
+								break;
+							},
+						}
+					},
+					SubmitFailure::Other => {
+						errors += 1;
+						node_errors += 1;
+						if node_errors <= 5 {
+							tracing::warn!("[{url}] pool-fill submit error [{i}]: {e}");
+						}
+						if node_errors > 10 {
+							tracing::error!("[{url}] too many errors, moving to the next node");
+							break;
+						}
+					},
 				},
 			}
 		}
 
-		if !node_pool_full && sub_idx >= submitters.len() {
+		if !node_pool_full && retired.iter().all(|r| *r) {
 			tracing::warn!(
 				"[{url}] all {} submitters exhausted without reaching PoolFull — \
 				 more submitters are needed to fill this pool",
@@ -685,6 +770,7 @@ pub async fn run_mixed(
 	payload_size: usize,
 	concurrency: usize,
 	writers: Option<usize>,
+	ack_ratio: f64,
 	duration_secs: u64,
 	submitters: &[Keypair],
 	results: &mut Vec<ScenarioResult>,
@@ -699,14 +785,22 @@ pub async fn run_mixed(
 	let writer_count = writers.unwrap_or_else(|| std::cmp::max(1, concurrency / 2)).max(1);
 	let reader_count = std::cmp::max(1, concurrency.saturating_sub(writer_count));
 
+	// Acking releases the entry, so at ratio 1.0 inflow and outflow cancel and the pool
+	// cannot grow however many writers there are - it sits near empty while both sides
+	// stay busy. A ratio below 1.0 leaves the balance in the pool to age out at
+	// `--hop-retention-secs`, which is what makes a fill test out of a lifecycle test.
+	let ack_ratio = ack_ratio.clamp(0.0, 1.0);
+	let ack_permille = (ack_ratio * 1000.0).round() as u64;
+
 	tracing::info!(
 		"S5: Mixed — {} byte payloads, {} writer(s) / {} reader(s) over {} node(s) with {} \
-		 submitter(s), {}s duration",
+		 submitter(s), acking {:.0}% of claims, {}s duration",
 		payload_size,
 		writer_count,
 		reader_count,
 		ws_urls.len(),
 		submitters.len(),
+		ack_ratio * 100.0,
 		duration_secs,
 	);
 
@@ -731,6 +825,7 @@ pub async fn run_mixed(
 
 	let claim_count = Arc::new(AtomicU64::new(0));
 	let claim_errors = Arc::new(AtomicU64::new(0));
+	let ack_count = Arc::new(AtomicU64::new(0));
 	let claim_bytes = Arc::new(AtomicU64::new(0));
 	let claim_lats = Arc::new(Mutex::new(Vec::<Duration>::new()));
 
@@ -754,7 +849,7 @@ pub async fn run_mixed(
 		let cancel = cancel.clone();
 
 		writer_handles.push(tokio::spawn(async move {
-			let ws = match client::connect_ws(&url).await {
+			let mut ws = match client::connect_ws_retry(&url, CONNECT_ATTEMPTS).await {
 				Ok(ws) => ws,
 				Err(e) => {
 					tracing::error!("Writer {w_idx} connect failed: {e}");
@@ -764,16 +859,13 @@ pub async fn run_mixed(
 
 			let mut idx = MIXED_INDEX_BASE + (w_idx as u64) * 1_000_000;
 			let mut sub_idx = 0usize;
+			// Retired = this account's byte quota is spent on this node. Rate limiting
+			// rotates among the live accounts instead of retiring any of them.
+			let mut retired = vec![false; writer_submitters.len()];
+			let mut throttle_streak = 0usize;
+			let mut pool_full_backoff = POOL_FULL_BACKOFF_START;
+			let mut pool_full_logged = false;
 			while Instant::now() < deadline && !cancel.load(Ordering::Relaxed) {
-				if sub_idx >= writer_submitters.len() {
-					tracing::warn!(
-						"Writer {w_idx} on {url}: all {} submitter(s) exhausted their quota; \
-						 acks are not releasing bytes fast enough, or more are needed",
-						writer_submitters.len()
-					);
-					break;
-				}
-
 				let data = hop::generate_payload(payload_size, idx);
 				let recipients = vec![RecipientKeypair::generate()];
 				idx += 1;
@@ -783,6 +875,9 @@ pub async fn run_mixed(
 						count.fetch_add(1, Ordering::Relaxed);
 						bytes.fetch_add(payload_size as u64, Ordering::Relaxed);
 						lats.lock().await.push(latency);
+						throttle_streak = 0;
+						pool_full_backoff = POOL_FULL_BACKOFF_START;
+						pool_full_logged = false;
 						pending.lock().await.push(SubmittedEntry {
 							hash,
 							data,
@@ -790,20 +885,73 @@ pub async fn run_mixed(
 							collator_url: url.clone(),
 						});
 					},
-					Err(e) => {
-						let err_str = e.to_string();
-						// Rate limited: backpressure, not failure — the node caps submits
-						// per minute, so wait and retry with the same account.
-						if err_str.contains("1020") || err_str.contains("Rate limited") {
-							tokio::time::sleep(Duration::from_secs(1)).await;
+					Err(e) => match classify_submit_error(&e) {
+						// Node-wide limit, so no account can help and retrying tightly
+						// only re-sends payloads the node will reject. Wait for acks or
+						// expiry to free space, escalating up to the cap.
+						SubmitFailure::PoolFull => {
+							if !pool_full_logged {
+								tracing::warn!(
+									"Writer {w_idx} on {url}: pool full, backing off (up to {}s) \
+									 until entries are acked or expire",
+									POOL_FULL_BACKOFF_MAX.as_secs()
+								);
+								pool_full_logged = true;
+							}
+							tokio::time::sleep(pool_full_backoff).await;
+							pool_full_backoff = (pool_full_backoff * 2).min(POOL_FULL_BACKOFF_MAX);
 							continue;
-						}
-						// Quota spent on this node for this account: move to the next.
-						if err_str.contains("1013") || err_str.contains("quota") {
-							sub_idx += 1;
+						},
+						// Buckets are per account, so another account can submit right
+						// now. Only sleep once every live account has been throttled in
+						// turn, which means the node-side budget really is spent.
+						SubmitFailure::RateLimited => {
+							throttle_streak += 1;
+							match next_live_submitter(&retired, sub_idx) {
+								Some(next) => sub_idx = next,
+								None => break,
+							}
+							let live = retired.iter().filter(|r| !**r).count();
+							if throttle_streak >= live {
+								throttle_streak = 0;
+								tokio::time::sleep(Duration::from_secs(1)).await;
+							}
 							continue;
-						}
-						errors.fetch_add(1, Ordering::Relaxed);
+						},
+						// Quota spent on this node for this account: retire it and move on.
+						SubmitFailure::QuotaExceeded => {
+							retired[sub_idx] = true;
+							match next_live_submitter(&retired, sub_idx) {
+								Some(next) => sub_idx = next,
+								None => {
+									tracing::warn!(
+										"Writer {w_idx} on {url}: all {} submitter(s) exhausted \
+										 their quota; acks are not releasing bytes fast enough, \
+										 or more are needed",
+										writer_submitters.len()
+									);
+									break;
+								},
+							}
+							continue;
+						},
+						// The node restarted or the stream dropped. Redial: this client
+						// will fail every subsequent request otherwise.
+						SubmitFailure::Transport => {
+							tracing::warn!("Writer {w_idx} on {url}: connection lost: {e}");
+							match client::connect_ws_retry(&url, CONNECT_ATTEMPTS).await {
+								Ok(fresh) => ws = fresh,
+								Err(e) => {
+									tracing::error!("Writer {w_idx} on {url}: redial failed: {e}");
+									errors.fetch_add(1, Ordering::Relaxed);
+									break;
+								},
+							}
+							continue;
+						},
+						SubmitFailure::Other => {
+							errors.fetch_add(1, Ordering::Relaxed);
+						},
 					},
 				}
 			}
@@ -816,12 +964,16 @@ pub async fn run_mixed(
 		let pending = pending.clone();
 		let count = claim_count.clone();
 		let errors = claim_errors.clone();
+		let acked = ack_count.clone();
 		let bytes = claim_bytes.clone();
 		let lats = claim_lats.clone();
 		let cancel = cancel.clone();
 		let writers_done = writers_done.clone();
 
 		reader_handles.push(tokio::spawn(async move {
+			// Bresenham over permille, so acks are spread across the claim stream rather
+			// than acking the first N of every thousand.
+			let mut ack_credit = 0u64;
 			loop {
 				if cancel.load(Ordering::Relaxed) {
 					break;
@@ -829,20 +981,38 @@ pub async fn run_mixed(
 				let entry = pending.lock().await.pop();
 				match entry {
 					Some(entry) => {
-						let ws = match client::connect_ws(&entry.collator_url).await {
-							Ok(ws) => ws,
-							Err(_) => continue,
-						};
+						let ws =
+							match client::connect_ws_retry(&entry.collator_url, CONNECT_ATTEMPTS)
+								.await
+							{
+								Ok(ws) => ws,
+								Err(e) => {
+									tracing::warn!(
+										"Reader cannot reach {}: {e}",
+										entry.collator_url
+									);
+									errors.fetch_add(1, Ordering::Relaxed);
+									continue;
+								},
+							};
 						let kp = &entry.recipients[0];
 						match hop::hop_claim(&ws, &entry.hash, kp).await {
 							Ok((data, latency)) => {
 								count.fetch_add(1, Ordering::Relaxed);
 								bytes.fetch_add(data.len() as u64, Ordering::Relaxed);
 								lats.lock().await.push(latency);
-								// Entries carry a single recipient here, so this ack
+								// Entries carry a single recipient here, so an ack
 								// releases the entry and frees pool and per-user budget.
-								if hop::hop_ack(&ws, &entry.hash, kp).await.is_err() {
-									errors.fetch_add(1, Ordering::Relaxed);
+								// Skipping it is what lets the pool grow: the entry then
+								// occupies both until `--hop-retention-secs` expires it.
+								ack_credit += ack_permille;
+								if ack_credit >= 1000 {
+									ack_credit -= 1000;
+									if hop::hop_ack(&ws, &entry.hash, kp).await.is_err() {
+										errors.fetch_add(1, Ordering::Relaxed);
+									} else {
+										acked.fetch_add(1, Ordering::Relaxed);
+									}
 								}
 							},
 							Err(_) => {
@@ -865,6 +1035,7 @@ pub async fn run_mixed(
 	let progress_cancel = cancel.clone();
 	let s_count = submit_count.clone();
 	let c_count = claim_count.clone();
+	let a_count = ack_count.clone();
 	let s_err = submit_errors.clone();
 	let c_err = claim_errors.clone();
 	let p_ref = pending.clone();
@@ -877,11 +1048,14 @@ pub async fn run_mixed(
 			}
 			let elapsed = start.elapsed().as_secs_f64();
 			let plen = p_ref.lock().await.len();
+			// submitted - acked is what stays resident in the pools, so the two counts
+			// together say whether the run is filling them or just cycling entries.
 			tracing::info!(
-				"[{:.0}s] submitted: {}, claimed: {}, pending: {}, errors: {}/{}",
+				"[{:.0}s] submitted: {}, claimed: {}, acked: {}, pending: {}, errors: {}/{}",
 				elapsed,
 				s_count.load(Ordering::Relaxed),
 				c_count.load(Ordering::Relaxed),
+				a_count.load(Ordering::Relaxed),
 				plen,
 				s_err.load(Ordering::Relaxed),
 				c_err.load(Ordering::Relaxed),
@@ -1077,6 +1251,7 @@ pub async fn run_hop_sweep(
 	num_recipients: usize,
 	duration_secs: u64,
 	writers: Option<usize>,
+	ack_ratio: f64,
 	submitters: &[Keypair],
 	results: &mut Vec<ScenarioResult>,
 	on_result: &dyn Fn(&mut Vec<ScenarioResult>),
@@ -1139,6 +1314,7 @@ pub async fn run_hop_sweep(
 				size,
 				concurrency,
 				writers,
+				ack_ratio,
 				duration_secs,
 				submitters,
 				results,
@@ -1205,6 +1381,7 @@ pub async fn run_hop_sweep(
 					size,
 					concurrency,
 					writers,
+					ack_ratio,
 					duration_secs,
 					submitters,
 					results,
@@ -1229,5 +1406,81 @@ fn format_payload_label(size: usize) -> String {
 		format!("{}KB", size / 1024)
 	} else {
 		format!("{size}B")
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn rotation_advances_to_the_next_live_submitter() {
+		let retired = vec![false; 3];
+		assert_eq!(next_live_submitter(&retired, 0), Some(1));
+		assert_eq!(next_live_submitter(&retired, 1), Some(2));
+		// Wraps rather than running off the end, so throttled accounts are revisited
+		// once their buckets have refilled.
+		assert_eq!(next_live_submitter(&retired, 2), Some(0));
+	}
+
+	#[test]
+	fn rotation_skips_retired_submitters() {
+		let retired = vec![false, true, true, false];
+		assert_eq!(next_live_submitter(&retired, 0), Some(3));
+		assert_eq!(next_live_submitter(&retired, 3), Some(0));
+	}
+
+	#[test]
+	fn rotation_keeps_a_lone_live_submitter() {
+		// `from` is considered last, so the only account with quota left is returned
+		// instead of reporting exhaustion.
+		let retired = vec![true, false, true];
+		assert_eq!(next_live_submitter(&retired, 1), Some(1));
+	}
+
+	#[test]
+	fn rotation_reports_exhaustion_when_every_submitter_is_retired() {
+		assert_eq!(next_live_submitter(&[true, true], 0), None);
+		assert_eq!(next_live_submitter(&[], 0), None);
+	}
+
+	/// The reader's ack decision, extracted so the ratio is testable without a node.
+	fn ack_decisions(ack_permille: u64, claims: usize) -> usize {
+		let mut credit = 0u64;
+		let mut acks = 0;
+		for _ in 0..claims {
+			credit += ack_permille;
+			if credit >= 1000 {
+				credit -= 1000;
+				acks += 1;
+			}
+		}
+		acks
+	}
+
+	#[test]
+	fn ack_ratio_governs_how_many_claims_are_acked() {
+		// 1.0 acks everything, which is why the pool cannot grow at the default.
+		assert_eq!(ack_decisions(1000, 100), 100);
+		assert_eq!(ack_decisions(250, 100), 25);
+		assert_eq!(ack_decisions(500, 100), 50);
+		// 0.0 never releases: every entry stays until it expires.
+		assert_eq!(ack_decisions(0, 100), 0);
+	}
+
+	#[test]
+	fn ack_decisions_are_spread_not_front_loaded() {
+		// Bresenham puts one ack in each group of four at 0.25, rather than acking the
+		// first 250 of every 1000 and then stalling.
+		let mut credit = 0u64;
+		let mut acked_at = Vec::new();
+		for i in 0..12u64 {
+			credit += 250;
+			if credit >= 1000 {
+				credit -= 1000;
+				acked_at.push(i);
+			}
+		}
+		assert_eq!(acked_at, vec![3, 7, 11]);
 	}
 }

--- a/stress-test/src/store.rs
+++ b/stress-test/src/store.rs
@@ -215,7 +215,8 @@ pub enum TxPoolError {
 }
 
 impl TxPoolError {
-	/// Stable `class` label value for `bulletin_stress_tx_errors_total`.
+	/// Stable label value for the `outcome` of `bulletin_stress_submit_attempts_total` and the
+	/// `reason` of `bulletin_stress_tx_abandoned_total`.
 	pub fn metric_class(self) -> &'static str {
 		match self {
 			Self::PoolFull => "pool_full",


### PR DESCRIPTION
## Ack claimed HOP entries

No scenario called `hop_ack`. A claim only reads; the node keeps the entry until every recipient acks. Claimed entries stayed in the pool and counted against the submitter's quota until `--hop-retention-secs` expired them.

Added `hop_ack()` using the `hop-ack-v1:` context, called by `full-cycle`, `group` and `mixed`. Error 1004 (`NotFound`) counts as success. Added `--hop-submitters`, because the byte quota applies per `(node, submitter)` pair: filling a 10 GiB pool with a 256 MiB quota needs 40 accounts.

## Split write-path metrics

`tx_submitted_total` counted RPC calls, so retries inflated it and it was not comparable with `tx_confirmed_total`.

Added `tx_offered_*`, `tx_accepted_*`, `tx_abandoned_*` (once per extrinsic), `submit_attempts_total` (once per RPC call), `tx_accepted_encoded_bytes_total` for wire size, and the `block_bytes` histogram.

**Breaking:** removed `tx_submitted_total`, `tx_submitted_bytes_total` and `tx_errors_total`. Dashboards using those names need updating.

## Fix the HOP fill loops

1. Rate limits apply per account, but code 1020 slept 1s and retried the same    account, leaving the other accounts idle.
2. `WsClient` does not reconnect, so a node restart or a DNS failure at connect time stopped a writer for the rest of the run.
3. `PoolFull` retried with no delay and no log line.
4. The quota check tested for code 1013 (`IoError`); the real code is 1011. It worked only because the message contains "quota".

Fixes: match on numeric codes via one `classify_submit_error()`; a rate limit switches accounts and sleeps only when all accounts are limited; `PoolFull` backs off 1s to 30s; `connect_ws_retry()` reconnects writers and readers.

Added `--writers` for `mixed` and `--ack-ratio` (default 1.0, current behaviour). At 1.0 the submit and removal rates are equal, so the pool stays at 0 entries for any writer count; lower values leave entries until `--hop-retention-secs` expires them.
